### PR TITLE
Fixed composer installation error caused by conflict function name in install script

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -66,7 +66,7 @@ class InstallCommand extends Command
         $this->call('shopper:link');
         $this->progressBar->advance();
 
-        $this->complete();
+        $this->completeSetup();
 
         if (! (bool) $this->option('no-interaction')) {
             (new Thanks($this->output))();
@@ -104,7 +104,7 @@ class InstallCommand extends Command
         $this->info('Add SHOPPER_DASHBOARD_PREFIX to .env file');
     }
 
-    protected function complete(): void
+    protected function completeSetup(): void
     {
         $this->progressBar->finish();
 


### PR DESCRIPTION
`'InstallCommand::complete()'  is not compatible with method 'Illuminate\Console\Command::complete()'` does is due to conflict with existing `Illuminate\Command` method

Steps to reproduce: 
- install latest laravel version
- attempt to install latest version of this package