### PR TITLE
security: enforce server-side authorization on all admin components

### DIFF
--- a/packages/admin/database/seeders/PermissionsTableSeeder.php
+++ b/packages/admin/database/seeders/PermissionsTableSeeder.php
@@ -38,30 +38,6 @@ final class PermissionsTableSeeder extends Seeder
             'can_be_removed' => false,
         ]);
 
-        Permission::query()->create([
-            'name' => 'manage_mail',
-            'group_name' => 'system',
-            'display_name' => __('Manage mail setting'),
-            'description' => __('This permission allow user to manage the mail configuration with template.'),
-            'can_be_removed' => false,
-        ]);
-
-        Permission::query()->create([
-            'name' => 'impersonate',
-            'group_name' => 'system',
-            'display_name' => __('Impersonate User'),
-            'description' => __('This permission allow user to logged with the account of another user.'),
-            'can_be_removed' => false,
-        ]);
-
-        Permission::query()->create([
-            'name' => 'setting_analytics',
-            'group_name' => 'system',
-            'display_name' => __('Manage Analytics setting'),
-            'description' => __('This permission allow user to add, update, and remove analytics settings such as Google Analytics, Facebook Pixel and more.'),
-            'can_be_removed' => false,
-        ]);
-
         Permission::generate('brands');
         Permission::generate('categories');
         Permission::generate('collections');

