### PR TITLE
chore: rebrand from Laravel Shopper to Shopper

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,26 +1,33 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code when working with code in the Laravel Shopper repository.
+This file provides guidance to Claude Code when working with code in the Shopper repository.
 
 ## Project Overview
 
-Laravel Shopper is a headless e-commerce admin panel built for Laravel using the TALL stack (Tailwind CSS, Alpine.js, Laravel, Livewire). It is organized as a monorepo with four packages: `admin`, `core`, `sidebar`, and `shipping`.
+Shopper is a headless e-commerce admin panel built for Laravel using the TALL stack (Tailwind CSS, Alpine.js, Laravel, Livewire). It is organized as a monorepo with eight packages.
 
 ## Monorepo Structure
 
 ```
 packages/
-├── admin/      → Main admin UI (Livewire components, views, routes, assets)
-├── core/       → E-commerce domain logic (Models, Actions, Enums, Contracts)
+├── admin/      → Main admin UI (Livewire components, Filament forms/tables, views, routes, assets)
+├── cart/       → Cart management with pipeline-based calculation, discounts, and taxes
+├── core/       → E-commerce domain logic (Models, Actions, Enums, Contracts, Stock, Taxes)
+├── payment/    → Payment processing with extensible driver architecture
+├── shipping/   → Shipping providers integration with driver architecture
 ├── sidebar/    → Sidebar navigation builder (DDD-style architecture)
-└── shipping/   → Shipping providers integration
+├── stripe/     → Stripe payment driver for the payment system
+└── types/      → TypeScript type definitions (NPM package, no PHP)
 ```
 
-Each package has its own service provider:
+Each PHP package has its own service provider:
 - `Shopper\ShopperServiceProvider` (admin)
+- `Shopper\Cart\CartServiceProvider` (cart)
 - `Shopper\Core\CoreServiceProvider` (core)
-- `Shopper\Sidebar\SidebarServiceProvider` (sidebar)
+- `Shopper\Payment\PaymentServiceProvider` (payment)
 - `Shopper\Shipping\ShippingServiceProvider` (shipping)
+- `Shopper\Sidebar\SidebarServiceProvider` (sidebar)
+- `Shopper\Stripe\StripeServiceProvider` (stripe)
 
 Packages are split to separate repositories via the `monorepo-split.yml` workflow on push to `*.x` branches.
 
