### PR TITLE
fix: collection price rules query prices table

### DIFF
--- a/packages/admin/resources/lang/en/forms.php
+++ b/packages/admin/resources/lang/en/forms.php
@@ -13,6 +13,7 @@ return [
         'change' => 'Change',
         'optional' => 'Optional',
         'summary' => 'Summary',
+        'featured' => 'Featured',
         'description' => 'Description',
         'title' => 'Title',
         'confirm' => 'Confirm',

--- a/packages/admin/resources/lang/en/pages/products.php
+++ b/packages/admin/resources/lang/en/pages/products.php
@@ -24,6 +24,7 @@ return [
     'product_shipped_help_text' => 'Reassure to fill in the information concerning the shipment of the product.',
     'general' => 'Product information',
     'status' => 'Product availability',
+    'featured_help_text' => 'This product will be marked as featured.',
     'visible_help_text' => 'This product will be hidden from all sales channels.',
     'availability_description' => 'Specify a publication date so that your product are scheduled on your store.',
     'type' => 'Product type',

--- a/packages/admin/resources/lang/fr/forms.php
+++ b/packages/admin/resources/lang/fr/forms.php
@@ -13,6 +13,7 @@ return [
         'change' => 'Changer',
         'optional' => 'Optionnel',
         'summary' => 'Résumé',
+        'featured' => 'En vedette',
         'description' => 'Description',
         'title' => 'Titre',
         'confirm' => 'Confirmer',

--- a/packages/admin/resources/lang/fr/pages/products.php
+++ b/packages/admin/resources/lang/fr/pages/products.php
@@ -24,6 +24,7 @@ return [
     'product_shipped_help_text' => 'Renseignez les informations concernant l\'expédition du produit.',
     'general' => 'Information générale du produit',
     'status' => 'Disponibilité du produit',
+    'featured_help_text' => 'Ce produit sera marqué comme étant en vedette.',
     'visible_help_text' => 'Ce produit sera caché de tous les canaux de vente.',
     'availability_description' => 'Spécifiez une date de publication pour que vos produits soient programmés sur votre boutique.',
     'type' => 'Type de product',

--- a/packages/admin/src/Livewire/Components/Products/Form/Edit.php
+++ b/packages/admin/src/Livewire/Components/Products/Form/Edit.php
@@ -85,6 +85,11 @@ class Edit extends Component implements HasActions, HasSchemas
                                 Textarea::make('summary')
                                     ->label(__('shopper::forms.label.summary'))
                                     ->columnSpan('full'),
+                                Toggle::make('featured')
+                                    ->label(__('shopper::forms.label.featured'))
+                                    ->helperText(__('shopper::pages/products.featured_help_text'))
+                                    ->onColor('success')
+                                    ->default(true),
                                 RichEditor::make('description')
                                     ->label(__('shopper::forms.label.description'))
                                     ->columnSpan('full'),

--- a/packages/core/src/Models/Contracts/Product.php
+++ b/packages/core/src/Models/Contracts/Product.php
@@ -7,6 +7,7 @@ namespace Shopper\Core\Models\Contracts;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 
 interface Product extends Stockable
@@ -42,4 +43,6 @@ interface Product extends Stockable
     public function brand(): BelongsTo;
 
     public function options(): BelongsToMany;
+
+    public function prices(): MorphMany;
 }

--- a/packages/core/src/Queries/CollectionProductsQuery.php
+++ b/packages/core/src/Queries/CollectionProductsQuery.php
@@ -103,8 +103,8 @@ final class CollectionProductsQuery
     {
         match ($rule->rule) {
             Rule::ProductTitle => $this->applyStringRule($query, 'name', $rule),
-            Rule::ProductPrice => $this->applyNumericRule($query, 'price_amount', $rule),
-            Rule::CompareAtPrice => $this->applyNumericRule($query, 'old_price_amount', $rule),
+            Rule::ProductPrice => $this->applyPriceRule($query, 'amount', $rule),
+            Rule::CompareAtPrice => $this->applyPriceRule($query, 'compare_amount', $rule),
             Rule::InventoryStock => $this->applyStockRule($query, $rule),
             Rule::ProductBrand => $this->applyBrandRule($query, $rule),
             Rule::ProductCategory => $this->applyCategoryRule($query, $rule),
@@ -134,7 +134,7 @@ final class CollectionProductsQuery
     /**
      * @param  Builder<Product>  $query
      */
-    private function applyNumericRule(Builder $query, string $column, CollectionRule $rule): void
+    private function applyPriceRule(Builder $query, string $column, CollectionRule $rule): void
     {
         $operator = match ($rule->operator) {
             Operator::NotEqualTo => '!=',
@@ -143,7 +143,9 @@ final class CollectionProductsQuery
             default => '=',
         };
 
-        $query->where($column, $operator, (int) $rule->value);
+        $query->whereHas('prices', function (Builder $subQuery) use ($column, $operator, $rule): void {
+            $subQuery->where($column, $operator, (int) $rule->value);
+        });
     }
 
     /**


### PR DESCRIPTION
## Summary                                                                                                             

- Fix price-based collection rules (`ProductPrice`, `CompareAtPrice`) to query through the prices polymorphic relation instead of directly on the products table, since price columns no longer exist on the product model
- Add the `prices()` method to the Product contract to support the polymorphic relation
- Add a "Featured" toggle field on the product edit form with translations (EN/FR)