### PR TITLE
fix: allow passing user_id in stock mutation arguments

### DIFF
--- a/packages/core/src/Models/Traits/HasStock.php
+++ b/packages/core/src/Models/Traits/HasStock.php
@@ -96,8 +96,6 @@ trait HasStock
      */
     public function createStockMutation(int $quantity, int $inventoryId, array $arguments = []): InventoryHistory
     {
-        /** @var int $authId */
-        $authId = Auth::id();
         $reference = Arr::get($arguments, 'reference');
 
         $createArguments = collect([
@@ -106,7 +104,7 @@ trait HasStock
             'description' => Arr::get($arguments, 'description'),
             'event' => Arr::get($arguments, 'event'),
             'inventory_id' => $inventoryId,
-            'user_id' => $authId,
+            'user_id' => Arr::get($arguments, 'user_id', Auth::id()),
         ])->when($reference, fn ($collection) => $collection
             ->put('reference_type', $reference->getMorphClass())
             ->put('reference_id', $reference->getKey()))


### PR DESCRIPTION
## Summary

The `createStockMutation` method in the `HasStock` trait hardcodes `Auth::id()` as the `user_id` for inventory history entries. This makes it impossible to create stock mutations from contexts where no user is authenticated, such as API integrations, queued jobs, or console commands.

This PR allows passing an optional `user_id` key in the `$arguments` array, falling back to `Auth::id()` when not provided. This is a non-breaking change — existing code continues to work without modification.

## Changes

- `HasStock::createStockMutation()` now reads `user_id` from `$arguments` with `Auth::id()` as default

### Before

```php
  $product->mutateStock($inventoryId, 10, [
      'event' => 'Restock',
  ]);
  // Fails with "Column 'user_id' cannot be null" if no authenticated user
```

### After

```php
  $product->mutateStock($inventoryId, 10, [
      'event' => 'Restock',
      'user_id' => $userId, // optional, falls back to Auth::id()
  ]);
```