### PR TITLE
Fix: customer detail

### DIFF
--- a/packages/admin/resources/views/livewire/components/customers/orders.blade.php
+++ b/packages/admin/resources/views/livewire/components/customers/orders.blade.php
@@ -37,10 +37,14 @@
                                 {{ __('shopper::pages/customers.orders.ship_to') }}
                             </dt>
                             <dd class="mt-1 text-sm font-medium text-gray-700 dark:text-gray-300">
-                                {{ $order->shippingAddress->street_address }}
-                                {{ $order->shippingAddress->postal_code }},
-                                {{ $order->shippingAddress->city }}
-                                {{ $order->shippingAddress->country_name }}
+                                @if ($order->shippingAddress)
+                                    {{ $order->shippingAddress->street_address }}
+                                    {{ $order->shippingAddress->postal_code }},
+                                    {{ $order->shippingAddress->city }}
+                                    {{ $order->shippingAddress->country_name }}
+                                @else
+                                    {{ __('N/A') }}
+                                @endif
                             </dd>
                         </div>
                     </div>

--- a/packages/admin/src/Livewire/Pages/Customers/Create.php
+++ b/packages/admin/src/Livewire/Pages/Customers/Create.php
@@ -139,7 +139,6 @@ class Create extends AbstractPageComponent implements HasForms
         $address = array_merge(Arr::only($data, ['address'])['address'], [
             'first_name' => $data['first_name'],
             'last_name' => $data['last_name'],
-            'is_default' => true,
             'type' => AddressType::Shipping,
         ]);
 


### PR DESCRIPTION
Fix bug in customer detail view: Attempt to read property "street_address" on null

Resolved an issue where accessing the street_address property on a null value would cause an error. This occurred because the orders.shipping_address_id column can be null, meaning no associated shipping address exists for some orders. A null check has been added to prevent the error when the shipping address is missing.

<img width="1405" alt="image" src="https://github.com/user-attachments/assets/0a308eee-80c0-4118-b057-567ce7cd0752" />
