### PR TITLE
Make symlink using prefix

### DIFF
--- a/packages/admin/src/Console/SymlinkCommand.php
+++ b/packages/admin/src/Console/SymlinkCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Shopper\Console;
 
 use Illuminate\Console\Command;
+use Shopper\Shopper;
 
 final class SymlinkCommand extends Command
 {
@@ -14,14 +15,15 @@ final class SymlinkCommand extends Command
 
     public function handle(): void
     {
-        $link = public_path('shopper');
+        $prefix = Shopper::prefix();
+        $link = public_path($prefix);
         $target = realpath(__DIR__ . '/../../public/');
 
         if (file_exists($link)) {
-            $this->error('The "public/shopper" directory already exists.');
+            $this->error('The "public/' . $prefix . '" directory already exists.');
         } else {
             $this->laravel->make('files')->link($target, $link);
-            $this->info('The [public/shopper] directory has been linked.');
+            $this->info('The [public/' . $prefix . '] directory has been linked.');
         }
 
         $this->info('The link have been created.');


### PR DESCRIPTION
The PR helps you to use the Shopper::prefix() method to create the symlinl in public folder.

This is useful when you don't use the default SHOPPER_PREFIX.