### PR TITLE
Fix: Attempt to read property "svg_flag" on null

### DIFF
--- a/packages/admin/resources/views/livewire/pages/settings/locations/index.blade.php
+++ b/packages/admin/resources/views/livewire/pages/settings/locations/index.blade.php
@@ -61,6 +61,7 @@
                                     </div>
                                     <div class="mt-2 sm:flex sm:justify-between">
                                         <div class="sm:flex sm:gap-x-4">
+                                            @if ($inventory->country)
                                             <div class="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
                                                 <img
                                                     src="{{ $inventory->country->svg_flag }}"
@@ -69,6 +70,7 @@
                                                 />
                                                 {{ $inventory->country->name }}
                                             </div>
+                                            @endif
                                             <div class="mt-2 flex gap-2 items-center text-sm text-gray-500 dark:text-gray-400 sm:mt-0">
                                                 <x-untitledui-marker-pin-02
                                                     class="size-5 shrink-0 text-gray-400 dark:text-gray-500"

--- a/packages/admin/src/Livewire/Pages/Customers/Create.php
+++ b/packages/admin/src/Livewire/Pages/Customers/Create.php
@@ -139,7 +139,6 @@ class Create extends AbstractPageComponent implements HasForms
         $address = array_merge(Arr::only($data, ['address'])['address'], [
             'first_name' => $data['first_name'],
             'last_name' => $data['last_name'],
-            'is_default' => true,
             'type' => AddressType::Shipping,
         ]);
 


### PR DESCRIPTION
Fix null country error in location settings page

Previously, when creating a store, the country field was optional.
<img width="592" alt="image" src="https://github.com/user-attachments/assets/ababc3b7-07c1-41d6-862e-79cb72a74e49" />

If no country was selected, it caused an error on the Location Settings page: Attempt to read property "svg_flag" on null.
This fix ensures the page handles cases where the store has no country set, preventing the null property access error.