@@ -254,10 +261,12 @@ it('can display the product list', function (): void {
 
 ### Key PHP Packages
 
-- `filament/filament` ^4.5 (headless admin panel components)
+- `filament/filament` ^4.7 (headless admin panel components)
 - `livewire/livewire` ^3.7
 - `spatie/laravel-permission` ^6.24
 - `spatie/laravel-media-library` ^11.5
+- `stripe/stripe-php` ^16.0 (stripe package)
+- `ivanmitrikeski/laravel-shipping` ^1.0 (shipping package)
 
 ### PHP Version
 
@@ -277,3 +286,8 @@ it('can display the product list', function (): void {
 - Config: `packages/*/config/`
 - Migrations: `packages/core/database/migrations/`
 - Routes: `packages/admin/routes/`
+- Render hooks: `packages/admin/src/View/*RenderHook.php` (scoped by business domain)
+- Payment drivers: `packages/payment/src/Drivers/`
+- Shipping drivers: `packages/shipping/src/Drivers/`
+- Cart pipelines: `packages/cart/src/Pipelines/`
+- TypeScript types: `packages/types/`

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "shopper/shopper",
-  "description": "Laravel Shopper Monorepo",
+  "description": "Shopper Monorepo",
   "license": "MIT",
   "keywords": [
     "e-commerce",

--- a/packages/admin/resources/boost/guidelines/core.blade.php
+++ b/packages/admin/resources/boost/guidelines/core.blade.php
@@ -2,7 +2,7 @@
     /** @var \Laravel\Boost\Install\GuidelineAssist $assist */
 @endphp
 
-## Laravel Shopper Laravel Shopper is a headless e-commerce framework providing a complete admin panel built with
+## Shopper Shopper is a headless e-commerce framework providing a complete admin panel built with
 Filament and Livewire. For detailed documentation, refer to https://docs.laravelshopper.dev ### Installation - Use
 `{{ $assist->composerCommand('require shopper/framework --with-dependencies') }}` to install Shopper. - Run
 `{{ $assist->artisanCommand('shopper:install') }}` to publish config, migrations, and assets. - Run

--- a/packages/admin/resources/boost/skills/extending-shopper/SKILL.md
+++ b/packages/admin/resources/boost/skills/extending-shopper/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: extending-shopper
-description: Provides patterns for extending Laravel Shopper with custom sidebar items, component overrides, event listeners, and domain features like stock, pricing, and media. Use when customizing Shopper behavior.
+description: Provides patterns for extending Shopper with custom sidebar items, component overrides, event listeners, and domain features like stock, pricing, and media. Use when customizing Shopper behavior.
 ---
 
 # Extending Shopper

--- a/packages/admin/resources/boost/skills/shopper-development/SKILL.md
+++ b/packages/admin/resources/boost/skills/shopper-development/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: developing-shopper
-description: Provides coding standards and patterns for Laravel Shopper development. Use when creating or modifying Models, Actions, Enums, Livewire components, migrations, or tests in any Shopper package.
+description: Provides coding standards and patterns for Shopper development. Use when creating or modifying Models, Actions, Enums, Livewire components, migrations, or tests in any Shopper package.
 ---
 
 # Developing Shopper

--- a/packages/admin/resources/boost/skills/shopper-livewire/SKILL.md
+++ b/packages/admin/resources/boost/skills/shopper-livewire/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: shopper-livewire
-description: Provides patterns for building Livewire components in Laravel Shopper with Filament Forms, Tables, and Actions. Use when creating Pages, SlideOvers, or reusable components.
+description: Provides patterns for building Livewire components in Shopper with Filament Forms, Tables, and Actions. Use when creating Pages, SlideOvers, or reusable components.
 ---
 
 # Shopper Livewire Components

--- a/packages/admin/resources/views/components/brand.blade.php
+++ b/packages/admin/resources/views/components/brand.blade.php
@@ -6,6 +6,6 @@
     <img
         {{ $attributes }}
         src="{{ asset(shopper()->prefix() . '/images/shopper-icon.svg') }}"
-        alt="Laravel Shopper"
+        alt="Shopper"
     />
 @endif

--- a/packages/core/composer.json
+++ b/packages/core/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "shopper/core",
-  "description": "Laravel Shopper e-commerce core functionality",
+  "description": "Shopper e-commerce core functionality",
   "license": "MIT",
   "require": {
     "ext-intl": "*",

--- a/packages/core/src/Console/InstallCommand.php
+++ b/packages/core/src/Console/InstallCommand.php
@@ -89,7 +89,7 @@ final class InstallCommand extends Command
     protected function introMessage(): void
     {
         note($this->shopperLogo());
-        intro('✦ Laravel Shopper :: Install ✦');
+        intro('✦ Shopper :: Install ✦');
     }
 
     private function shopperLogo(): string

--- a/packages/payment/composer.json
+++ b/packages/payment/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "shopper/payment",
-  "description": "Laravel Shopper payment providers integration",
+  "description": "Shopper payment providers integration",
   "license": "MIT",
   "require": {
     "php": "^8.3",

--- a/packages/shipping/composer.json
+++ b/packages/shipping/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "shopper/shipping",
-  "description": "Laravel Shopper shipping providers integration",
+  "description": "Shopper shipping providers integration",
   "license": "MIT",
   "require": {
     "php": "^8.3",

--- a/packages/stripe/composer.json
+++ b/packages/stripe/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "shopper/stripe",
-  "description": "Stripe payment driver for Laravel Shopper",
+  "description": "Stripe payment driver for Shopper",
   "license": "MIT",
   "require": {
     "php": "^8.3",

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -4,7 +4,7 @@
 
 # Shopper Types definitions
 
-TypeScript types derived from the OpenAPI Spec (OAS) to be used in API clients for Laravel Shopper.
+TypeScript types derived from the OpenAPI Spec (OAS) to be used in API clients for Shopper.
 
 ## Install
 

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopperlabs/shopper-types",
   "version": "1.0.0",
-  "description": "TypeScript types for Laravel Shopper",
+  "description": "TypeScript types for Shopper",
   "author": "Arthur Monney <monneylobe@gmail.com> (https://arthurmonney.me)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

- Remove all "Laravel Shopper" references and replace with "Shopper" across the codebase
- Update `CLAUDE.md` to reflect the current 8-package monorepo structure (was outdated at 4 packages)
- Update Filament version reference (^4.5 → ^4.7) and add missing dependencies

### Files updated

- `composer.json` and all package `composer.json` / `package.json` descriptions
- `InstallCommand.php` intro message
- `brand.blade.php` alt text
- Boost guidelines and skills descriptions
- `types/README.md`
- `CLAUDE.md` (packages, service providers, dependencies, file organization)