### PR TITLE
fix: create new customer

### DIFF
--- a/packages/admin/src/Livewire/Pages/Customers/Create.php
+++ b/packages/admin/src/Livewire/Pages/Customers/Create.php
@@ -139,7 +139,6 @@ class Create extends AbstractPageComponent implements HasForms
         $address = array_merge(Arr::only($data, ['address'])['address'], [
             'first_name' => $data['first_name'],
             'last_name' => $data['last_name'],
-            'is_default' => true,
             'type' => AddressType::Shipping,
         ]);
 


### PR DESCRIPTION
Fix: SQL Error for Missing is_default Column

This pull request resolves a bug where the application throws the following SQL error:
SQLSTATE[42S22]: Column not found: 1054 Unknown column 'is_default' in 'field list' 

This PR fixes an error caused by referencing the is_default column, which was removed in https://github.com/shopperlabs/shopper/pull/254/files#diff-b106fdc237e3e8f3dcc2e5969dcd06457d8c56e607bb656b5707062da140851c