### PR TITLE
fix product prices and disable implicite lazy loading Model

### DIFF
--- a/packages/admin/resources/lang/fr/pages/settings/menu.php
+++ b/packages/admin/resources/lang/fr/pages/settings/menu.php
@@ -20,5 +20,7 @@ return [
     'zone_description' => "Gérer l'expédition, le paiement et l'exécution dans toutes les zones",
     'tax' => 'Tax',
     'tax_description' => 'Gérez la façon dont votre boutique facture les taxes.',
+    'sales' => 'Cannaux de vente',
+    'sales_description' => 'Gérez les canaux en ligne et hors ligne sur lesquels vous vendez vos produits.',
 
 ];

--- a/packages/admin/resources/views/livewire/components/customers/addresses.blade.php
+++ b/packages/admin/resources/views/livewire/components/customers/addresses.blade.php
@@ -1,6 +1,6 @@
 <x-shopper::container>
     <div class="grid grid-cols-1 gap-x-4 gap-y-6 sm:grid-cols-3">
-        @forelse ($addresses as $address)
+        @forelse ($this->addresses as $address)
             <x-shopper::card class="relative flex items-center px-6 py-5">
                 <div class="min-w-0 flex-1">
                     <div class="focus:outline-none">

--- a/packages/admin/resources/views/livewire/components/customers/orders.blade.php
+++ b/packages/admin/resources/views/livewire/components/customers/orders.blade.php
@@ -1,6 +1,6 @@
 <x-shopper::container class="space-y-8">
-    @if ($orders->isNotEmpty())
-        @foreach ($orders as $order)
+    @if ($this->orders->isNotEmpty())
+        @foreach ($this->orders as $order)
             @php
                 $total = $order->total() + (int) $order->shippingOption?->price;
             @endphp
@@ -168,7 +168,7 @@
             </div>
         @endforeach
 
-        {{ $orders->links() }}
+        {{ $this->orders->links() }}
     @else
         <x-shopper::card class="sm:col-span-3">
             <x-shopper::empty-card

--- a/packages/admin/resources/views/livewire/pages/brand/index.blade.php
+++ b/packages/admin/resources/views/livewire/pages/brand/index.blade.php
@@ -1,3 +1,7 @@
+@php
+    $total = $this->table->getRecords()->total();
+@endphp
+
 <x-shopper::container class="py-5">
     <x-shopper::heading :title="__('shopper::pages/brands.menu')">
         <x-slot name="action">

--- a/packages/admin/resources/views/livewire/pages/category/index.blade.php
+++ b/packages/admin/resources/views/livewire/pages/category/index.blade.php
@@ -1,5 +1,5 @@
 @php
-    $total = $this->table->getQuery()->count();
+    $total = $this->table->getRecords()->total();
 @endphp
 
 <x-shopper::container class="py-5">

--- a/packages/admin/resources/views/livewire/pages/collections/browse.blade.php
+++ b/packages/admin/resources/views/livewire/pages/collections/browse.blade.php
@@ -1,3 +1,7 @@
+@php
+    $total = $this->table->getRecords()->total();
+@endphp
+
 <x-shopper::container class="py-5">
     <x-shopper::heading :title="__('shopper::pages/collections.menu')">
         <x-slot name="action">

--- a/packages/admin/resources/views/livewire/pages/customers/index.blade.php
+++ b/packages/admin/resources/views/livewire/pages/customers/index.blade.php
@@ -1,3 +1,7 @@
+@php
+    $total = $this->table->getRecords()->total();
+@endphp
+
 <x-shopper::container class="py-5">
     <x-shopper::heading :title="__('shopper::pages/customers.menu')">
         <x-slot name="action">

--- a/packages/admin/resources/views/livewire/pages/customers/show.blade.php
+++ b/packages/admin/resources/views/livewire/pages/customers/show.blade.php
@@ -93,13 +93,13 @@
 
         <div class="mt-10">
             <div x-show="currentTab === 'profile'">
-                <livewire:shopper-customers.profile :customer="$customer" />
+                <livewire:shopper-customers.profile :$customer />
             </div>
             <div x-cloak x-show="currentTab === 'address'">
-                <livewire:shopper-customers.addresses :adresses="$customer->addresses" />
+                <livewire:shopper-customers.addresses :$customer />
             </div>
             <div x-cloak x-show="currentTab === 'orders'">
-                <livewire:shopper-customers.orders :customer="$customer" />
+                <livewire:shopper-customers.orders :$customer />
             </div>
         </div>
     </div>

--- a/packages/admin/resources/views/livewire/pages/discounts/index.blade.php
+++ b/packages/admin/resources/views/livewire/pages/discounts/index.blade.php
@@ -1,3 +1,7 @@
+@php
+    $total = $this->table->getRecords()->total();
+@endphp
+
 <x-shopper::container class="py-5">
     <x-shopper::heading :title="__('shopper::pages/discounts.menu')">
         <x-slot name="action">

--- a/packages/admin/resources/views/livewire/pages/orders/detail.blade.php
+++ b/packages/admin/resources/views/livewire/pages/orders/detail.blade.php
@@ -1,6 +1,11 @@
 <div>
     @php
+        $shippingOption = $this->order->shippingOption;
+        $billingAddress = $this->order->billingAddress;
+        $shippingAddress = $this->order->shippingAddress;
+
         $total = $order->total() + $shippingOption?->price;
+        $customer = $this->customer;
     @endphp
 
     <x-shopper::container class="py-5">
@@ -396,23 +401,23 @@
                         {{ __('shopper::words.customer') }}
                     </h3>
                     <div class="mt-4 space-y-4">
