### PR TITLE
fix: update bacon/bacon-qr-code version constraint to support 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "ext-intl": "*"
   },
   "require-dev": {
-    "bacon/bacon-qr-code": "^2.0",
+    "bacon/bacon-qr-code": "^2.0|^3.0",
     "blade-ui-kit/blade-heroicons": "^2.6",
     "codeat3/blade-phosphor-icons": "^2.3",
     "codewithdennis/filament-select-tree": "^4.0",


### PR DESCRIPTION
This pull request makes a minor update to the development dependencies in `composer.json`, expanding the allowed versions for the `bacon/bacon-qr-code` package to include both `^2.0` and `^3.0`. This ensures compatibility with newer versions of the package.