### PR TITLE
feat(admin): add Laravel Boost skills for Shopper development

### DIFF
--- a/packages/admin/resources/boost/skills/extending-shopper/SKILL.md
+++ b/packages/admin/resources/boost/skills/extending-shopper/SKILL.md
@@ -1,0 +1,215 @@
+---
+name: extending-shopper
+description: Provides patterns for extending Laravel Shopper with custom sidebar items, component overrides, event listeners, and domain features like stock, pricing, and media. Use when customizing Shopper behavior.
+---
+
+# Extending Shopper
+
+## Sidebar Navigation
+
+### Add Item to Existing Group
+
+```php
+// app/Sidebar/ShippingSidebar.php
+namespace App\Sidebar;
+
+use Shopper\Sidebar\AbstractAdminSidebar;
+use Shopper\Sidebar\Contracts\Builder\Group;
+use Shopper\Sidebar\Contracts\Builder\Item;
+use Shopper\Sidebar\Contracts\Builder\Menu;
+
+class ShippingSidebar extends AbstractAdminSidebar
+{
+    public function extendWith(Menu $menu): Menu
+    {
+        $menu->group(__('shopper::layout.sidebar.catalog'), function (Group $group): void {
+            $group->weight(2); // Same weight as CatalogSidebar to merge
+
+            $group->item(__('Shipping'), function (Item $item): void {
+                $item->weight(5);
+                $item->useSpa();
+                $item->route('shopper.shipping.index');
+                $item->setIcon('untitledui-truck-01');
+                $item->setAuthorized($this->user->hasPermissionTo('browse_shipping'));
+            });
+        });
+
+        return $menu;
+    }
+}
+```
+
+Register in `AppServiceProvider`:
+
+```php
+use Shopper\Sidebar\SidebarBuilder;
+
+public function boot(): void
+{
+    $this->app['events']->listen(SidebarBuilder::class, ShippingSidebar::class);
+}
+```
+
+### Create New Sidebar Group
+
+```php
+$menu->group(__('Logistics'), function (Group $group): void {
+    $group->weight(5); // After CustomerSidebar (weight 4)
+    $group->setAuthorized();
+
+    $group->item(__('Shipping'), function (Item $item): void {
+        $item->weight(1);
+        $item->useSpa();
+        $item->route('shopper.shipping.index');
+        $item->setIcon('untitledui-truck-01');
+    });
+});
+```
+
+### Default Sidebar Groups
+
+| Group     | Weight | Class              |
+|-----------|--------|--------------------|
+| Dashboard | 1      | `DashboardSidebar` |
+| Catalog   | 2      | `CatalogSidebar`   |
+| Sales     | 3      | `SalesSidebar`     |
+| Customers | 4      | `CustomerSidebar`  |
+
+### Item Options
+
+- `$item->weight(int)` - Position (lower = higher)
+- `$item->useSpa()` - Enable `wire:navigate`
+- `$item->route('name')` - Set route
+- `$item->setIcon('untitledui-*')` - Icon
+- `$item->setAuthorized(bool)` - Visibility condition
+
+## Override Components
+
+Config files in `config/shopper/components/`:
+
+```php
+// config/shopper/components/product.php
+return [
+    'pages' => [
+        'product-index' => App\Livewire\Shopper\Products\Index::class,
+        'product-edit' => \Shopper\Livewire\Pages\Product\Edit::class,
+    ],
+    'components' => [
+        'products.form.edit' => App\Livewire\Shopper\Products\EditForm::class,
+    ],
+];
+```
+
+Extend the base component:
+
+```php
+namespace App\Livewire\Shopper\Products;
+
+use Shopper\Livewire\Pages\Product\Index as BaseIndex;
+
+class Index extends BaseIndex
+{
+    public function table(Table $table): Table
+    {
+        return parent::table($table)
+            ->columns([
+                ...parent::table($table)->getColumns(),
+                TextColumn::make('custom_field'),
+            ]);
+    }
+}
+```
+
+## Events
+
+Listen to Shopper events:
+
+```php
+// EventServiceProvider
+protected $listen = [
+    \Shopper\Core\Events\Products\ProductCreated::class => [YourListener::class],
+    \Shopper\Core\Events\Products\ProductUpdated::class => [],
+    \Shopper\Core\Events\Products\ProductDeleted::class => [],
+    \Shopper\Core\Events\Orders\OrderCreated::class => [SendOrderConfirmation::class],
+    \Shopper\Core\Events\Orders\OrderCompleted::class => [],
+    \Shopper\Core\Events\Orders\OrderPaid::class => [],
+    \Shopper\Core\Events\Orders\OrderCancel::class => [],
+];
+```
+
+## Stock Management
+
+```php
+use Shopper\Core\Models\Inventory;
+
+$product = Product::query()->find($id);
+$inventory = Inventory::query()->where('is_default', true)->first();
+
+$product->setStock(100, $inventory->id);
+$product->decreaseStock($inventory->id, 5);
+$currentStock = $product->getStock();
+```
+
+## Pricing
+
+Amounts stored in cents, supports multi-currency:
+
+```php
+use Shopper\Core\Models\Currency;
+
+$product->prices()->create([
+    'currency_id' => Currency::where('code', 'USD')->first()->id,
+    'amount' => 2999,         // $29.99
+    'compare_amount' => 3999, // $39.99 (crossed-out)
+    'cost_amount' => 1500,    // $15.00 (cost)
+]);
+```
+
+## Media Management
+
+```php
+// Add thumbnail
+$product->addMedia($file)
+    ->toMediaCollection(config('shopper.media.storage.thumbnail_collection'));
+
+// Add gallery images
+$product->addMedia($file)
+    ->toMediaCollection(config('shopper.media.storage.collection_name'));
+
+// Get URL
+$thumbnail = $product->getFirstMediaUrl(config('shopper.media.storage.thumbnail_collection'));
+```
+
+## Feature Flags
+
+```php
+if (\Shopper\Feature::enabled('review')) {
+    // Show reviews
+}
+```
+
+Configure in `config/shopper/features.php`.
+
+## Helper Functions
+
+| Function                       | Purpose                             |
+|--------------------------------|-------------------------------------|
+| `shopper_table('products')`    | Prefixed table name (`sh_products`) |
+| `shopper_setting('shop_name')` | Get shop setting                    |
+| `shopper_fallback_url()`       | Fallback image URL                  |
+| `generate_number()`            | Order number with prefix            |
+| `shopper()->auth()->user()`    | Authenticated admin                 |
+
+## Custom Routes
+
+```php
+// config/shopper/routes.php
+return [
+    'custom_file' => base_path('routes/shopper.php'),
+];
+
+// routes/shopper.php
+use App\Livewire\Shopper\Shipping;
+
+Route::get('shipping', Shipping::class)->name('shopper.shipping.index');
+```