-                        @if ($order->customer)
+                        @if ($customer)
                             <div class="flex items-center space-x-4">
                                 <div class="shrink-0">
                                     <img
                                         class="size-8 rounded-full"
-                                        src="{{ $order->customer->picture }}"
+                                        src="{{ $customer->picture }}"
                                         alt="Customer profile"
                                     />
                                 </div>
                                 <div class="min-w-0 flex-1">
                                     <p class="truncate text-sm font-medium text-gray-900 dark:text-white">
-                                        {{ $order->customer->full_name }}
+                                        {{ $customer->full_name }}
                                     </p>
                                 </div>
                                 <div>
                                     <x-shopper::link
-                                        href="{{ route('shopper.customers.show', $order->customer) }}"
+                                        href="{{ route('shopper.customers.show', $customer) }}"
                                         class="inline-flex items-center rounded-full border border-gray-300 bg-white px-2.5 py-0.5 text-sm font-medium leading-5 text-gray-700 shadow-sm hover:bg-gray-50 dark:border-white/10 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
                                     >
                                         {{ __('shopper::words.view') }}
@@ -420,8 +425,8 @@
                                 </div>
                             </div>
                             <p class="text-sm leading-5 text-gray-500 dark:text-gray-400">
-                                {{ __('shopper::pages/orders.customer_date', ['date' => $order->customer->created_at->diffForHumans()]) }},
-                                {{ __('shopper::pages/orders.customer_orders', ['number' => $order->customer->orders->count()]) }}
+                                {{ __('shopper::pages/orders.customer_date', ['date' => $customer->created_at->diffForHumans()]) }},
+                                {{ __('shopper::pages/orders.customer_orders', ['number' => $customer->orders_count]) }}
                             </p>
                         @else
                             <div
@@ -443,18 +448,19 @@
                     <h3 class="text-xs font-medium uppercase leading-4 tracking-wider text-gray-900 dark:text-white">
                         {{ __('shopper::pages/orders.customer_infos') }}
                     </h3>
-                    @if ($order->customer)
+
+                    @if ($customer)
                         <div class="space-y-1">
                             <p class="text-sm leading-5 text-gray-500 dark:text-gray-400">
                                 <a
-                                    href="mailto:{{ $order->customer->email }}"
+                                    href="mailto:{{ $customer->email }}"
                                     class="text-primary-600 underline hover:text-primary-500"
                                 >
-                                    {{ $order->customer->email }}
+                                    {{ $customer->email }}
                                 </a>
                             </p>
                             <p class="text-sm leading-5 text-gray-500 dark:text-gray-400">
-                                {{ $order->customer->phone_number ?? __('shopper::words.no_phone_number') }}
+                                {{ $customer->phone_number ?? __('shopper::words.no_phone_number') }}
                             </p>
                         </div>
                     @else
@@ -463,6 +469,7 @@
                         </p>
                     @endif
                 </div>
+
                 @if ($shippingAddress)
                     <div class="py-4">
                         <h3 class="text-xs font-medium uppercase leading-4 tracking-wider text-gray-900 dark:text-white">
@@ -487,11 +494,13 @@
                             @endif
                         </p>
                     </div>
+
                     @if ($billingAddress)
                         <div class="space-y-3 py-4">
                             <h3 class="text-xs font-medium uppercase leading-4 tracking-wider text-gray-900 dark:text-white">
                                 {{ __('shopper::pages/customers.addresses.billing') }}
                             </h3>
+
                             @if ($billingAddress->is($shippingAddress))
                                 <p class="text-sm text-gray-500 dark:text-gray-400">
                                     {{ __('shopper::words.same_address') }}

--- a/packages/admin/resources/views/livewire/pages/orders/index.blade.php
+++ b/packages/admin/resources/views/livewire/pages/orders/index.blade.php
@@ -1,3 +1,7 @@
+@php
+    $total = $this->table->getRecords()->total();
+@endphp
+
 <x-shopper::container class="py-5">
     <x-shopper::heading :title="__('shopper::pages/orders.menu')" />
 

--- a/packages/admin/resources/views/livewire/pages/products/index.blade.php
+++ b/packages/admin/resources/views/livewire/pages/products/index.blade.php
@@ -1,3 +1,7 @@
+@php
+    $total = $this->table->getRecords()->total();
+@endphp
+
 <x-shopper::container class="py-5">
     <x-shopper::heading :title="__('shopper::pages/products.menu')">
         <x-slot name="action">

--- a/packages/admin/resources/views/livewire/pages/reviews/index.blade.php
+++ b/packages/admin/resources/views/livewire/pages/reviews/index.blade.php
@@ -1,3 +1,7 @@
+@php
+    $total = $this->table->getRecords()->total();
+@endphp
+
 <x-shopper::container class="py-5">
     <x-shopper::heading :title="__('shopper::pages/reviews.menu')" />
 

--- a/packages/admin/resources/views/livewire/slide-overs/review-detail.blade.php
+++ b/packages/admin/resources/views/livewire/slide-overs/review-detail.blade.php
@@ -34,10 +34,6 @@
                                     @if ($review->reviewrateable->sku)
                                         <span>{{ $review->reviewrateable->sku }} -</span>
                                     @endif
-
-                                    <span class="border-b border-dashed border-primary-500 pb-0 text-primary-500">
-                                        {{ $review->reviewrateable->getPriceAmount()?->formatted ?? __('N/A') }}
-                                    </span>
                                 </p>
                             </dd>
                         </div>

--- a/packages/admin/resources/views/livewire/tables/cells/products/attribute-value.blade.php
+++ b/packages/admin/resources/views/livewire/tables/cells/products/attribute-value.blade.php
@@ -5,7 +5,7 @@
 <div>
     @if($record->attribute_value_id)
         @php
