### PR TITLE
fix API `/brands` Route

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -1,7 +1,6 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
-use Shopper\Framework\Http\Controllers\Api;
 
 /*
 |--------------------------------------------------------------------------
@@ -11,4 +10,4 @@ use Shopper\Framework\Http\Controllers\Api;
 |
 */
 
-Route::get('/brands', Api\BrandController::class)->name('brands');
+Route::get('/brands', BrandController::class)->name('brands');


### PR DESCRIPTION
this solves the next issue:
```
sail@045db7310620:/var/www/html$ php artisan

   UnexpectedValueException

  Invalid route action: [Shopper\Framework\Http\Controllers\Api\Shopper\Framework\Http\Controllers\Api\BrandController].

  at vendor/laravel/framework/src/Illuminate/Routing/RouteAction.php:92
     88▕      */
     89▕     protected static function makeInvokable($action)
     90▕     {
     91▕         if (! method_exists($action, '__invoke')) {
  ➜  92▕             throw new UnexpectedValueException("Invalid route action: [{$action}].");
     93▕         }
     94▕
     95▕         return $action.'@__invoke';
     96▕     }

  • `Shopper\Framework\Http\Controllers\Api\Shopper\Framework\Http\Controllers\Api\BrandController` was not found: Controller class `Shopper\Framework\Http\Controllers\Api\Shopper\Framework\Http\Controllers\Api\BrandController` for one of your routes was not found. Are you sure this controller exists and is imported correctly?

      +30 vendor frames
  31  [internal]:0
      Illuminate\Foundation\Application::Illuminate\Foundation\{closure}()

      +5 vendor frames
  37  artisan:37
      Illuminate\Foundation\Console\Kernel::handle()
```

Tested on **Laravel v8.83.23**