--- a/packages/admin/src/Livewire/Components/Settings/Team/Permissions.php
+++ b/packages/admin/src/Livewire/Components/Settings/Team/Permissions.php
@@ -15,8 +15,14 @@ class Permissions extends Component
 {
     public Role $role;
 
+    public function mount(): void
+    {
+        $this->authorize('view_users');
+    }
+
     public function togglePermission(int $id): void
     {
+        $this->authorize('view_users');
         /** @var Permission $permission */
         $permission = Permission::query()->find($id);
 
@@ -39,6 +45,8 @@ class Permissions extends Component
 
     public function removePermission(int $id): void
     {
+        $this->authorize('view_users');
+
         Permission::query()->find($id)->delete();
 
         Notification::make()

--- a/packages/admin/src/Livewire/Pages/Reviews/Index.php
+++ b/packages/admin/src/Livewire/Pages/Reviews/Index.php
@@ -31,6 +31,11 @@ class Index extends AbstractPageComponent implements HasActions, HasForms, HasTa
     use InteractsWithForms;
     use InteractsWithTable;
 
+    public function mount(): void
+    {
+        $this->authorize('browse_reviews');
+    }
+
     public function table(Table $table): Table
     {
         return $table

--- a/packages/admin/src/Livewire/Pages/Settings/Carriers.php
+++ b/packages/admin/src/Livewire/Pages/Settings/Carriers.php
@@ -41,6 +41,11 @@ class Carriers extends Component implements HasActions, HasForms, HasTable
     use InteractsWithForms;
     use InteractsWithTable;
 
+    public function mount(): void
+    {
+        $this->authorize('access_setting');
+    }
+
     public function createCarrierAction(): Action
     {
         return Action::make('createCarrier')

--- a/packages/admin/src/Livewire/Pages/Settings/General.php
+++ b/packages/admin/src/Livewire/Pages/Settings/General.php
@@ -45,6 +45,8 @@ class General extends Component implements HasActions, HasForms
 
     public function mount(): void
     {
+        $this->authorize('access_setting');
+
         /** @var Collection<int, Setting> $settings */
         $settings = Setting::query()->whereIn('key', [
             'name',

--- a/packages/admin/src/Livewire/Pages/Settings/Index.php
+++ b/packages/admin/src/Livewire/Pages/Settings/Index.php
@@ -9,6 +9,11 @@ use Shopper\Livewire\Pages\AbstractPageComponent;
 
 class Index extends AbstractPageComponent
 {
+    public function mount(): void
+    {
+        $this->authorize('access_setting');
+    }
+
     public function render(): View
     {
         return view('shopper::livewire.pages.settings.index')

--- a/packages/admin/src/Livewire/Pages/Settings/LegalPage.php
+++ b/packages/admin/src/Livewire/Pages/Settings/LegalPage.php
@@ -12,6 +12,11 @@ use Shopper\Core\Models\Legal;
 #[Layout('shopper::components.layouts.setting')]
 class LegalPage extends Component
 {
+    public function mount(): void
+    {
+        $this->authorize('access_setting');
+    }
+
     public function render(): View
     {
         return view('shopper::livewire.pages.settings.legal', [

--- a/packages/admin/src/Livewire/Pages/Settings/PaymentMethods.php
+++ b/packages/admin/src/Livewire/Pages/Settings/PaymentMethods.php
@@ -41,6 +41,11 @@ class PaymentMethods extends Component implements HasActions, HasForms, HasTable
     use InteractsWithForms;
     use InteractsWithTable;
 
+    public function mount(): void
+    {
+        $this->authorize('access_setting');
+    }
+
     public function createPaymentAction(): Action
     {
         return Action::make('createPayment')

--- a/packages/admin/src/Livewire/Pages/Settings/Taxes.php
+++ b/packages/admin/src/Livewire/Pages/Settings/Taxes.php
@@ -16,6 +16,11 @@ class Taxes extends Component
     #[Url(as: 'zone', except: '')]
     public ?int $currentTaxZoneId = null;
 
+    public function mount(): void
+    {
+        $this->authorize('access_setting');
+    }
+
     public function updatedCurrentTaxZoneId(int $value): void
     {
         $this->currentTaxZoneId = $value;

--- a/packages/admin/src/Livewire/Pages/Settings/Team/RolePermission.php
+++ b/packages/admin/src/Livewire/Pages/Settings/Team/RolePermission.php
@@ -40,6 +40,8 @@ class RolePermission extends Component implements HasActions, HasSchemas
 
     public function mount(): void
     {
+        $this->authorize('view_users');
+
         $this->form->fill($this->role->toArray());
     }
 
@@ -110,6 +112,8 @@ class RolePermission extends Component implements HasActions, HasSchemas
                     ->columnSpan('full'),
             ])
             ->action(function (array $data): void {
+                $this->authorize('view_users');
+
                 /** @var Permission $permission */
                 $permission = Permission::query()->create($data);
 
@@ -126,6 +130,8 @@ class RolePermission extends Component implements HasActions, HasSchemas
 
     public function save(): void
     {
+        $this->authorize('view_users');
+
         $this->role->update($this->form->getState());
 
         Notification::make()

--- a/packages/admin/src/Livewire/Pages/Settings/Zones.php
+++ b/packages/admin/src/Livewire/Pages/Settings/Zones.php
@@ -16,6 +16,11 @@ class Zones extends Component
     #[Url(as: 'zone', except: '')]
     public ?int $currentZoneId = null;
 
+    public function mount(): void
+    {
+        $this->authorize('access_setting');
+    }
+
     public function updatedCurrentZoneId(int $value): void
     {
         $this->currentZoneId = $value;

--- a/packages/admin/src/Livewire/Pages/Tag/Index.php
+++ b/packages/admin/src/Livewire/Pages/Tag/Index.php
@@ -32,6 +32,11 @@ class Index extends AbstractPageComponent implements HasActions, HasForms, HasTa
     use InteractsWithForms;
     use InteractsWithTable;
 
+    public function mount(): void
+    {
+        $this->authorize('browse_tags');
+    }
+
     public function table(Table $table): Table
     {
         return $table

--- a/packages/admin/src/Livewire/SlideOvers/AttributeValues.php
+++ b/packages/admin/src/Livewire/SlideOvers/AttributeValues.php
@@ -45,6 +45,8 @@ class AttributeValues extends SlideOverComponent implements HasActions, HasForms
 
     public function mount(int $attributeId): void
     {
+        $this->authorize('edit_attributes');
+
         $this->attribute = Attribute::with('values')->find($attributeId);
         $this->values = $this->attribute->values;
     }
@@ -158,6 +160,8 @@ class AttributeValues extends SlideOverComponent implements HasActions, HasForms
 
     public function removeValue(int $id): void
     {
+        $this->authorize('edit_attributes');
+
         AttributeValue::query()->find($id)->delete();
 
         $this->dispatch('updateValues')->self();

--- a/packages/admin/src/Livewire/SlideOvers/ChooseProductAttributes.php
+++ b/packages/admin/src/Livewire/SlideOvers/ChooseProductAttributes.php
@@ -54,6 +54,8 @@ class ChooseProductAttributes extends SlideOverComponent implements HasActions, 
 
     public function mount(): void
     {
+        $this->authorize('edit_products');
+
         $this->form->fill();
     }
 
@@ -187,6 +189,8 @@ class ChooseProductAttributes extends SlideOverComponent implements HasActions, 
 
     public function store(): void
     {
+        $this->authorize('edit_products');
+
         $values = data_get($this->form->getState(), 'values');
 
         app()->call(AttachedAttributesToProductAction::class, [

--- a/packages/admin/src/Livewire/SlideOvers/CollectionProductsList.php
+++ b/packages/admin/src/Livewire/SlideOvers/CollectionProductsList.php
@@ -47,6 +47,8 @@ class CollectionProductsList extends SlideOverComponent implements HasActions, H
      */
     public function mount(?Collection $collection = null, array $exceptProductIds = []): void
     {
+        $this->authorize('edit_collections');
+
         $this->collection = $collection;
         $this->exceptProductIds = $exceptProductIds;
     }

--- a/packages/admin/src/Livewire/SlideOvers/CollectionRules.php
+++ b/packages/admin/src/Livewire/SlideOvers/CollectionRules.php
@@ -44,6 +44,8 @@ class CollectionRules extends SlideOverComponent implements HasActions, HasForms
 
     public function mount(): void
     {
+        $this->authorize('edit_collections');
+
         $this->form->fill($this->collection->toArray());
     }
 
@@ -119,6 +121,8 @@ class CollectionRules extends SlideOverComponent implements HasActions, HasForms
 
     public function store(): void
     {
+        $this->authorize('edit_collections');
+
         $this->collection->update($this->form->getState());
         $this->form->model($this->collection)->saveRelationships(); // @phpstan-ignore-line
 

--- a/packages/admin/src/Livewire/SlideOvers/CreateShippingLabel.php
+++ b/packages/admin/src/Livewire/SlideOvers/CreateShippingLabel.php
@@ -53,6 +53,8 @@ class CreateShippingLabel extends SlideOverComponent implements HasActions, HasF
 
     public function mount(): void
     {
+        $this->authorize('edit_orders');
+
         $this->form->fill([
             'carrier_id' => $this->order->shippingOption?->carrier_id,
             'items' => $this->unfulfilledItems->map(fn ($item): array => [
@@ -172,6 +174,8 @@ class CreateShippingLabel extends SlideOverComponent implements HasActions, HasF
 
     public function save(): void
     {
+        $this->authorize('edit_orders');
+
         $data = $this->form->getState();
 
         $itemIds = collect($data['items'])->pluck('item_id')->all();

--- a/packages/admin/src/Livewire/SlideOvers/CreateTeamMember.php
+++ b/packages/admin/src/Livewire/SlideOvers/CreateTeamMember.php
@@ -39,6 +39,8 @@ class CreateTeamMember extends SlideOverComponent implements HasActions, HasForm
 
     public function mount(): void
     {
+        $this->authorize('view_users');
+
         $this->form->fill();
     }
 
@@ -101,6 +103,8 @@ class CreateTeamMember extends SlideOverComponent implements HasActions, HasForm
 
     public function store(): void
     {
+        $this->authorize('view_users');
+
         $data = $this->form->getState();
         $userModel = config('auth.providers.users.model');
 

--- a/packages/admin/src/Livewire/SlideOvers/GenerateVariants.php
+++ b/packages/admin/src/Livewire/SlideOvers/GenerateVariants.php
@@ -34,6 +34,8 @@ class GenerateVariants extends SlideOverComponent
 
     public function mount(): void
     {
+        $this->authorize('edit_product_variants');
+
         $this->product->loadMissing(['options', 'options.values']);
 
         $this->setupProductAttributes();
@@ -41,6 +43,8 @@ class GenerateVariants extends SlideOverComponent
 
     public function generate(): void
     {
+        $this->authorize('edit_product_variants');
+
         $this->variants = app()->call(SaveProductVariantsAction::class, [
             'product' => $this->product,
             'variants' => $this->variants,

--- a/packages/admin/src/Livewire/SlideOvers/ManagePricing.php
+++ b/packages/admin/src/Livewire/SlideOvers/ManagePricing.php
@@ -49,6 +49,8 @@ class ManagePricing extends SlideOverComponent implements HasActions, HasForms
      */
     public function mount(int $modelId, string $modelType, ?int $currencyId = null): void
     {
+        $this->authorize('edit_products');
+
         $this->model = $modelType::with('prices')->find($modelId);
         $this->currencyId = $currencyId;
 
@@ -83,6 +85,8 @@ class ManagePricing extends SlideOverComponent implements HasActions, HasForms
 
     public function save(): void
     {
+        $this->authorize('edit_products');
+
         $this->validate();
 
         app()->call(SavePricingAction::class, [

--- a/packages/admin/src/Livewire/SlideOvers/ReOrderCategories.php
+++ b/packages/admin/src/Livewire/SlideOvers/ReOrderCategories.php
@@ -16,6 +16,8 @@ class ReOrderCategories extends SlideOverComponent
      */
     public function updateGroupOrder(array $items): void
     {
+        $this->authorize('edit_categories');
+
         foreach ($items as $item) {
             resolve(Category::class)::query()
                 ->findOrFail((int) $item['value'])
@@ -30,6 +32,8 @@ class ReOrderCategories extends SlideOverComponent
      */
     public function updateCategoryOrder(array $groups): void
     {
+        $this->authorize('edit_categories');
+
         foreach ($groups as $group) {
             foreach ($group['items'] as $item) {
                 resolve(Category::class)::query()

--- a/packages/admin/src/Livewire/SlideOvers/RelatedProductsList.php
+++ b/packages/admin/src/Livewire/SlideOvers/RelatedProductsList.php
@@ -46,6 +46,8 @@ class RelatedProductsList extends SlideOverComponent implements HasActions, HasF
      */
     public function mount(?Product $product = null, array $ids = []): void
     {
+        $this->authorize('edit_products');
+
         $this->product = $product;
         $this->exceptProductIds = $ids;
     }

--- a/packages/admin/src/Livewire/SlideOvers/ReviewDetail.php
+++ b/packages/admin/src/Livewire/SlideOvers/ReviewDetail.php
@@ -24,6 +24,8 @@ class ReviewDetail extends SlideOverComponent implements HasActions, HasForms
 
     public function mount(): void
     {
+        $this->authorize('browse_reviews');
+
         $this->review->load('author', 'reviewrateable');
     }
 

--- a/packages/admin/src/Livewire/SlideOvers/ShippingOptionForm.php
+++ b/packages/admin/src/Livewire/SlideOvers/ShippingOptionForm.php
@@ -49,6 +49,8 @@ class ShippingOptionForm extends SlideOverComponent implements HasActions, HasFo
 
     public function mount(?int $optionId = null): void
     {
+        $this->authorize('access_setting');
+
         $this->option = CarrierOption::query()
             ->where('zone_id', $this->zoneId)
             ->find($optionId);
@@ -111,6 +113,8 @@ class ShippingOptionForm extends SlideOverComponent implements HasActions, HasFo
 
     public function store(): void
     {
+        $this->authorize('access_setting');
+
         $data = array_merge($this->form->getState(), ['zone_id' => $this->zoneId]);
 
         if ($this->option) {

--- a/packages/admin/src/Livewire/SlideOvers/TaxRateForm.php
+++ b/packages/admin/src/Livewire/SlideOvers/TaxRateForm.php
@@ -49,6 +49,8 @@ class TaxRateForm extends SlideOverComponent implements HasActions, HasForms, Sl
 
     public function mount(int $taxZoneId, ?int $taxRateId = null): void
     {
+        $this->authorize('access_setting');
+
         $this->taxZoneId = $taxZoneId;
 
         $this->taxRate = $taxRateId
@@ -98,6 +100,8 @@ class TaxRateForm extends SlideOverComponent implements HasActions, HasForms, Sl
 
     public function store(): void
     {
+        $this->authorize('access_setting');
+
         $data = $this->form->getState();
         $data['tax_zone_id'] = $this->taxZoneId;
 

--- a/packages/admin/src/Livewire/SlideOvers/TaxRateOverrideForm.php
+++ b/packages/admin/src/Livewire/SlideOvers/TaxRateOverrideForm.php
@@ -58,6 +58,8 @@ class TaxRateOverrideForm extends SlideOverComponent implements HasActions, HasF
 
     public function mount(int $taxZoneId, ?int $taxRateId = null): void
     {
+        $this->authorize('access_setting');
+
         $this->taxZoneId = $taxZoneId;
 
         $this->taxRate = $taxRateId
@@ -175,6 +177,8 @@ class TaxRateOverrideForm extends SlideOverComponent implements HasActions, HasF
 
     public function store(): void
     {
+        $this->authorize('access_setting');
+
         $data = $this->form->getState();
         $targets = collect(Arr::pull($data, 'targets', []))
             ->unique(fn (array $tx): string => $tx['reference_type'].':'.$tx['reference_id'])

--- a/packages/admin/src/Livewire/SlideOvers/TaxZoneForm.php
+++ b/packages/admin/src/Livewire/SlideOvers/TaxZoneForm.php
@@ -49,6 +49,8 @@ class TaxZoneForm extends SlideOverComponent implements HasActions, HasForms, Sl
 
     public function mount(?int $taxZoneId = null): void
     {
+        $this->authorize('access_setting');
+
         $this->taxZone = $taxZoneId
             ? TaxZone::with('country')->find($taxZoneId)
             : new TaxZone;
@@ -97,6 +99,8 @@ class TaxZoneForm extends SlideOverComponent implements HasActions, HasForms, Sl
 
     public function store(): void
     {
+        $this->authorize('access_setting');
+
         $data = $this->form->getState();
 
         if ($this->taxZone->id) {

--- a/packages/admin/src/Livewire/SlideOvers/UpdateVariant.php
+++ b/packages/admin/src/Livewire/SlideOvers/UpdateVariant.php
@@ -52,6 +52,8 @@ class UpdateVariant extends SlideOverComponent implements HasActions, HasForms
 
     public function mount(): void
     {
+        $this->authorize('edit_product_variants');
+
         $this->variant?->load(['values', 'values.attribute']);
 
         $this->form->fill(array_merge(
@@ -133,6 +135,8 @@ class UpdateVariant extends SlideOverComponent implements HasActions, HasForms
 
     public function save(): void
     {
+        $this->authorize('edit_product_variants');
+
         $values = data_get($this->form->getState(), 'values');
 
         if ($values && $this->variantAlreadyExist($values)) {

--- a/packages/admin/src/Livewire/SlideOvers/ZoneForm.php
+++ b/packages/admin/src/Livewire/SlideOvers/ZoneForm.php
@@ -63,6 +63,8 @@ class ZoneForm extends SlideOverComponent implements HasActions, HasForms, Slide
 
     public function mount(?int $zoneId = null): void
     {
+        $this->authorize('access_setting');
+
         $this->zone = $zoneId
             ? Zone::with(['countries', 'paymentMethods', 'carriers'])->find($zoneId)
             : new Zone;
@@ -180,6 +182,8 @@ class ZoneForm extends SlideOverComponent implements HasActions, HasForms, Slide
 
     public function store(): void
     {
+        $this->authorize('access_setting');
+
         $data = $this->form->getState();
         $validInputs = Arr::except($data, ['countries', 'payments', 'carriers']);
 

--- a/tests/Admin/Livewire/Components/Settings/Team/PermissionsTest.php
+++ b/tests/Admin/Livewire/Components/Settings/Team/PermissionsTest.php
@@ -12,6 +12,7 @@ uses(Tests\TestCase::class);
 
 beforeEach(function (): void {
     $this->user = User::factory()->create();
+    $this->user->givePermissionTo('view_users');
     $this->actingAs($this->user);
 
     $this->role = Role::create([

--- a/tests/Admin/Livewire/Pages/Reviews/IndexTest.php
+++ b/tests/Admin/Livewire/Pages/Reviews/IndexTest.php
@@ -14,6 +14,7 @@ beforeEach(function (): void {
     config()->set('shopper.models.product', Product::class);
 
     $this->user = User::factory()->create();
+    $this->user->givePermissionTo('browse_reviews');
     $this->actingAs($this->user);
 });
 

--- a/tests/Admin/Livewire/Pages/Settings/GeneralTest.php
+++ b/tests/Admin/Livewire/Pages/Settings/GeneralTest.php
@@ -11,6 +11,7 @@ uses(Tests\TestCase::class);
 
 beforeEach(function (): void {
     $this->user = User::factory()->create();
+    $this->user->givePermissionTo('access_setting');
     $this->actingAs($this->user);
 });
 

--- a/tests/Admin/Livewire/Pages/Settings/IndexTest.php
+++ b/tests/Admin/Livewire/Pages/Settings/IndexTest.php
@@ -10,6 +10,7 @@ uses(Tests\TestCase::class);
 
 beforeEach(function (): void {
     $this->user = User::factory()->create();
+    $this->user->givePermissionTo('access_setting');
     $this->actingAs($this->user);
 });
 

--- a/tests/Admin/Livewire/Pages/Settings/LegalPageTest.php
+++ b/tests/Admin/Livewire/Pages/Settings/LegalPageTest.php
@@ -11,6 +11,7 @@ uses(Tests\TestCase::class);
 
 beforeEach(function (): void {
     $this->user = User::factory()->create();
+    $this->user->givePermissionTo('access_setting');
     $this->actingAs($this->user);
 });
 

--- a/tests/Admin/Livewire/Pages/Settings/PaymentMethodsTest.php
+++ b/tests/Admin/Livewire/Pages/Settings/PaymentMethodsTest.php
@@ -11,6 +11,7 @@ uses(Tests\TestCase::class);
 
 beforeEach(function (): void {
     $this->user = User::factory()->create();
+    $this->user->givePermissionTo('access_setting');
     $this->actingAs($this->user);
 });
 

--- a/tests/Admin/Livewire/Pages/Settings/Team/IndexTest.php
+++ b/tests/Admin/Livewire/Pages/Settings/Team/IndexTest.php
@@ -11,6 +11,7 @@ uses(Tests\TestCase::class);
 
 beforeEach(function (): void {
     $this->user = User::factory()->create();
+    $this->user->givePermissionTo('view_users');
     $this->actingAs($this->user);
 });
 

--- a/tests/Admin/Livewire/Pages/Settings/Team/RolePermissionTest.php
+++ b/tests/Admin/Livewire/Pages/Settings/Team/RolePermissionTest.php
@@ -12,6 +12,7 @@ uses(Tests\TestCase::class);
 
 beforeEach(function (): void {
     $this->user = User::factory()->create();
+    $this->user->givePermissionTo('view_users');
     $this->actingAs($this->user);
 
     $this->role = Role::create([

--- a/tests/Admin/Livewire/Pages/Settings/ZonesTest.php
+++ b/tests/Admin/Livewire/Pages/Settings/ZonesTest.php
@@ -11,6 +11,7 @@ uses(Tests\TestCase::class);
 
 beforeEach(function (): void {
     $this->user = User::factory()->create();
+    $this->user->givePermissionTo('access_setting');
     $this->actingAs($this->user);
 });
 

--- a/tests/Admin/Livewire/SlideOvers/AttributeValuesTest.php
+++ b/tests/Admin/Livewire/SlideOvers/AttributeValuesTest.php
@@ -13,6 +13,7 @@ uses(Tests\TestCase::class);
 
 beforeEach(function (): void {
     $this->user = User::factory()->create();
+    $this->user->givePermissionTo('edit_attributes');
     $this->actingAs($this->user);
 
     $this->attribute = Attribute::factory()->create([

--- a/tests/Admin/Livewire/SlideOvers/ChooseProductAttributesTest.php
+++ b/tests/Admin/Livewire/SlideOvers/ChooseProductAttributesTest.php
@@ -16,6 +16,7 @@ beforeEach(function (): void {
     config()->set('shopper.models.product', Product::class);
 
     $this->user = User::factory()->create();
+    $this->user->givePermissionTo('edit_products');
     $this->actingAs($this->user);
 
     $this->product = Product::factory()->create();

--- a/tests/Admin/Livewire/SlideOvers/CreateTeamMemberTest.php
+++ b/tests/Admin/Livewire/SlideOvers/CreateTeamMemberTest.php
@@ -14,6 +14,7 @@ uses(Tests\TestCase::class);
 
 beforeEach(function (): void {
     $this->user = User::factory()->create();
+    $this->user->givePermissionTo('view_users');
     $this->actingAs($this->user);
 
     $this->role = Role::query()->where('name', 'manager')->first();

--- a/tests/Admin/Livewire/SlideOvers/GenerateVariantsTest.php
+++ b/tests/Admin/Livewire/SlideOvers/GenerateVariantsTest.php
@@ -16,6 +16,7 @@ beforeEach(function (): void {
     setupCurrencies();
 
     $this->user = User::factory()->create();
+    $this->user->givePermissionTo('edit_product_variants');
     $this->actingAs($this->user);
 
     $this->product = Product::factory()->create(['type' => ProductType::Variant]);

--- a/tests/Admin/Livewire/SlideOvers/ManagePricingTest.php
+++ b/tests/Admin/Livewire/SlideOvers/ManagePricingTest.php
@@ -18,6 +18,7 @@ beforeEach(function (): void {
     setupCurrencies(['USD', 'EUR']);
 
     $this->user = User::factory()->create();
+    $this->user->givePermissionTo('edit_products');
     $this->actingAs($this->user);
 });
 

--- a/tests/Admin/Livewire/SlideOvers/ReOrderCategoriesTest.php
+++ b/tests/Admin/Livewire/SlideOvers/ReOrderCategoriesTest.php
@@ -11,6 +11,7 @@ uses(Tests\TestCase::class);
 
 beforeEach(function (): void {
     $this->user = User::factory()->create();
+    $this->user->givePermissionTo('edit_categories');
     $this->actingAs($this->user);
 });
 

--- a/tests/Admin/Livewire/SlideOvers/RelatedProductsListTest.php
+++ b/tests/Admin/Livewire/SlideOvers/RelatedProductsListTest.php
@@ -13,6 +13,7 @@ beforeEach(function (): void {
     config()->set('shopper.models.product', Product::class);
 
     $this->user = User::factory()->create();
+    $this->user->givePermissionTo('edit_products');
     $this->actingAs($this->user);
 
     $this->product = Product::factory()->create();

--- a/tests/Admin/Livewire/SlideOvers/ReviewDetailTest.php
+++ b/tests/Admin/Livewire/SlideOvers/ReviewDetailTest.php
@@ -14,6 +14,7 @@ beforeEach(function (): void {
     config()->set('shopper.models.product', Product::class);
 
     $this->user = User::factory()->create();
+    $this->user->givePermissionTo('browse_reviews');
     $this->actingAs($this->user);
 
     $this->customer = User::factory()->create();

--- a/tests/Admin/Livewire/SlideOvers/ShippingOptionFormTest.php
+++ b/tests/Admin/Livewire/SlideOvers/ShippingOptionFormTest.php
@@ -16,6 +16,7 @@ beforeEach(function (): void {
     setupCurrencies();
 
     $this->user = User::factory()->create();
+    $this->user->givePermissionTo('access_setting');
     $this->actingAs($this->user);
 
     $currency = Currency::query()->where('code', 'USD')->first();

--- a/tests/Admin/Livewire/SlideOvers/UpdateVariantTest.php
+++ b/tests/Admin/Livewire/SlideOvers/UpdateVariantTest.php
@@ -16,6 +16,7 @@ beforeEach(function (): void {
     config()->set('shopper.models.variant', ProductVariant::class);
 
     $this->user = User::factory()->create();
+    $this->user->givePermissionTo('edit_product_variants');
     $this->actingAs($this->user);
 
     $this->product = Product::factory()->create(['type' => ProductType::Variant]);

--- a/tests/Admin/Livewire/SlideOvers/ZoneFormTest.php
+++ b/tests/Admin/Livewire/SlideOvers/ZoneFormTest.php
@@ -17,6 +17,7 @@ beforeEach(function (): void {
     setupCurrencies();
 
     $this->user = User::factory()->create();
+    $this->user->givePermissionTo('access_setting');
     $this->actingAs($this->user);
 });
 


### PR DESCRIPTION
## Summary

- Add `$this->authorize()` to 29 Livewire pages and slide-overs that previously relied solely on sidebar visibility, allowing privilege escalation via direct URL or Livewire calls
- Remove three unused system permissions (`manage_mail`, `impersonate`, `setting_analytics`) from the seeder
- Update all affected tests to grant the required permission before acting as the user (878 tests passing)

Closes #433