-            $attributeValue = \Shopper\Core\Models\AttributeValue::with('attribute')->find($record->attribute_value_id);
+            $attributeValue = $record->value;
         @endphp
 
         <span class="inline-flex items-center text-sm leading-6 gap-2 text-gray-500 dark:text-gray-400">

--- a/packages/admin/src/Livewire/Components/Customers/Addresses.php
+++ b/packages/admin/src/Livewire/Components/Customers/Addresses.php
@@ -5,16 +5,21 @@ declare(strict_types=1);
 namespace Shopper\Livewire\Components\Customers;
 
 use Illuminate\Contracts\View\View;
-use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Collection;
+use Livewire\Attributes\Computed;
 use Livewire\Component;
+use Shopper\Core\Models\Address;
 
 class Addresses extends Component
 {
-    public Collection $addresses;
+    public $customer;
 
-    public function mount($adresses): void
+    #[Computed(persist: true)]
+    public function addresses(): Collection
     {
-        $this->addresses = $adresses;
+        return Address::with('country')
+            ->whereBelongsTo($this->customer)
+            ->get();
     }
 
     public function render(): View

--- a/packages/admin/src/Livewire/Components/Customers/Orders.php
+++ b/packages/admin/src/Livewire/Components/Customers/Orders.php
@@ -4,25 +4,34 @@ declare(strict_types=1);
 
 namespace Shopper\Livewire\Components\Customers;
 
+use Illuminate\Contracts\Pagination\Paginator;
 use Illuminate\Contracts\View\View;
+use Livewire\Attributes\Computed;
 use Livewire\Component;
+use Shopper\Core\Models\Order;
 
 class Orders extends Component
 {
     public $customer;
 
-    public function mount($customer): void
+    #[Computed(persist: true)]
+    public function orders(): Paginator
     {
-        $this->customer = $customer->load(['orders']);
+        return Order::with([
+            'items',
+            'items.product',
+            'items.product.media',
+            'shippingAddress',
+            'paymentMethod',
+            'shippingOption',
+        ])
+            ->whereBelongsTo($this->customer, 'customer')
+            ->latest()
+            ->simplePaginate(3);
     }
 
     public function render(): View
     {
-        return view('shopper::livewire.components.customers.orders', [
-            'orders' => $this->customer->orders()
-                ->with(['items', 'shippingAddress', 'paymentMethod', 'shippingOption'])
-                ->latest()
-                ->simplePaginate(3),
-        ]);
+        return view('shopper::livewire.components.customers.orders');
     }
 }

--- a/packages/admin/src/Livewire/Components/Products/Form/Attributes.php
+++ b/packages/admin/src/Livewire/Components/Products/Form/Attributes.php
@@ -34,7 +34,7 @@ class Attributes extends Component implements HasForms, HasTable
     {
         return $table
             ->query(
-                AttributeProduct::with(['attribute', 'value'])
+                AttributeProduct::with(['attribute', 'value', 'value.attribute'])
                     ->where('product_id', $this->product->id)
             )
             ->columns([

--- a/packages/admin/src/Livewire/Components/Products/Form/RelatedProducts.php
+++ b/packages/admin/src/Livewire/Components/Products/Form/RelatedProducts.php
@@ -25,7 +25,7 @@ class RelatedProducts extends Component implements HasActions, HasForms
 
     public function mount($product): void
     {
-        $this->product = $product;
+        $this->product->load('relatedProducts');
     }
 
     public function placeholder(): View

--- a/packages/admin/src/Livewire/Components/Products/Form/Variants.php
+++ b/packages/admin/src/Livewire/Components/Products/Form/Variants.php
@@ -99,7 +99,6 @@ class Variants extends Component implements HasForms, HasTable
                         fn ($record) => $this->redirectRoute(
                             name: 'shopper.products.variant',
                             parameters: ['productId' => $this->product->id, 'variantId' => $record->id],
-                            navigate: true
                         ),
                     ),
                 Tables\Actions\DeleteAction::make()

--- a/packages/admin/src/Livewire/Pages/Brand/Index.php
+++ b/packages/admin/src/Livewire/Pages/Brand/Index.php
@@ -13,7 +13,6 @@ use Filament\Tables\Contracts\HasTable;
 use Filament\Tables\Table;
 use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Collection;
-use Livewire\Attributes\On;
 use Shopper\Core\Repositories\BrandRepository;
 use Shopper\Facades\Shopper;
 use Shopper\Livewire\Pages\AbstractPageComponent;
@@ -127,11 +126,9 @@ class Index extends AbstractPageComponent implements HasForms, HasTable
             ->persistFiltersInSession();
     }
 
-    #[On('brand-save')]
     public function render(): View
     {
-        return view('shopper::livewire.pages.brand.index', [
-            'total' => (new BrandRepository)->count(),
-        ])->title(__('shopper::pages/brands.menu'));
+        return view('shopper::livewire.pages.brand.index')
+            ->title(__('shopper::pages/brands.menu'));
     }
 }

--- a/packages/admin/src/Livewire/Pages/Category/Index.php
+++ b/packages/admin/src/Livewire/Pages/Category/Index.php
@@ -13,7 +13,6 @@ use Filament\Tables\Contracts\HasTable;
 use Filament\Tables\Table;
 use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Collection;
-use Livewire\Attributes\On;
 use Shopper\Core\Repositories\CategoryRepository;
 use Shopper\Livewire\Pages\AbstractPageComponent;
 use Shopper\Traits\HasAuthenticated;
@@ -34,8 +33,8 @@ class Index extends AbstractPageComponent implements HasForms, HasTable
         return $table
             ->query(
                 (new CategoryRepository)
-                    ->with('parent:id,name')
                     ->query()
+                    ->with('parent')
                     ->latest()
             )
             ->columns([
@@ -148,7 +147,6 @@ class Index extends AbstractPageComponent implements HasForms, HasTable
             ]);
     }
 
