### PR TITLE
patch: fix settings nav active state and rename canceled_at column

### DIFF
--- a/packages/admin/resources/views/components/layouts/setting.blade.php
+++ b/packages/admin/resources/views/components/layouts/setting.blade.php
@@ -61,7 +61,7 @@
                     id="setting-tabs"
                 >
                     @foreach (resolve(\Shopper\Settings\SettingManager::class)->all() as $menu)
-                        <x-shopper::menu.nav-setting :menu="$menu" />
+                        <x-shopper::menu.nav-setting :$menu />
                     @endforeach
                 </nav>
                 <div

--- a/packages/admin/resources/views/components/menu/nav-setting.blade.php
+++ b/packages/admin/resources/views/components/menu/nav-setting.blade.php
@@ -4,7 +4,7 @@
 
 @php
     $url = $menu->url();
-    $isCurrent = $url && str_starts_with(request()->url(), $url);
+    $isCurrent = $url && request()->is(trim(parse_url($url, PHP_URL_PATH), '/') . '*');
 @endphp
 
 <a

--- a/packages/admin/src/Livewire/Pages/Order/Detail.php
+++ b/packages/admin/src/Livewire/Pages/Order/Detail.php
@@ -91,7 +91,7 @@ class Detail extends AbstractPageComponent implements HasActions, HasSchemas
             ->action(function (): void {
                 $this->order->update([
                     'status' => OrderStatus::Cancelled,
-                    'canceled_at' => now(),
+                    'cancelled_at' => now(),
                 ]);
 
                 event(new OrderCancel($this->order));

--- a/packages/core/database/migrations/2026_01_30_095257_rename_canceled_at_to_cancelled_at_on_orders_table.php
+++ b/packages/core/database/migrations/2026_01_30_095257_rename_canceled_at_to_cancelled_at_on_orders_table.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Shopper\Core\Helpers\Migration;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table($this->getTableName('orders'), static function (Blueprint $table): void {
+            $table->renameColumn('canceled_at', 'cancelled_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table($this->getTableName('orders'), static function (Blueprint $table): void {
+            $table->renameColumn('cancelled_at', 'canceled_at');
+        });
+    }
+};

--- a/packages/core/src/Models/Order.php
+++ b/packages/core/src/Models/Order.php
@@ -34,7 +34,7 @@ use Shopper\Core\Traits\HasModelContract;
  * @property-read ?int $customer_id
  * @property-read ?int $channel_id
  * @property-read ?int $parent_order_id
- * @property-read ?CarbonInterface $canceled_at
+ * @property-read ?CarbonInterface $cancelled_at
  * @property-read ?CarbonInterface $archived_at
  * @property-read OrderStatus $status
  * @property-read CarrierOption $shippingOption
@@ -253,7 +253,7 @@ class Order extends Model implements OrderContract
     {
         return [
             'status' => OrderStatus::class,
-            'canceled_at' => 'datetime',
+            'cancelled_at' => 'datetime',
             'archived_at' => 'datetime',
         ];
     }

--- a/packages/types/src/order.ts
+++ b/packages/types/src/order.ts
@@ -48,7 +48,7 @@ export interface Order extends Entity {
   /** The order status. */
   status: OrderStatus
   /** The date the order was cancelled. */
-  canceled_at: DateEntity | null
+  cancelled_at: DateEntity | null
   /** The date the order was archived. */
   archived_at: DateEntity | null
   /** The zone ID. */


### PR DESCRIPTION
- Fix settings navigation active state not working in production by using request()->is()
- Rename canceled_at to cancelled_at on orders table for consistency with British spelling used throughout the codebase (Cancelled enum, methods, etc.)