### PR TITLE
Add nullable to "last_name" and "gender" columns in customer migration

### DIFF
--- a/database/migrations/2019_05_03_000001_create_customer_columns.php
+++ b/database/migrations/2019_05_03_000001_create_customer_columns.php
@@ -22,8 +22,8 @@ class CreateCustomerColumns extends Migration
 
             $table->after('id', function ($table) {
                 $table->string('first_name')->nullable();
-                $table->string('last_name');
-                $table->enum('gender', ['male', 'female']);
+                $table->string('last_name')->nullable();
+                $table->enum('gender', ['male', 'female'])->nullable();
                 $table->string('phone_number')->nullable();
                 $table->date('birth_date')->nullable();
                 $table->string('avatar_type')->default('gravatar');


### PR DESCRIPTION
For Postgres don't complain about non-null columns.

![image](https://user-images.githubusercontent.com/3616259/169606155-1b1d9034-a5cf-4eb9-a8db-8e6137608242.png)