-    #[On('category-save')]
     public function render(): View
     {
         return view('shopper::livewire.pages.category.index')

--- a/packages/admin/src/Livewire/Pages/Collection/Index.php
+++ b/packages/admin/src/Livewire/Pages/Collection/Index.php
@@ -29,8 +29,8 @@ class Index extends AbstractPageComponent implements HasForms, HasTable
         return $table
             ->query(
                 (new CollectionRepository)
-                    ->with('rules')
                     ->query()
+                    ->with('rules')
             )
             ->columns([
                 Tables\Columns\SpatieMediaLibraryImageColumn::make('image')
@@ -76,9 +76,7 @@ class Index extends AbstractPageComponent implements HasForms, HasTable
 
     public function render(): View
     {
-        return view('shopper::livewire.pages.collections.browse', [
-            'total' => (new CollectionRepository)->count(),
-        ])
+        return view('shopper::livewire.pages.collections.browse')
             ->title(__('shopper::pages/collections.menu'));
     }
 }

--- a/packages/admin/src/Livewire/Pages/Customers/Index.php
+++ b/packages/admin/src/Livewire/Pages/Customers/Index.php
@@ -14,7 +14,6 @@ use Filament\Tables\Table;
 use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Builder;
 use Shopper\Core\Enum\OrderStatus;
-use Shopper\Core\Models\Country;
 use Shopper\Core\Repositories\UserRepository;
 use Shopper\Livewire\Pages\AbstractPageComponent;
 
@@ -33,8 +32,8 @@ class Index extends AbstractPageComponent implements HasForms, HasTable
         return $table
             ->query(
                 (new UserRepository)
-                    ->with(['roles', 'addresses'])
                     ->query()
+                    ->with(['addresses', 'addresses.country'])
                     ->scopes('customers')
                     ->latest()
             )
@@ -52,7 +51,7 @@ class Index extends AbstractPageComponent implements HasForms, HasTable
                 Tables\Columns\TextColumn::make('country')
                     ->label(__('shopper::forms.label.country'))
                     ->getStateUsing(
-                        fn ($record): ?string => Country::query()->find($record->addresses->first()?->country_id)?->name ?? null
+                        fn ($record): ?string => $record->addresses->first()?->country?->name
                     )
                     ->sortable(),
                 Tables\Columns\TextColumn::make('orders_count')
@@ -101,12 +100,7 @@ class Index extends AbstractPageComponent implements HasForms, HasTable
 
     public function render(): View
     {
-        return view('shopper::livewire.pages.customers.index', [
-            'total' => (new UserRepository)
-                ->query()
-                ->scopes('customers')
-                ->count(),
-        ])
+        return view('shopper::livewire.pages.customers.index')
             ->title(__('shopper::pages/customers.menu'));
     }
 }

--- a/packages/admin/src/Livewire/Pages/Discount/Index.php
+++ b/packages/admin/src/Livewire/Pages/Discount/Index.php
@@ -15,7 +15,6 @@ use Filament\Tables\Table;
 use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
-use Livewire\Attributes\On;
 use Shopper\Core\Enum\DiscountApplyTo;
 use Shopper\Core\Enum\DiscountEligibility;
 use Shopper\Core\Models\Discount;
@@ -36,7 +35,7 @@ class Index extends AbstractPageComponent implements HasForms, HasTable
     public function table(Table $table): Table
     {
         return $table
-            ->query(Discount::with('zone')->latest())
+            ->query(Discount::with('zone', 'zone.currency')->latest())
             ->columns([
                 Tables\Columns\TextColumn::make('code')
                     ->label(__('shopper::forms.label.code'))
@@ -144,12 +143,9 @@ class Index extends AbstractPageComponent implements HasForms, HasTable
             ->emptyStateHeading(__('shopper::pages/discounts.empty_message'));
     }
 
-    #[On('discount-save')]
     public function render(): View
     {
-        return view('shopper::livewire.pages.discounts.index', [
-            'total' => Discount::query()->count(),
-        ])
+        return view('shopper::livewire.pages.discounts.index')
             ->title(__('shopper::pages/discounts.menu'));
     }
 }

--- a/packages/admin/src/Livewire/Pages/Order/Detail.php
+++ b/packages/admin/src/Livewire/Pages/Order/Detail.php
@@ -11,6 +11,7 @@ use Filament\Forms\Concerns\InteractsWithForms;
 use Filament\Forms\Contracts\HasForms;
 use Filament\Notifications\Notification;
 use Illuminate\Contracts\View\View;
+use Livewire\Attributes\Computed;
 use Livewire\Attributes\Validate;
 use Livewire\WithPagination;
 use Shopper\Core\Enum\OrderStatus;
@@ -20,8 +21,12 @@ use Shopper\Core\Events\Orders\Completed;
 use Shopper\Core\Events\Orders\Paid;
 use Shopper\Core\Events\Orders\Registered;
 use Shopper\Core\Models\Order;
+use Shopper\Core\Models\User;
 use Shopper\Livewire\Pages\AbstractPageComponent;
 
+/**
+ * @property-read User|null $customer
+ */
 class Detail extends AbstractPageComponent implements HasActions, HasForms
 {
     use InteractsWithActions;
@@ -32,12 +37,14 @@ class Detail extends AbstractPageComponent implements HasActions, HasForms
 
     public int $perPage = 3;
 
-    #[Validate('required')]
+    #[Validate('required|string')]
     public ?string $notes = null;
 
     public function mount(): void
     {
         $this->authorize('read_orders');
+
+        $this->order->load('items', 'shippingAddress', 'billingAddress');
     }
 
     public function goToOrder(int $id): void
@@ -57,6 +64,14 @@ class Detail extends AbstractPageComponent implements HasActions, HasForms
             ->body(__('shopper::pages/orders.notifications.note_added'))
             ->success()
             ->send();
+    }
+
+    #[Computed(persist: true)]
+    public function customer(): ?User
+    {
+        return User::query()
+            ->withCount('orders')
+            ->find($this->order->customer_id);
     }
 
     public function cancelOrderAction(): Action
@@ -132,7 +147,7 @@ class Detail extends AbstractPageComponent implements HasActions, HasForms
         return view('shopper::livewire.pages.orders.detail', [
             'items' => $this->order
                 ->items()
-                ->with('product')
+                ->with('product', 'product.media', 'product.prices')
                 ->simplePaginate($this->perPage),
             'nextOrder' => Order::query()
                 ->where('id', '>', $this->order->id)
@@ -142,9 +157,6 @@ class Detail extends AbstractPageComponent implements HasActions, HasForms
                 ->where('id', '<', $this->order->id)
                 ->latest('id')
                 ->first(),
-            'billingAddress' => $this->order->billingAddress?->load('customer'),
-            'shippingAddress' => $this->order->shippingAddress?->load('customer'),
-            'shippingOption' => $this->order->shippingOption,
         ])
             ->title(__('shopper::pages/orders.show_title', ['number' => $this->order->number]));
     }

--- a/packages/admin/src/Livewire/Pages/Order/Index.php
+++ b/packages/admin/src/Livewire/Pages/Order/Index.php
@@ -33,6 +33,8 @@ class Index extends AbstractPageComponent implements HasForms, HasTable
                         'customer',
                         'items',
                         'zone',
+                        'items.product',
+                        'items.product.media',
                     ])
                     ->latest()
             )