--- a/packages/admin/resources/boost/skills/shopper-development/MODELS.md
+++ b/packages/admin/resources/boost/skills/shopper-development/MODELS.md
@@ -1,0 +1,132 @@
+# Swappable Model Pattern
+
+Shopper models can be replaced via `config/shopper/models.php`.
+
+## Resolving Models
+
+```php
+use Shopper\Core\Models\Contracts\Product as ProductContract;
+
+// Via contract (recommended)
+resolve(ProductContract::class)::query()->get();
+
+// Via class (static calls are proxied)
+Product::query()->get();
+Product::find(1);
+```
+
+## Creating a Model
+
+### 1. Contract
+
+`packages/core/src/Models/Contracts/Warehouse.php`:
+
+```php
+interface Warehouse
+{
+    public function isDefault(): bool;
+    public function inventories(): HasMany;
+}
+```
+
+### 2. Model
+
+`packages/core/src/Models/Warehouse.php`:
+
+```php
+/**
+ * @property-read int $id
+ * @property-read string $name
+ * @property-read bool $is_default
+ */
+class Warehouse extends Model implements WarehouseContract
+{
+    use HasFactory;
+    use HasModelContract;
+
+    protected $guarded = [];
+
+    public static function configKey(): string
+    {
+        return 'warehouse';
+    }
+
+    public function getTable(): string
+    {
+        return shopper_table('warehouses');
+    }
+
+    public function isDefault(): bool
+    {
+        return $this->is_default;
+    }
+
+    /**
+     * @return HasMany<Inventory, $this>
+     */
+    public function inventories(): HasMany
+    {
+        return $this->hasMany(config('shopper.models.inventory'), 'warehouse_id');
+    }
+
+    protected function casts(): array
+    {
+        return ['is_default' => 'boolean'];
+    }
+}
+```
+
+### 3. Register
+
+In `packages/core/config/models.php`:
+
+```php
+'warehouse' => Models\Warehouse::class,
+```
+
+## Available Traits
+
+| Trait | Purpose |
+|-------|---------|
+| `HasModelContract` | Enables swapping |
+| `HasSlug` | Unique slugs, `findBySlug()` |
+| `HasPrices` | `prices()`, `getPrice()` |
+| `HasStock` | Inventory tracking |
+| `HasDimensions` | weight, height, width, depth, volume |
+| `HasMedia` | Spatie Media Library |
+| `HasDiscounts` | `discounts()` |
+| `HasZones` | `zones()` polymorphic |
+| `InteractsWithReviews` | `reviews()` |
+
+## Relationships
+
+Always use `config()` for related models:
+
+```php
+public function brand(): BelongsTo
+{
+    return $this->belongsTo(config('shopper.models.brand'), 'brand_id');
+}
+```
+
+## Extending Models
+
+```php
+namespace App\Models;
+
+use Shopper\Core\Models\Product as ShopperProduct;
+
+class Product extends ShopperProduct
+{
+    public function isPublished(): bool
+    {
+        return parent::isPublished() && $this->custom_condition;
+    }
+}
+```
+
+Then in `config/shopper/models.php`:
+
+```php
+'product' => App\Models\Product::class,
+```

