### PR TITLE
feat: add render hooks, fluent asset API, and brandLogo to ShopperPanel

### DIFF
--- a/packages/admin/resources/views/components/brand.blade.php
+++ b/packages/admin/resources/views/components/brand.blade.php
@@ -1,5 +1,7 @@
-@if (filled($brand = config('shopper.admin.brand')))
-    <img {{ $attributes }} src="{{ asset($brand) }}" alt="{{ config('app.name') }}" />
+@if ($brandLogo = shopper()->getBrandLogo())
+    {!! $brandLogo !!}
+@elseif (filled($brandPath = config('shopper.admin.brand')))
+    <img {{ $attributes }} src="{{ asset($brandPath) }}" alt="{{ config('app.name') }}" />
 @else
     <img
         {{ $attributes }}

--- a/packages/admin/resources/views/components/layouts/app.blade.php
+++ b/packages/admin/resources/views/components/layouts/app.blade.php
@@ -21,9 +21,13 @@
                 @endisset
 
                 <main class="sh-main flex-1">
+                    {{ shopper()->getRenderHook(\Shopper\Enum\RenderHook::ContentStart) }}
+
                     <div {{ $attributes->twMerge(['class' => 'flex-1 min-h-full']) }}>
                         {{ $slot }}
                     </div>
+
+                    {{ shopper()->getRenderHook(\Shopper\Enum\RenderHook::ContentEnd) }}
                 </main>
             </div>
         </div>

--- a/packages/admin/resources/views/components/layouts/base.blade.php
+++ b/packages/admin/resources/views/components/layouts/base.blade.php
@@ -30,6 +30,8 @@
             rel="stylesheet"
         />
 
+        {{ shopper()->getRenderHook(\Shopper\Enum\RenderHook::HeadStart) }}
+
         @filamentStyles
         {{ \Shopper\Facades\Shopper::getThemeLink() }}
 
@@ -44,6 +46,8 @@
         ></script>
 
         @include('shopper::includes._additional-styles')
+
+        {{ shopper()->getRenderHook(\Shopper\Enum\RenderHook::HeadEnd) }}
 
         <style>
             :root {
@@ -74,6 +78,8 @@
         data-sidebar-breakpoint="{{ \Shopper\Sidebar\sidebar_breakpoint() }}"
         data-sidebar-collapsible="{{ \Shopper\Sidebar\sidebar_is_collapsible() ? 'true' : 'false' }}"
     >
+        {{ shopper()->getRenderHook(\Shopper\Enum\RenderHook::BodyStart) }}
+
         {{ $slot }}
 
         @livewire(\Filament\Notifications\Livewire\Notifications::class)
@@ -82,5 +88,7 @@
         @filamentScripts
 
         @include('shopper::includes._additional-scripts')
+
+        {{ shopper()->getRenderHook(\Shopper\Enum\RenderHook::BodyEnd) }}
     </body>
 </html>

--- a/packages/admin/resources/views/includes/_additional-scripts.blade.php
+++ b/packages/admin/resources/views/includes/_additional-scripts.blade.php
@@ -1,6 +1,6 @@
-@if (filled(config('shopper.admin.resources.scripts')))
+@if (filled(shopper()->getScripts()))
     <!-- Additional Javascript -->
-    @foreach (config('shopper.admin.resources.scripts') as $js)
+    @foreach (shopper()->getScripts() as $js)
         @if (\Illuminate\Support\Str::of($js)->startsWith(['http://', 'https://']))
             <script type="text/javascript" src="{!! $js !!}"></script>
         @else

--- a/packages/admin/resources/views/includes/_additional-styles.blade.php
+++ b/packages/admin/resources/views/includes/_additional-styles.blade.php
@@ -1,6 +1,6 @@
-@if (filled(config('shopper.admin.resources.stylesheets')))
+@if (filled(shopper()->getStyles()))
     <!-- Additional CSS -->
-    @foreach (config('shopper.admin.resources.stylesheets') as $css)
+    @foreach (shopper()->getStyles() as $css)
         @if (\Illuminate\Support\Str::of($css)->startsWith(['http://', 'https://']))
             <link rel="stylesheet" type="text/css" href="{!! $css !!}" />
         @else

--- a/packages/admin/src/Enum/RenderHook.php
+++ b/packages/admin/src/Enum/RenderHook.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Enum;
+
+enum RenderHook: string
+{
+    case HeadStart = 'head.start';
+
+    case HeadEnd = 'head.end';
+
+    case BodyStart = 'body.start';
+
+    case BodyEnd = 'body.end';
+
+    case ContentStart = 'content.start';
+
+    case ContentEnd = 'content.end';
+}

--- a/packages/admin/src/Facades/Shopper.php
+++ b/packages/admin/src/Facades/Shopper.php
@@ -8,18 +8,26 @@ use Closure;
 use Illuminate\Contracts\Auth\StatefulGuard;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Facades\Facade;
+use Shopper\Enum\RenderHook;
 use Shopper\ShopperPanel;
 
 /**
  * @method static StatefulGuard auth()
  * @method static string prefix()
  * @method static Htmlable getThemeLink()
- * @method static void registerScripts(array $scripts)
- * @method static void registerStyles(array $styles)
- * @method static void registerTheme(string | Htmlable | null $theme)
- * @method static void registerViteTheme(string | array $theme, string | null $buildDirectory = null)
+ * @method static ShopperPanel registerTheme(string | Htmlable | null $theme)
+ * @method static ShopperPanel registerViteTheme(string | array $theme, string | null $buildDirectory = null)
+ * @method static ShopperPanel brandLogo(string | Closure $brandLogo)
+ * @method static Htmlable|null getBrandLogo()
+ * @method static ShopperPanel renderHook(RenderHook $hook, Closure $callback)
+ * @method static Htmlable getRenderHook(RenderHook $hook)
+ * @method static ShopperPanel styles(array $styles)
+ * @method static ShopperPanel scripts(array $scripts)
+ * @method static array getStyles()
+ * @method static array getScripts()
  * @method static void serving(Closure $callback)
  * @method static void setServingStatus(bool $condition = true)
+ * @method static bool isServing()
  * @method static string version()
  *
  * @see ShopperPanel

--- a/packages/admin/src/ShopperPanel.php
+++ b/packages/admin/src/ShopperPanel.php
@@ -12,6 +12,7 @@ use Illuminate\Foundation\Vite;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\Str;
+use Shopper\Enum\RenderHook;
 use Shopper\Events\LoadShopper;
 
 final class ShopperPanel
@@ -19,6 +20,18 @@ final class ShopperPanel
     private bool $isServing = false;
 
     private string|Htmlable|null $theme = null;
+
+    /** @var string|Closure(): (Htmlable|string)|null */
+    private string|Closure|null $brandLogo = null;
+
+    /** @var array<string, list<Closure(): string>> */
+    private array $renderHooks = [];
+
+    /** @var list<string> */
+    private array $styles = [];
+
+    /** @var list<string> */
+    private array $scripts = [];
 
     public function auth(): StatefulGuard
     {
@@ -31,9 +44,11 @@ final class ShopperPanel
         return config('shopper.admin.prefix');
     }
 
-    public function registerTheme(string|Htmlable|null $theme): void
+    public function registerTheme(string|Htmlable|null $theme): self
     {
         $this->theme = $theme;
+
+        return $this;
     }
 
     /**
@@ -41,9 +56,11 @@ final class ShopperPanel
      *
      * @throws Exception
      */
-    public function registerViteTheme(string|array $theme, ?string $buildDirectory = null): void
+    public function registerViteTheme(string|array $theme, ?string $buildDirectory = null): self
     {
         $this->theme = app(Vite::class)($theme, $buildDirectory);
+
+        return $this;
     }
 
     public function getThemeLink(): Htmlable
@@ -58,6 +75,93 @@ final class ShopperPanel
         ]);
 
         return new HtmlString("<link rel=\"stylesheet\" href=\"{$url}\" />");
