### PR TITLE
fix: add wire:navigate to internal links for SPA navigation

### DIFF
--- a/packages/admin/resources/views/components/empty-state.blade.php
+++ b/packages/admin/resources/views/components/empty-state.blade.php
@@ -28,7 +28,7 @@
             @if ($permission)
                 @can($permission)
                     @if ($url)
-                        <x-filament::button tag="a" :href="$url" class="mt-5">
+                        <x-filament::button tag="a" :href="$url" wire:navigate class="mt-5">
                             {{ $button }}
                         </x-filament::button>
                     @elseif ($panel)

--- a/packages/admin/resources/views/livewire/pages/customers/index.blade.php
+++ b/packages/admin/resources/views/livewire/pages/customers/index.blade.php
@@ -2,7 +2,7 @@
     <x-shopper::heading :title="__('shopper::pages/customers.menu')">
         <x-slot name="action">
             @can('add_customers')
-                <x-filament::button tag="a" :href="route('shopper.customers.create')">
+                <x-filament::button tag="a" :href="route('shopper.customers.create')" wire:navigate>
                     {{ __('shopper::forms.actions.add_label', ['label' => __('shopper::pages/customers.single')]) }}
                 </x-filament::button>
             @endcan

--- a/packages/admin/resources/views/livewire/pages/settings/locations/index.blade.php
+++ b/packages/admin/resources/views/livewire/pages/settings/locations/index.blade.php
@@ -15,7 +15,7 @@
             @can('add_inventories')
                 @if ($inventories->count() < (int) config('shopper.admin.inventory_limit') + 1)
                     <div class="flex">
-                        <x-filament::button tag="a" :href="route('shopper.settings.locations.create')">
+                        <x-filament::button tag="a" :href="route('shopper.settings.locations.create')" wire:navigate>
                             {{ __('shopper::forms.actions.add_label', ['label' => __('shopper::pages/settings/global.location.single')]) }}
                         </x-filament::button>
                     </div>

--- a/packages/admin/resources/views/livewire/slide-overs/review-detail.blade.php
+++ b/packages/admin/resources/views/livewire/slide-overs/review-detail.blade.php
@@ -1,11 +1,9 @@
 <div class="flex h-full flex-col divide-y divide-gray-200 dark:divide-white/10">
-    <div class="h-0 flex-1 overflow-y-auto py-6">
-        <div class="px-4 sm:px-6">
-            <x-shopper::heading class="mt-5">
-                <x-slot name="title">
-                    {{ $review->reviewrateable->name }}
-                </x-slot>
-            </x-shopper::heading>
+    <div class="h-0 flex-1 overflow-y-auto py-4">
+        <div class="px-4">
+            <h2 class="font-heading text-2xl font-bold text-gray-900 dark:text-white">
+                {{ $review->reviewrateable->name }}
+            </h2>
 
             <div class="mt-8">
                 <x-shopper::section-heading

--- a/packages/admin/src/Livewire/Pages/Collection/Index.php
+++ b/packages/admin/src/Livewire/Pages/Collection/Index.php
@@ -90,6 +90,7 @@ class Index extends AbstractPageComponent implements HasActions, HasForms, HasTa
                             parameters: ['collection' => $record]
                         ),
                     )
+                    ->extraAttributes(['wire:navigate' => true])
                     ->visible(Shopper::auth()->user()->can('edit_collections')),
                 Action::make('delete')
                     ->label(__('shopper::forms.actions.delete'))


### PR DESCRIPTION
## Summary

- Add missing `wire:navigate` attribute to internal navigation links (`customers/index`, `locations/index`, `empty-state` component, `Collection/Index` action) to prevent full page reloads
- Clean up review detail slide-over heading markup