@@ -54,16 +56,16 @@ class Index extends AbstractPageComponent implements HasForms, HasTable
                     ->label(__('shopper::words.customer'))
                     ->searchable()
                     ->sortable()
-                    ->formatStateUsing(fn (Order $model): View => view(
+                    ->formatStateUsing(fn (Order $record): View => view(
                         'shopper::livewire.tables.cells.orders.customer',
-                        ['order' => $model->load('customer')]
+                        ['order' => $record]
                     ))
                     ->toggleable(),
                 Tables\Columns\TextColumn::make('id')
                     ->label(__('shopper::words.purchased'))
-                    ->formatStateUsing(fn (Order $model): View => view(
+                    ->formatStateUsing(fn (Order $record): View => view(
                         'shopper::livewire.tables.cells.orders.purchased',
-                        ['order' => $model->load('items')]
+                        ['order' => $record]
                     )),
                 Tables\Columns\TextColumn::make('currency_code')
                     ->label(__('shopper::forms.label.price_amount'))
@@ -86,15 +88,12 @@ class Index extends AbstractPageComponent implements HasForms, HasTable
                             parameters: ['order' => $record]
                         ),
                     ),
-            ])
-            ->filters([]);
+            ]);
     }
 
     public function render(): View
     {
-        return view('shopper::livewire.pages.orders.index', [
-            'total' => Order::query()->count(),
-        ])
+        return view('shopper::livewire.pages.orders.index')
             ->title(__('shopper::pages/orders.menu'));
     }
 }

--- a/packages/admin/src/Livewire/Pages/Product/Index.php
+++ b/packages/admin/src/Livewire/Pages/Product/Index.php
@@ -84,8 +84,7 @@ class Index extends AbstractPageComponent implements HasForms, HasTable
                         ->color('primary')
                         ->action(fn ($record) => $this->redirectRoute(
                             name: 'shopper.products.edit',
-                            parameters: ['product' => $record],
-                            navigate: true
+                            parameters: ['product' => $record]
                         )),
                     Tables\Actions\Action::make(__('shopper::forms.actions.delete'))
                         ->icon('untitledui-trash-03')
@@ -119,9 +118,7 @@ class Index extends AbstractPageComponent implements HasForms, HasTable
 
     public function render(): View
     {
-        return view('shopper::livewire.pages.products.index', [
-            'total' => (new ProductRepository)->count(),
-        ])
+        return view('shopper::livewire.pages.products.index')
             ->title(__('shopper::pages/products.menu'));
     }
 }

--- a/packages/admin/src/Livewire/Pages/Product/Variant.php
+++ b/packages/admin/src/Livewire/Pages/Product/Variant.php
@@ -31,7 +31,14 @@ class Variant extends AbstractPageComponent implements HasActions, HasForms
         $this->authorize('edit_products');
 
         $this->product = (new ProductRepository)->getById($productId);
-        $this->variant = (new VariantRepository)->with(['prices', 'media'])->getById($variantId);
+        $this->variant = (new VariantRepository)
+            ->with([
+                'prices',
+                'media',
+                'values',
+                'values.attribute',
+            ])
+            ->getById($variantId);
     }
 
     public function updateStockAction(): Action

--- a/packages/admin/src/Livewire/Pages/Reviews/Index.php
+++ b/packages/admin/src/Livewire/Pages/Reviews/Index.php
@@ -12,7 +12,6 @@ use Filament\Tables\Concerns\InteractsWithTable;
 use Filament\Tables\Contracts\HasTable;
 use Filament\Tables\Table;
 use Illuminate\Contracts\View\View;
-use Livewire\Attributes\On;
 use Shopper\Core\Models\Review;
 use Shopper\Livewire\Pages\AbstractPageComponent;
 