+    }
+
+    /**
+     * @param  string|Closure(): (Htmlable|string)  $brandLogo
+     */
+    public function brandLogo(string|Closure $brandLogo): self
+    {
+        $this->brandLogo = $brandLogo;
+
+        return $this;
+    }
+
+    public function getBrandLogo(): ?Htmlable
+    {
+        if ($this->brandLogo instanceof Closure) {
+            $result = ($this->brandLogo)();
+
+            if (is_string($result)) {
+                return new HtmlString($result);
+            }
+
+            return $result;
+        }
+
+        if (is_string($this->brandLogo)) {
+            return new HtmlString($this->brandLogo);
+        }
+
+        return null;
+    }
+
+    public function renderHook(RenderHook $hook, Closure $callback): self
+    {
+        $this->renderHooks[$hook->value][] = $callback;
+
+        return $this;
+    }
+
+    public function getRenderHook(RenderHook $hook): Htmlable
+    {
+        $output = collect($this->renderHooks[$hook->value] ?? [])
+            ->map(fn (Closure $callback): string => $callback())
+            ->implode('');
+
+        return new HtmlString($output);
+    }
+
+    /**
+     * @param  list<string>  $styles
+     */
+    public function styles(array $styles): self
+    {
+        $this->styles = array_merge($this->styles, $styles);
+
+        return $this;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getStyles(): array
+    {
+        return array_merge(
+            config('shopper.admin.resources.stylesheets', []),
+            $this->styles,
+        );
+    }
+
+    /**
+     * @param  list<string>  $scripts
+     */
+    public function scripts(array $scripts): self
+    {
+        $this->scripts = array_merge($this->scripts, $scripts);
+
+        return $this;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getScripts(): array
+    {
+        return array_merge(
+            config('shopper.admin.resources.scripts', []),
+            $this->scripts,
+        );
     }
 
     public function setServingStatus(bool $condition = true): void


### PR DESCRIPTION
Allow developers to extend the admin panel layout without overriding views.
Render hooks enable injecting Blade content at specific positions (head, body, content) for third-party packages like Flux UI, Wire Elements Modal, etc.
The fluent API on ShopperPanel now supports chaining for theme, brand logo, styles, scripts, and render hooks registration directly from service providers.