### PR TITLE
feat: add zones relationship to collections using polymorphic pivot table

### DIFF
--- a/packages/admin/resources/lang/en/pages/collections.php
+++ b/packages/admin/resources/lang/en/pages/collections.php
@@ -15,6 +15,7 @@ return [
     'filter_type' => 'Collection Type',
     'product_conditions' => 'Product conditions',
     'availability_description' => 'Specify a publication date so that your collections are scheduled on your store.',
+    'zone_description' => 'Limit this collection only to the selected zones.',
     'empty_collections' => 'There are no products in this collection. Add or change conditions to dynamically add products.',
     'remove_product' => 'The product have been correctly remove to this collection.',
 

--- a/packages/admin/resources/lang/fr/pages/collections.php
+++ b/packages/admin/resources/lang/fr/pages/collections.php
@@ -15,6 +15,7 @@ return [
     'filter_type' => 'Type de Collection',
     'product_conditions' => 'Conditions du produit',
     'availability_description' => 'Précisez une date de publication pour que la collection soit programmée sur votre boutique.',
+    'zone_description' => 'Limiter cette collection uniquement aux zones sélectionnées.',
     'empty_collections' => 'Il n\'y a aucun produit dans cette collection. Ajoutez ou modifiez des conditions pour ajouter dynamiquement des produits.',
     'remove_product' => 'Le produit a été correctement retiré de cette collection.',
 

--- a/packages/admin/src/Livewire/Pages/Collection/Edit.php
+++ b/packages/admin/src/Livewire/Pages/Collection/Edit.php
@@ -9,6 +9,7 @@ use Filament\Actions\Contracts\HasActions;
 use Filament\Forms\Components\DateTimePicker;
 use Filament\Forms\Components\KeyValue;
 use Filament\Forms\Components\RichEditor;
+use Filament\Forms\Components\Select;
 use Filament\Forms\Components\SpatieMediaLibraryFileUpload;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Concerns\InteractsWithForms;
@@ -100,6 +101,14 @@ class Edit extends AbstractPageComponent implements HasActions, HasForms
                             ->required()
                             ->default(now())
                             ->helperText(__('shopper::pages/collections.availability_description')),
+                        Select::make('zones')
+                            ->label(__('shopper::pages/settings/zones.title'))
+                            ->relationship('zones', 'name')
+                            ->multiple()
+                            ->native(false)
+                            ->searchable()
+                            ->preload()
+                            ->helperText(__('shopper::pages/collections.zone_description')),
                         Group::make()
                             ->schema([
                                 TextEntry::make(__('shopper::words.seo.slug'))

--- a/packages/admin/src/Livewire/Pages/Collection/Index.php
+++ b/packages/admin/src/Livewire/Pages/Collection/Index.php
@@ -39,7 +39,7 @@ class Index extends AbstractPageComponent implements HasActions, HasForms, HasTa
     public function table(Table $table): Table
     {
         return $table
-            ->query(resolve(CollectionContract::class)::query()->with('rules')->latest())
+            ->query(resolve(CollectionContract::class)::query()->with(['rules', 'zones'])->latest())
             ->columns([
                 SpatieMediaLibraryImageColumn::make('image')
                     ->collection(config('shopper.media.storage.thumbnail_collection'))

--- a/packages/admin/src/Livewire/Pages/Collection/Index.php
+++ b/packages/admin/src/Livewire/Pages/Collection/Index.php
@@ -15,10 +15,12 @@ use Filament\Tables\Columns\SpatieMediaLibraryImageColumn;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Concerns\InteractsWithTable;
 use Filament\Tables\Contracts\HasTable;
+use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Table;
 use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Collection;
 use Mckenziearts\Icons\Untitledui\Enums\Untitledui;
+use Shopper\Core\Enum\CollectionType;
 use Shopper\Core\Models\Contracts\Collection as CollectionContract;
 use Shopper\Facades\Shopper;
 use Shopper\Livewire\Pages\AbstractPageComponent;
@@ -57,9 +59,25 @@ class Index extends AbstractPageComponent implements HasActions, HasForms, HasTa
                     ->formatStateUsing(
                         fn (CollectionContract $record): string => $record->rules->isNotEmpty() ? ucfirst($record->firstRule()) : 'N/A'
                     ),
+                TextColumn::make('zones.name')
+                    ->label(__('shopper::pages/settings/zones.title'))
+                    ->badge()
+                    ->toggleable(isToggledHiddenByDefault: true),
                 TextColumn::make('updated_at')
                     ->label(__('shopper::forms.label.updated_at'))
                     ->date(),
+            ])
+            ->filters([
+                SelectFilter::make('type')
+                    ->label(__('shopper::pages/collections.filter_type'))
+                    ->options(CollectionType::class),
+                SelectFilter::make('zones')
+                    ->label(__('shopper::pages/settings/zones.title'))
+                    ->relationship('zones', 'name')
+                    ->multiple()
+                    ->searchable()
+                    ->preload()
+                    ->optionsLimit(5),
             ])
             ->recordActions([
                 Action::make('edit')

--- a/packages/admin/src/Livewire/SlideOvers/AddCollectionForm.php
+++ b/packages/admin/src/Livewire/SlideOvers/AddCollectionForm.php
@@ -7,9 +7,11 @@ namespace Shopper\Livewire\SlideOvers;
 use Filament\Actions\Concerns\InteractsWithActions;
 use Filament\Actions\Contracts\HasActions;
 use Filament\Forms\Components\DateTimePicker;
+use Filament\Forms\Components\Hidden;
 use Filament\Forms\Components\KeyValue;
 use Filament\Forms\Components\Radio;
 use Filament\Forms\Components\RichEditor;
+use Filament\Forms\Components\Select;
 use Filament\Forms\Components\SpatieMediaLibraryFileUpload;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Concerns\InteractsWithForms;
@@ -62,13 +64,8 @@ class AddCollectionForm extends SlideOverComponent implements HasActions, HasFor
                                     $set('slug', Str::slug($state));
                                 }
                             }),
-                        TextInput::make('slug')
-                            ->label(__('shopper::forms.label.slug'))
-                            ->disabled()
-                            ->dehydrated()
-                            ->required()
-                            ->maxLength(255)
-                            ->unique(table: config('shopper.models.collection'), column: 'slug'),
+                        Hidden::make('slug')
+                            ->label(__('shopper::forms.label.slug')),
                         DateTimePicker::make('published_at')
                             ->label(__('shopper::forms.label.availability'))
                             ->native(false)
@@ -80,6 +77,14 @@ class AddCollectionForm extends SlideOverComponent implements HasActions, HasFor
                             ->label(__('shopper::pages/collections.filter_type'))
                             ->required()
                             ->options(CollectionType::class),
+                        Select::make('zones')
+                            ->label(__('shopper::pages/settings/zones.title'))
+                            ->relationship('zones', 'name')
+                            ->multiple()
+                            ->native(false)
+                            ->searchable()
+                            ->preload()
+                            ->helperText(__('shopper::pages/collections.zone_description')),
                         RichEditor::make('description')
                             ->label(__('shopper::forms.label.description'))
                             ->toolbarButtons([

--- a/packages/core/database/migrations/2026_01_27_000001_update_zones_metadata_column_to_jsonb.php
+++ b/packages/core/database/migrations/2026_01_27_000001_update_zones_metadata_column_to_jsonb.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Shopper\Core\Helpers\Migration;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table($this->getTableName('zones'), function (Blueprint $table): void {
+            $table->jsonb('metadata')->nullable()->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table($this->getTableName('zones'), function (Blueprint $table): void {
+            $table->json('metadata')->nullable()->change();
+        });
+    }
+};

--- a/packages/core/src/Models/Collection.php
+++ b/packages/core/src/Models/Collection.php
@@ -33,6 +33,7 @@ use Spatie\MediaLibrary\HasMedia as SpatieHasMedia;
  * @property-read ?string $seo_title
  * @property-read ?string $seo_description
  * @property-read EloquentCollection<int, CollectionRule> $rules
+ * @property-read EloquentCollection<int, Zone> $zones
  * @property-read EloquentCollection<int, Product> $products
  */
 class Collection extends Model implements CollectionContract, SpatieHasMedia
@@ -129,6 +130,14 @@ class Collection extends Model implements CollectionContract, SpatieHasMedia
     {
         // @phpstan-ignore-next-line
         return $this->morphToMany(config('shopper.models.product'), 'productable', shopper_table('product_has_relations'));
+    }
+
+    /**
+     * @return MorphToMany<Zone, $this>
+     */
+    public function zones(): MorphToMany
+    {
+        return $this->morphToMany(Zone::class, 'zonable', shopper_table('zone_has_relations'));
     }
 
     /**

--- a/packages/core/src/Models/Contracts/Collection.php
+++ b/packages/core/src/Models/Contracts/Collection.php
@@ -30,4 +30,6 @@ interface Collection
     public function products(): MorphToMany;
 
     public function rules(): HasMany;
+
+    public function zones(): MorphToMany;
 }

--- a/packages/core/src/Models/Zone.php
+++ b/packages/core/src/Models/Zone.php
@@ -6,7 +6,7 @@ namespace Shopper\Core\Models;
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
-use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -29,10 +29,11 @@ use Shopper\Core\Models\Traits\HasSlug;
  * @property-read string $payments_name
  * @property-read string $currency_code
  * @property-read Currency $currency
- * @property-read Collection<int, Carrier> $carriers
- * @property-read Collection<int, CarrierOption> $shippingOptions
- * @property-read Collection<int, PaymentMethod> $paymentMethods
- * @property-read Collection<int, Country> $countries
+ * @property-read EloquentCollection<int, Carrier> $carriers
+ * @property-read EloquentCollection<int, CarrierOption> $shippingOptions
+ * @property-read EloquentCollection<int, PaymentMethod> $paymentMethods
+ * @property-read EloquentCollection<int, Country> $countries
+ * @property-read EloquentCollection<int, Contracts\Collection> $collections
  */
 class Zone extends Model implements ZoneContract
 {
@@ -130,6 +131,15 @@ class Zone extends Model implements ZoneContract
     public function carriers(): MorphToMany
     {
         return $this->morphedByMany(Carrier::class, 'zonable', shopper_table('zone_has_relations'));
+    }
+
+    /**
+     * @return MorphToMany<Collection, $this>
+     */
+    public function collections(): MorphToMany
+    {
+        // @phpstan-ignore-next-line
+        return $this->morphedByMany(config('shopper.models.collection'), 'zonable', shopper_table('zone_has_relations'));
     }
 
     /**

--- a/tests/Admin/Livewire/Pages/Collection/EditTest.php
+++ b/tests/Admin/Livewire/Pages/Collection/EditTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Livewire\Livewire;
 use Shopper\Core\Enum\CollectionType;
+use Shopper\Core\Models\Zone;
 use Shopper\Livewire\Pages\Collection\Edit;
 use Tests\Core\Stubs\Collection;
 use Tests\Core\Stubs\User;
@@ -71,5 +72,19 @@ describe(Edit::class, function (): void {
             ->assertHasNoFormErrors();
 
         expect($collection->refresh()->type)->toBe(CollectionType::Manual);
+    });
+
+    it('can update a collection with zones', function (): void {
+        $collection = Collection::factory()->create();
+        $zones = Zone::factory()->count(2)->create();
+
+        Livewire::test(Edit::class, ['collection' => $collection])
+            ->fillForm([
+                'zones' => $zones->pluck('id')->toArray(),
+            ])
+            ->call('store')
+            ->assertHasNoFormErrors();
+
+        expect($collection->refresh()->zones)->toHaveCount(2);
     });
 })->group('livewire', 'collections');

--- a/tests/Admin/Livewire/Pages/Collection/IndexTest.php
+++ b/tests/Admin/Livewire/Pages/Collection/IndexTest.php
@@ -2,8 +2,11 @@
 
 declare(strict_types=1);
 
+use Filament\Actions\Testing\TestAction;
 use Livewire\Livewire;
+use Shopper\Core\Enum\CollectionType;
 use Shopper\Core\Models\Collection;
+use Shopper\Core\Models\Zone;
 use Shopper\Livewire\Pages\Collection\Index;
 use Tests\Core\Stubs\User;
 
@@ -28,7 +31,7 @@ describe(Index::class, function (): void {
 
         Livewire::test(Index::class)
             ->loadTable()
-            ->assertCanSeeTableRecords(Collection::limit(3)->get());
+            ->assertCanSeeTableRecords(Collection::query()->limit(3)->get());
     });
 
     it('can search collection by name', function (): void {
@@ -48,7 +51,32 @@ describe(Index::class, function (): void {
         $collection = $collections->first();
 
         Livewire::test(Index::class)
-            ->assertTableActionExists('edit')
-            ->callTableAction('edit', $collection);
+            ->assertActionExists(TestAction::make('edit')->table($collection))
+            ->callAction(TestAction::make('edit')->table($collection));
+    });
+
+    it('can filter collections by type', function (): void {
+        Collection::factory()->create(['type' => CollectionType::Manual]);
+        Collection::factory()->create(['type' => CollectionType::Auto]);
+
+        Livewire::test(Index::class)
+            ->loadTable()
+            ->filterTable('type', CollectionType::Manual->value)
+            ->assertCanSeeTableRecords(Collection::query()->where('type', CollectionType::Manual)->get())
+            ->assertCanNotSeeTableRecords(Collection::query()->where('type', CollectionType::Auto)->get());
+    });
+
+    it('can filter collections by zones', function (): void {
+        $zone = Zone::factory()->create();
+        $collectionWithZone = Collection::factory()->create();
+        $collectionWithoutZone = Collection::factory()->create();
+
+        $collectionWithZone->zones()->attach($zone);
+
+        Livewire::test(Index::class)
+            ->loadTable()
+            ->filterTable('zones', [$zone->id])
+            ->assertCanSeeTableRecords([$collectionWithZone])
+            ->assertCanNotSeeTableRecords([$collectionWithoutZone]);
     });
 })->group('livewire', 'collections');

--- a/tests/Admin/Livewire/SlideOvers/AddCollectionFormTest.php
+++ b/tests/Admin/Livewire/SlideOvers/AddCollectionFormTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Livewire\Livewire;
 use Shopper\Core\Enum\CollectionType;
 use Shopper\Core\Models\Contracts\Collection as CollectionContract;
+use Shopper\Core\Models\Zone;
 use Shopper\Livewire\SlideOvers\AddCollectionForm;
 use Tests\Core\Stubs\Collection;
 use Tests\Core\Stubs\User;
@@ -22,7 +23,6 @@ beforeEach(function (): void {
 describe(AddCollectionForm::class, function (): void {
     it('can validate required fields on add collection form', function (): void {
         Livewire::test(AddCollectionForm::class)
-            ->assertFormExists()
             ->fillForm()
             ->call('store')
             ->assertHasFormErrors(['name' => 'required', 'type' => 'required']);
@@ -30,7 +30,6 @@ describe(AddCollectionForm::class, function (): void {
 
     it('can create a collection', function (): void {
         Livewire::test(AddCollectionForm::class)
-            ->assertFormExists()
             ->fillForm([
                 'name' => 'My manual collection',
                 'type' => CollectionType::Manual(),
@@ -45,5 +44,23 @@ describe(AddCollectionForm::class, function (): void {
             );
 
         expect(resolve(CollectionContract::class)::query()->count())->toBe(1);
+    });
+
+    it('can create a collection with zones', function (): void {
+        $zones = Zone::factory()->count(2)->create();
+
+        Livewire::test(AddCollectionForm::class)
+            ->fillForm([
+                'name' => 'Zoned collection',
+                'type' => CollectionType::Manual(),
+                'zones' => $zones->pluck('id')->toArray(),
+            ])
+            ->call('store')
+            ->assertHasNoFormErrors();
+
+        $collection = resolve(CollectionContract::class)::query()->first();
+
+        expect($collection)->not->toBeNull()
+            ->and($collection->zones)->toHaveCount(2);
     });
 })->group('livewire', 'slideovers', 'collections');

--- a/tests/Core/Models/CollectionTest.php
+++ b/tests/Core/Models/CollectionTest.php
@@ -3,12 +3,14 @@
 declare(strict_types=1);
 
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Shopper\Core\Enum\CollectionType;
 use Shopper\Core\Enum\Operator;
 use Shopper\Core\Enum\Rule;
 use Shopper\Core\Models\Collection;
 use Shopper\Core\Models\CollectionRule;
 use Shopper\Core\Models\Product;
+use Shopper\Core\Models\Zone;
 
 uses(Tests\TestCase::class);
 
@@ -105,6 +107,34 @@ describe(Collection::class, function (): void {
 
         expect($collection->metadata)->toBeArray()
             ->and($collection->metadata)->toBe($metadata);
+    });
+
+    it('has zones relationship', function (): void {
+        $collection = Collection::factory()->create();
+
+        expect($collection->zones())->toBeInstanceOf(MorphToMany::class);
+    });
+
+    it('can attach zones to a collection', function (): void {
+        $collection = Collection::factory()->create();
+        $zones = Zone::factory()->count(2)->create();
+
+        $collection->zones()->attach($zones);
+
+        expect($collection->zones)->toHaveCount(2);
+    });
+
+    it('can detach zones from a collection', function (): void {
+        $collection = Collection::factory()->create();
+        $zone = Zone::factory()->create();
+
+        $collection->zones()->attach($zone);
+
+        expect($collection->zones)->toHaveCount(1);
+
+        $collection->zones()->detach($zone);
+
+        expect($collection->refresh()->zones)->toHaveCount(0);
     });
 
     it('can register media collections from HasMedia trait', function (): void {


### PR DESCRIPTION
## Summary

- Collections can now be associated with multiple zones via the existing `zone_has_relations` table.
- Added `MorphToMany` relationship on both `Collection` and `Zone` models, zone select field on create/edit forms, filters and toggleable column on the collections listing page