@@ -89,12 +88,9 @@ class Index extends AbstractPageComponent implements HasForms, HasTable
             ]);
     }
 
-    #[On('reviewUpdated')]
     public function render(): View
     {
-        return view('shopper::livewire.pages.reviews.index', [
-            'total' => Review::query()->count(),
-        ])
+        return view('shopper::livewire.pages.reviews.index')
             ->title(__('shopper::pages/reviews.menu'));
     }
 }

--- a/packages/admin/src/Livewire/SlideOvers/BrandForm.php
+++ b/packages/admin/src/Livewire/SlideOvers/BrandForm.php
@@ -11,11 +11,9 @@ use Filament\Forms\Form;
 use Filament\Forms\Set;
 use Filament\Notifications\Notification;
 use Illuminate\Contracts\View\View;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
 use Shopper\Components\Form\SeoField;
 use Shopper\Components\Section;
-use Shopper\Core\Models\Brand;
 use Shopper\Core\Repositories\BrandRepository;
 use Shopper\Livewire\Components\SlideOverComponent;
 
@@ -26,10 +24,7 @@ class BrandForm extends SlideOverComponent implements HasForms
 {
     use InteractsWithForms;
 
-    /**
-     * @var Brand|Model|null
-     */
-    public $brand = null;
+    public $brand;
 
     public ?array $data = [];
 
@@ -106,10 +101,13 @@ class BrandForm extends SlideOverComponent implements HasForms
 
     public function save(): void
     {
-        // @phpstan-ignore-next-line
-        if ($this->brand?->id) {
+        if ($this->brand->id) {
+            $this->authorize('edit_brands', $this->brand);
+
             $this->brand->update($this->form->getState());
         } else {
+            $this->authorize('add_brands');
+
             $brand = (new BrandRepository)->create($this->form->getState());
             $this->form->model($brand)->saveRelationships();
         }
@@ -119,11 +117,10 @@ class BrandForm extends SlideOverComponent implements HasForms
             ->success()
             ->send();
 
-        $this->dispatch('brand-save');
-
-        $this->closePanel();
-
-        $this->form->fill();
+        $this->redirectRoute(
+            name: 'shopper.brands.index',
+            navigate: true,
+        );
     }
 
     public function render(): View

--- a/packages/admin/src/Livewire/SlideOvers/CategoryForm.php
+++ b/packages/admin/src/Livewire/SlideOvers/CategoryForm.php
@@ -111,8 +111,12 @@ class CategoryForm extends SlideOverComponent implements HasForms
     public function save(): void
     {
         if ($this->category->id) {
+            $this->authorize('edit_categories', $this->category);
+
             $this->category->update($this->form->getState());
         } else {
+            $this->authorize('add_categories');
+
             $category = (new CategoryRepository)->create($this->form->getState());
             $this->form->model($category)->saveRelationships();
         }
@@ -122,11 +126,10 @@ class CategoryForm extends SlideOverComponent implements HasForms
             ->success()
             ->send();
 
-        $this->dispatch('category-save');
-
-        $this->closePanel();
-
-        $this->form->fill();
+        $this->redirectRoute(
+            name: 'shopper.categories.index',
+            navigate: true,
+        );
     }
 
     public function render(): View

--- a/packages/admin/src/Livewire/SlideOvers/DiscountForm.php
+++ b/packages/admin/src/Livewire/SlideOvers/DiscountForm.php
@@ -33,7 +33,7 @@ class DiscountForm extends SlideOverComponent implements HasForms
 {
     use InteractsWithForms;
 
-    public ?Discount $discount = null;
+    public Discount $discount;
 
     public ?array $data = [];
 
@@ -319,7 +319,7 @@ class DiscountForm extends SlideOverComponent implements HasForms
 
         $this->discount = app()->call(SaveAndDispatchDiscountAction::class, [
             'values' => $discountFormValues,
-            'discountId' => $this->discount?->id,
+            'discountId' => $this->discount->id ?? null,
             'productsIds' => data_get($data, 'products', []),
             'customersIds' => data_get($data, 'customers', []),
         ]);
@@ -329,9 +329,10 @@ class DiscountForm extends SlideOverComponent implements HasForms
             ->success()
             ->send();
 
-        $this->dispatch('discount-save');
-
-        $this->closePanel();
+        $this->redirectRoute(
+            name: 'shopper.discounts.index',
+            navigate: true,
+        );
     }
 
     public function render(): View

--- a/packages/admin/src/Livewire/SlideOvers/ReviewDetail.php
+++ b/packages/admin/src/Livewire/SlideOvers/ReviewDetail.php
@@ -22,6 +22,11 @@ class ReviewDetail extends SlideOverComponent implements HasActions, HasForms
 
     public Review $review;
 
+    public function mount(): void
+    {
+        $this->review->load('author', 'reviewrateable');
+    }
+
     public function approvedAction(): Action
     {
         return Action::make('approved')
@@ -30,13 +35,12 @@ class ReviewDetail extends SlideOverComponent implements HasActions, HasForms
             ->action(function (): void {
                 $this->review->updatedApproved(! $this->review->approved);
 
-                $this->dispatch('reviewUpdated');
-                $this->closePanel();
-
                 Notification::make()
                     ->title(__('shopper::pages/products.reviews.approved_message'))
                     ->success()
                     ->send();
+
+                $this->redirectRoute(name: 'shopper.reviews.index', navigate: true);
             });
     }
 

--- a/packages/core/src/Models/Collection.php
+++ b/packages/core/src/Models/Collection.php
@@ -70,7 +70,7 @@ class Collection extends Model implements SpatieHasMedia
     public function firstRule(): ?string
     {
         /** @var CollectionRule $collectionRule */
-        $collectionRule = $this->rules()->first();
+        $collectionRule = $this->rules->first();
 
         if ($this->isAutomatic()) {
             $words = $collectionRule->getFormattedRule() . ' ' . $collectionRule->getFormattedOperator() . ' ' . $collectionRule->getFormattedValue();

--- a/packages/core/src/Models/User.php
+++ b/packages/core/src/Models/User.php
@@ -31,6 +31,7 @@ use Spatie\Permission\Traits\HasRoles;
  * @property Carbon | null $birth_date
  * @property string | null $two_factor_recovery_codes
  * @property string | null $two_factor_secret
+ * @property-read \Illuminate\Support\Collection | Order[] $orders
  */
 class User extends Authenticatable
 {

--- a/tests/src/Admin/Features/Brand/BrandTest.php
+++ b/tests/src/Admin/Features/Brand/BrandTest.php
@@ -34,7 +34,7 @@ it('can create brand', function (): void {
             'name' => 'Nike',
         ])
         ->call('save')
-        ->assertDispatched('brand-save');
+        ->assertRedirectToRoute('shopper.brands.index');
 });
 
 it('will generate a slug when brand slug already exists', function (): void {
@@ -46,7 +46,7 @@ it('will generate a slug when brand slug already exists', function (): void {
             'name' => 'Nike',
         ])
         ->call('save')
-        ->assertDispatched('brand-save');
+        ->assertRedirectToRoute('shopper.brands.index');
 
     expect((new BrandRepository)->count())
         ->toBe(2)

--- a/tests/src/Admin/Features/Category/CategoryTest.php
+++ b/tests/src/Admin/Features/Category/CategoryTest.php
@@ -37,7 +37,7 @@ it('can create a category', function (): void {
         ])
         ->call('save')
         ->assertHasNoFormErrors()
-        ->assertDispatched('category-save');
+        ->assertRedirectToRoute('shopper.categories.index');
 
     expect((new CategoryRepository)->count())->toBe(1);
 })->group('category');
@@ -51,7 +51,7 @@ it('will generate a slug when brand slug already exists', function (): void {
             'name' => 'My first category',
         ])
         ->call('save')
-        ->assertDispatched('category-save');
+        ->assertRedirectToRoute('shopper.categories.index');
 
     expect((new CategoryRepository)->count())
         ->toBe(2)
@@ -70,7 +70,7 @@ it('can create category with parent', function (): void {
         ])
         ->call('save')
         ->assertHasNoFormErrors()
-        ->assertDispatched('category-save');
+        ->assertRedirectToRoute('shopper.categories.index');
 
     expect((new CategoryRepository)->count())->toBe(2);
 })->group('category');

--- a/tests/src/Admin/Features/Collection/CollectionProductsListTest.php
+++ b/tests/src/Admin/Features/Collection/CollectionProductsListTest.php
@@ -37,4 +37,4 @@ it('can have correct products after search', function (): void {
     $collection->refresh();
 
     expect($collection->products->count())->toBe(2);
-});
+})->group('collection');

