### PR TITLE
fix: lazy-evaluate Vite theme to prevent manifest errors at boot time

### DIFF
--- a/packages/admin/src/ShopperPanel.php
+++ b/packages/admin/src/ShopperPanel.php
@@ -21,6 +21,9 @@ final class ShopperPanel
 
     private string|Htmlable|null $theme = null;
 
+    /** @var array{path: string|array<string, mixed>, buildDirectory: string|null}|null */
+    private ?array $viteTheme = null;
+
     /** @var string|Closure(): (Htmlable|string)|null */
     private string|Closure|null $brandLogo = null;
 
@@ -53,18 +56,20 @@ final class ShopperPanel
 
     /**
      * @param  string|array<string, mixed>  $theme
-     *
-     * @throws Exception
      */
     public function registerViteTheme(string|array $theme, ?string $buildDirectory = null): self
     {
-        $this->theme = app(Vite::class)($theme, $buildDirectory);
+        $this->viteTheme = ['path' => $theme, 'buildDirectory' => $buildDirectory];
 
         return $this;
     }
 
     public function getThemeLink(): Htmlable
     {
+        if ($this->viteTheme !== null) {
+            return app(Vite::class)($this->viteTheme['path'], $this->viteTheme['buildDirectory']);
+        }
+
         if (Str::of($this->theme)->contains('<link')) {
             return $this->theme instanceof Htmlable ? $this->theme : new HtmlString($this->theme);
         }

--- a/packages/admin/src/ShopperPanel.php
+++ b/packages/admin/src/ShopperPanel.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Shopper;
 
 use Closure;
-use Exception;
 use Illuminate\Contracts\Auth\StatefulGuard;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Foundation\Vite;


### PR DESCRIPTION
registerViteTheme() now stores the arguments instead of immediately resolving the Vite helper. The resolution happens in getThemeLink() at render time, preventing errors during artisan commands or composer operations when the Vite manifest doesn't exist yet.