### PR TITLE
feat: optimize stock queries to prevent N+1 when iterating over stockable collections

### DIFF
--- a/packages/core/src/Exceptions/LazyStockLoadingException.php
+++ b/packages/core/src/Exceptions/LazyStockLoadingException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Core\Exceptions;
+
+use RuntimeException;
+
+final class LazyStockLoadingException extends RuntimeException
+{
+    public function __construct(string $model)
+    {
+        parent::__construct(
+            "Attempted to lazy load stock on model [{$model}] but lazy stock loading is disabled. "
+            ."Use [{$model}::loadCurrentStock(\$collection)] to batch-load stock before accessing \$model->stock."
+        );
+    }
+}

--- a/packages/core/src/Models/Traits/HasStock.php
+++ b/packages/core/src/Models/Traits/HasStock.php
@@ -6,14 +6,78 @@ namespace Shopper\Core\Models\Traits;
 
 use DateTimeInterface;
 use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Auth;
+use Shopper\Core\Exceptions\LazyStockLoadingException;
 use Shopper\Core\Models\InventoryHistory;
 
 trait HasStock
 {
+    protected static bool $preventLazyStockLoading = false;
+
+    public static function preventLazyStockLoading(bool $prevent = true): void
+    {
+        static::$preventLazyStockLoading = $prevent;
+    }
+
+    /**
+     * Batch-load current stock for a collection of stockable models in a single query,
+     * avoiding N+1 when iterating over products or variants.
+     *
+     * @param  Collection<int, Model>  $models
+     */
+    public static function loadCurrentStock(Collection $models): void
+    {
+        if ($models->isEmpty()) {
+            return;
+        }
+
+        $first = $models->first();
+
+        $stocks = InventoryHistory::query()
+            ->selectRaw('stockable_id, SUM(quantity) as aggregate')
+            ->where('stockable_type', $first->getMorphClass())
+            ->whereIn('stockable_id', $models->pluck($first->getKeyName()))
+            ->where('created_at', '<=', Carbon::now())
+            ->groupBy('stockable_id')
+            ->pluck('aggregate', 'stockable_id');
+
+        $models->each(function (Model $model) use ($stocks): void {
+            $model->setAttribute('real_stock', (int) ($stocks[$model->getKey()] ?? 0));
+        });
+    }
+
+    /**
+     * Batch-load stock for a specific inventory location.
+     *
+     * @param  Collection<int, Model>  $models
+     */
+    public static function loadStockForInventory(Collection $models, int $inventoryId): void
+    {
+        if ($models->isEmpty()) {
+            return;
+        }
+
+        $first = $models->first();
+
+        $stocks = InventoryHistory::query()
+            ->selectRaw('stockable_id, SUM(quantity) as aggregate')
+            ->where('stockable_type', $first->getMorphClass())
+            ->whereIn('stockable_id', $models->pluck($first->getKeyName()))
+            ->where('inventory_id', $inventoryId)
+            ->where('created_at', '<=', Carbon::now())
+            ->groupBy('stockable_id')
+            ->pluck('aggregate', 'stockable_id');
+
+        $models->each(function (Model $model) use ($stocks): void {
+            $model->setAttribute('real_stock', (int) ($stocks[$model->getKey()] ?? 0));
+        });
+    }
+
     public function inStock(int $quantity = 1): bool
     {
         return $this->stock > 0 && $this->stock >= $quantity;
@@ -124,7 +188,17 @@ trait HasStock
     protected function stock(): Attribute
     {
         return Attribute::make(
-            get: fn (): int => $this->getStock(),
+            get: function (): int {
+                if (array_key_exists('real_stock', $this->attributes)) {
+                    return (int) $this->attributes['real_stock'];
+                }
+
+                if (static::$preventLazyStockLoading) {
+                    throw new LazyStockLoadingException(static::class);
+                }
+
+                return $this->getStock();
+            },
         );
     }
 }


### PR DESCRIPTION
## Problem

Accessing `$model->stock` on any model using the `HasStock` trait triggers an individual `SUM(quantity)` query on `sh_inventory_histories` for each model instance. When iterating over a collection (e.g. displaying 28 product variants on a single product page), this results in 28 identical queries where only the `stockable_id` changes.

## Solution

- Add `loadCurrentStock(Collection $models)` static method to batch-load stock for an entire collection in a single `GROUP BY` query
- Add `loadStockForInventory(Collection $models, int $inventoryId)` for batch-loading stock per inventory location
- Update the `stock` accessor to use the preloaded value when available
- Add `preventLazyStockLoading()` following the same pattern as Laravel's `Model::preventLazyLoading()`, allowing developers to catch unoptimized stock access during development

## Usage

```php
// Batch-load stock (1 query instead of N)
ProductVariant::loadCurrentStock($product->variants);

// Per inventory location
ProductVariant::loadStockForInventory($product->variants, $inventoryId);

// Catch lazy stock loading in development
ProductVariant::preventLazyStockLoading(! app()->isProduction());
```
 
### Breaking changes

None. Existing behavior is preserved `$model->stock` continues to work without preloading. The `preventLazyStockLoading` protection is opt-in.