--- a/tests/src/Admin/Features/Collection/CollectionTest.php
+++ b/tests/src/Admin/Features/Collection/CollectionTest.php
@@ -23,7 +23,7 @@ it('can render collections page', function (): void {
 
     livewire(Pages\Collection\Index::class)
         ->assertSee(__('shopper::pages/collections.menu'));
-});
+})->group('collection');
 
 it('can validate `required` fields on add collection form', function (): void {
     livewire(AddCollectionForm::class)
@@ -31,7 +31,7 @@ it('can validate `required` fields on add collection form', function (): void {
         ->fillForm([])
         ->call('store')
         ->assertHasFormErrors(['name' => 'required', 'type' => 'required']);
-});
+})->group('collection');
 
 it('can create a collection', function (): void {
     livewire(AddCollectionForm::class)
@@ -50,7 +50,7 @@ it('can create a collection', function (): void {
         );
 
     expect((new CollectionRepository)->count())->toBe(1);
-});
+})->group('collection');
 
 it('can search collection by `name`', function (): void {
     $collections = Collection::factory()->count(10)->create();
@@ -61,7 +61,7 @@ it('can search collection by `name`', function (): void {
         ->searchTable($name)
         ->assertCanSeeTableRecords($collections->where('name', $name))
         ->assertCanNotSeeTableRecords($collections->where('name', '!=', $name));
-});
+})->group('collection');
 
 it('can display the edit collection page by click on table action', function (): void {
     $collections = Collection::factory()->count(3)->create();
@@ -73,7 +73,7 @@ it('can display the edit collection page by click on table action', function ():
 
     livewire(Pages\Collection\Edit::class, ['collection' => $collection->id])
         ->assertSuccessful();
-});
+})->group('collection');
 
 it('can render collection edit page', function (): void {
     $collection = Collection::factory()->create();
@@ -83,7 +83,7 @@ it('can render collection edit page', function (): void {
 
     livewire(Pages\Collection\Edit::class, ['collection' => $collection->id])
         ->assertSee($collection->name);
-});
+})->group('collection');
 
 it('can edit a collection', function (): void {
     $collection = Collection::factory()->create();
@@ -97,7 +97,7 @@ it('can edit a collection', function (): void {
         ->assertNotified(__('shopper::notifications.update', ['item' => __('shopper::pages/collections.single')]));
 
     expect($collection->refresh()->name)->toBe('My manual collection');
-});
+})->group('collection');
 
 it('can\'t change type of collection on edit form', function (): void {
     $collection = Collection::factory(['type' => CollectionType::Manual()])->create();
@@ -111,7 +111,7 @@ it('can\'t change type of collection on edit form', function (): void {
         ->assertHasNoFormErrors();
 
     expect($collection->refresh()->type)->toBe(CollectionType::Manual);
-});
+})->group('collection');
 
 it('can display products modal on manual collection', function (): void {
     $collection = Collection::factory(['type' => CollectionType::Manual()])->create();
@@ -130,7 +130,7 @@ it('can display products modal on manual collection', function (): void {
     livewire(CollectionProductsList::class, ['collectionId' => $collection->id])
         ->assertSuccessful()
         ->assertSee(__('shopper::pages/collections.modal.title'));
-});
+})->group('collection');
 
 it('can save rules on auto collection', function (): void {
     $collection = Collection::factory(['type' => CollectionType::Auto()])->create();
@@ -152,4 +152,4 @@ it('can save rules on auto collection', function (): void {
         ->fillForm([])
         ->call('store')
         ->assertHasNoFormErrors();
-});
+})->group('collection');