--- a/packages/admin/resources/boost/skills/shopper-development/SKILL.md
+++ b/packages/admin/resources/boost/skills/shopper-development/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: developing-shopper
+description: Provides coding standards and patterns for Laravel Shopper development. Use when creating or modifying Models, Actions, Enums, Livewire components, migrations, or tests in any Shopper package.
+---
+
+# Developing Shopper
+
+## Monorepo Structure
+
+| Package             | Namespace           | Purpose                            |
+|---------------------|---------------------|------------------------------------|
+| `packages/admin`    | `Shopper\`          | Livewire components, views, routes |
+| `packages/core`     | `Shopper\Core\`     | Models, Actions, Enums, Contracts  |
+| `packages/sidebar`  | `Shopper\Sidebar\`  | Sidebar navigation                 |
+| `packages/shipping` | `Shopper\Shipping\` | Shipping providers                 |
+
+## Required in Every PHP File
+
+```php
+<?php
+
+declare(strict_types=1);
+```
+
+## Class Element Order
+
+1. Traits → 2. Cases → 3. Constants → 4. Properties → 5. Constructor → 6. Magic methods → 7. Methods (public → protected → private)
+
+## Models
+
+See [MODELS.md](MODELS.md) for the swappable model pattern.
+
+```php
+class Product extends Model implements ProductContract
+{
+    use HasFactory;
+    use HasModelContract;
+    use HasSlug;
+
+    protected $guarded = [];
+
+    public static function configKey(): string
+    {
+        return 'product';
+    }
+
+    public function getTable(): string
+    {
+        return shopper_table('products');
+    }
+
+    protected function casts(): array
+    {
+        return ['featured' => 'boolean'];
+    }
+}
+```
+
+## Actions
+
+```php
+final class CreateOrderAction
+{
+    public function execute(array $data): Order
+    {
+        // Single responsibility
+    }
+}
+```
+
+## Enums
+
+```php
+enum OrderStatus: string implements HasColor, HasIcon, HasLabel
+{
+    use ArrayableEnum;
+    use HasEnumStaticMethods;
+
+    case Pending = 'pending';
+
+    public function getLabel(): string
+    {
+        return __('shopper-core::enum/order.pending');
+    }
+}
+```
+
+## Livewire Components
+
+```php
+class ProductForm extends Component implements HasActions, HasForms
+{
+    use InteractsWithActions;
+    use InteractsWithForms;
+
+    public ?array $data = [];
+
+    #[Computed]
+    public function categories(): Collection
+    {
+        return resolve(CategoryContract::class)::query()->get();
+    }
+
+    public function render(): View
+    {
+        return view('shopper::livewire.product-form');
+    }
+}
+```
+
+## Migrations
+
+```php
+return new class extends \Shopper\Core\Helpers\Migration
+{
+    public function up(): void
+    {
+        Schema::create($this->getTableName('products'), function (Blueprint $table): void {
+            $this->addCommonFields($table, hasSoftDelete: true);
+            $this->addSeoFields($table);
+            $this->addShippingFields($table);
+            $this->addForeignKey($table, 'brand_id', $this->getTableName('brands'));
+        });
+    }
+};
+```
+
+## Testing
+
+```php
+beforeEach(function (): void {
+    $this->user = User::factory()->create();
+});
+
+it('creates a product', function (): void {
+    $this->actingAs($this->user);
+
+    Livewire::test(ProductForm::class)
+        ->set('data.name', 'Test')
+        ->call('save')
+        ->assertHasNoErrors();
+})->group('products');
+```
+
+## Commands
+
+```bash
+composer test:sqlite   # Run tests
+composer test:types    # PHPStan
+composer cs            # Rector + Pint + Prettier
+```

--- a/packages/admin/resources/boost/skills/shopper-livewire/SKILL.md
+++ b/packages/admin/resources/boost/skills/shopper-livewire/SKILL.md
@@ -1,0 +1,216 @@
+---
+name: shopper-livewire
+description: Provides patterns for building Livewire components in Laravel Shopper with Filament Forms, Tables, and Actions. Use when creating Pages, SlideOvers, or reusable components.
+---
+
+# Shopper Livewire Components
+
+## Component Types
+
+| Type      | Base Class              | Location               |
+|-----------|-------------------------|------------------------|
+| Page      | `AbstractPageComponent` | `Livewire/Pages/`      |
+| SlideOver | `SlideOverComponent`    | `Livewire/SlideOvers/` |
+| Component | `Component`             | `Livewire/Components/` |
+
+## Page with Table
+
+```php
+class Index extends AbstractPageComponent implements HasActions, HasForms, HasTable
+{
+    use InteractsWithActions;
+    use InteractsWithForms;
+    use InteractsWithTable;
+
+    public function mount(): void
+    {
+        $this->authorize('browse_brands');
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->query(resolve(BrandContract::class)::query()->latest())
+            ->columns([
+                TextColumn::make('name')
+                    ->label(__('shopper::forms.label.name'))
+                    ->searchable()
+                    ->sortable(),
+            ])
+            ->recordActions([
+                Action::make('edit')
+                    ->icon(Untitledui::Edit03)
+                    ->iconButton()
+                    ->action(fn ($record) => $this->dispatch(
+                        'openPanel',
+                        component: 'shopper-slide-overs.brand-form',
+                        arguments: ['brand' => $record]
+                    )),
+            ]);
+    }
+
+    public function render(): View
+    {
+        return view('shopper::livewire.pages.brand.index')
+            ->title(__('shopper::pages/brands.menu'));
+    }
+}
+```
+
+## Blade View Structure
+
+```blade
+<x-shopper::container>
+    {{-- Breadcrumb --}}
+    <x-shopper::breadcrumb :back="route('shopper.settings.index')" :current="__('Shipping')">
+        <x-untitledui-chevron-left class="size-4 shrink-0 text-gray-300 dark:text-gray-600" />
+        <x-shopper::breadcrumb.link
+            :link="route('shopper.settings.index')"
+            :title="__('Settings')"
+        />
+    </x-shopper::breadcrumb>
+
+    {{-- Page Heading --}}
+    <x-shopper::heading class="my-6" :title="__('Shipping Methods')">
+        <x-slot name="action">
+            <x-filament::button wire:click="create">
+                {{ __('Add Method') }}
+            </x-filament::button>
+        </x-slot>
+    </x-shopper::heading>
+
+    {{-- Content --}}
+    <x-shopper::card class="mt-5">
+        {{ $this->table }}
+    </x-shopper::card>
+</x-shopper::container>
+```
+
+## Blade Components
+
+| Component                        | Purpose                              |
+|----------------------------------|--------------------------------------|
+| `<x-shopper::container>`         | Main content wrapper                 |
+| `<x-shopper::card>`              | Card wrapper                         |
+| `<x-shopper::heading :title="">` | Page title with optional action slot |
+| `<x-shopper::breadcrumb>`        | Navigation breadcrumb                |
+| `<x-shopper::separator>`         | Section separator                    |
+| `<x-shopper::empty-card>`        | Empty state                          |
+| `<x-filament::button>`           | Primary button                       |
+
+## SlideOver with Form
+
+```php
+/**
+ * @property-read Schema $form
+ */
+class BrandForm extends SlideOverComponent implements HasActions, HasForms
+{
+    use InteractsWithActions;
+    use InteractsWithForms;
+
+    public Brand $brand;
+    public ?array $data = [];
+
+    public function mount(?Brand $brand = null): void
+    {
+        $this->brand = $brand ?? resolve(Brand::class)::query()->newModelInstance();
+        $this->form->fill($this->brand->toArray());
+    }
+
+    public function form(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                Section::make(__('shopper::words.general'))
+                    ->collapsible()
+                    ->compact()
+                    ->schema([
+                        TextInput::make('name')
+                            ->label(__('shopper::forms.label.name'))
+                            ->required()
+                            ->live(onBlur: true)
+                            ->afterStateUpdated(fn ($state, Set $set) => $set('slug', Str::slug($state))),
+                        Hidden::make('slug'),
+                    ]),
+            ])
+            ->statePath('data')
+            ->model($this->brand);
+    }
+
+    public function save(): void
+    {
+        if ($this->brand->id) {
+            $this->authorize('edit_brands', $this->brand);
+            $this->brand->update($this->form->getState());
+        } else {
+            $this->authorize('add_brands');
+            $brand = resolve(Brand::class)::query()->create($this->form->getState());
+            $this->form->model($brand)->saveRelationships();
+        }
+
+        Notification::make()
+            ->title(__('shopper::notifications.save', ['item' => __('shopper::pages/brands.single')]))
+            ->success()
+            ->send();
+
+        $this->redirectRoute('shopper.brands.index', navigate: true);
+    }
+
+    public function render(): View
+    {
+        return view('shopper::livewire.slide-overs.brand-form');
+    }
+}
+```
+
+## SlideOver Operations
+
+```php
+// Open
+$this->dispatch(
+    'openPanel',
+    component: 'shopper-slide-overs.brand-form',
+    arguments: ['brand' => $record]
+);
+
+// Close
+$this->closePanel();
+
+// Close with events
+$this->closePanelWithEvents(['refresh']);
+```
+
+## SlideOver Configuration
+
+```php
+public static function panelMaxWidth(): string
+{
+    return '2xl'; // sm, md, lg, xl, 2xl, 3xl, 4xl, 5xl, 6xl, 7xl
+}
+
+public static function closePanelOnClickAway(): bool
+{
+    return false;
+}
+```
+
+## Computed Properties
+
+```php
+#[Computed]
+public function categories(): Collection
+{
+    return resolve(CategoryContract::class)::query()->get();
+}
+```
+
+## Authorization
+
+```php
+// In mount
+$this->authorize('browse_brands');
+
+// In table actions
+->visible(Shopper::auth()->user()->can('edit_brands'))
+```


### PR DESCRIPTION
Add three skills for Laravel Boost integration:
- shopper-development: coding standards, class patterns, models
- shopper-livewire: Pages, SlideOvers, Blade components, breadcrumbs
- extending-shopper: sidebar, overrides, events, stock, pricing, media