--- a/tests/src/Admin/Features/Discount/DiscountTest.php
+++ b/tests/src/Admin/Features/Discount/DiscountTest.php
@@ -28,13 +28,13 @@ beforeEach(function (): void {
     Queue::fake();
 });
 
-it('can render collections page', function (): void {
+it('can render discounts page', function (): void {
     get(route('shopper.discounts.index'))
         ->assertFound();
 
     livewire(Pages\Discount\Index::class)
         ->assertSee(__('shopper::pages/discounts.menu'));
-});
+})->group('discount');
 
 it('creates a new discount', function (): void {
     livewire(DiscountForm::class)
@@ -58,7 +58,7 @@ it('creates a new discount', function (): void {
     expect(Discount::query()->count())->toBe(1);
 
     Queue::assertCount(2);
-});
+})->group('discount');
 
 it('should not create a discount with a date in the past', function (): void {
     livewire(DiscountForm::class)
@@ -74,7 +74,7 @@ it('should not create a discount with a date in the past', function (): void {
         ])
         ->call('store')
         ->assertHasFormErrors(['start_at']);
-});
+})->group('discount');
 
 it('can update a discount', function (): void {
     $discount = Discount::factory()->create();
@@ -100,4 +100,4 @@ it('can update a discount', function (): void {
         ->toBe($code);
 
     Queue::assertCount(2);
-});
+})->group('discount');

--- a/tests/src/Admin/Features/Product/Forms/AttributesTest.php
+++ b/tests/src/Admin/Features/Product/Forms/AttributesTest.php
@@ -62,4 +62,4 @@ it('product can choose attributes', function (): void {
 
     expect($this->product->options->count())
         ->toBe(2);
-});
+})->group('product');

--- a/tests/src/Admin/Features/Product/ProductTest.php
+++ b/tests/src/Admin/Features/Product/ProductTest.php
@@ -31,7 +31,7 @@ it('can render products page', function (): void {
 
     livewire(Pages\Product\Index::class)
         ->assertSee(__('shopper::pages/products.menu'));
-});
+})->group('product');
 
 it('create a new product', function (): void {
     livewire(AddProduct::class)
@@ -48,7 +48,7 @@ it('create a new product', function (): void {
     Event::assertDispatched(Created::class);
 
     expect(Product::query()->count())->toBe(1);
-});
+})->group('product');
 
 it('create new product with stock', function (): void {
     Inventory::factory(['is_default' => true])->create();
@@ -77,7 +77,7 @@ it('create new product with stock', function (): void {
         ->toBe(1)
         ->and($product->stock)
         ->toBe(10);
-});
+})->group('product');
 
 it('create new product with associations', function (): void {
     $brand = Brand::factory(['is_enabled' => true])->create();
@@ -107,7 +107,7 @@ it('create new product with associations', function (): void {
         ->and($product->brand)->toBeInstanceOf(Brand::class)
         ->and($product->categories->count())->toBe(3)
         ->and($product->channels->count())->toBe(2);
-});
+})->group('product');
 
 it('redirect to edit page after create product', function (): void {
     livewire(AddProduct::class)
@@ -121,7 +121,7 @@ it('redirect to edit page after create product', function (): void {
         ->call('store')
         ->assertHasNoFormErrors()
         ->assertRedirect(route('shopper.products.edit', Product::query()->first()));
-});
+})->group('product');
 
 it('can update product information', function (): void {
     $product = Product::factory()->create();
@@ -138,7 +138,7 @@ it('can update product information', function (): void {
     Event::assertDispatched(Updated::class);
 
     expect($product->slug)->toBe('demo-product');
-});
+})->group('product');
 
 it('ensure that external_id field is invisible on non external product', function (): void {
     $product = Product::factory()->virtual()->create();
@@ -146,7 +146,7 @@ it('ensure that external_id field is invisible on non external product', functio
     livewire(Edit::class, ['product' => $product])
         ->fillForm()
         ->assertFormFieldIsHidden('external_id');
-});
+})->group('product');
 
 it('can view the external id field on external product editing', function (): void {
     $product = Product::factory()->external()->create();
@@ -164,4 +164,4 @@ it('can view the external id field on external product editing', function (): vo
     Event::assertDispatched(Updated::class);
 
     expect($product->external_id)->toBe($uuid);
-});
+})->group('product');


### PR DESCRIPTION
## Add
- Translations for sales channels

## Updated
- Customer `Orders` and `Addresses` Livewire components to use computed functions

## Fix
- Error on product price `$product->getPriceAmount()` when display Product Review
- Model implicite Lazy loading
- N+1 queries on Table data in `Category`, `Brand`, `Collection`, `Product`, `Review`, `Order`, `Attribute`
- Feature Tests