### PR TITLE
feat: add currencies settings page

### DIFF
--- a/packages/admin/config/components/setting.php
+++ b/packages/admin/config/components/setting.php
@@ -27,6 +27,7 @@ return [
         'team-roles' => Pages\Settings\Team\RolePermission::class,
         'zones' => Pages\Settings\Zones::class,
         'taxes' => Pages\Settings\Taxes::class,
+        'currencies' => Pages\Settings\Currencies::class,
     ],
 
     /*

--- a/packages/admin/config/settings.php
+++ b/packages/admin/config/settings.php
@@ -28,6 +28,7 @@ return [
         Items\LegalSetting::class => true,
         Items\ZoneSetting::class => true,
         Items\TaxSetting::class => true,
+        Items\CurrencySetting::class => true,
     ],
 
 ];

--- a/packages/admin/resources/lang/en/pages/settings/currencies.php
+++ b/packages/admin/resources/lang/en/pages/settings/currencies.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+
+    'title' => 'Currencies',
+    'single' => 'Currency',
+    'code' => 'Code',
+    'symbol' => 'Symbol',
+    'exchange_rate' => 'Exchange rate',
+    'exchange_rate_help' => 'Rate relative to your store\'s default currency. Leave at 1 for the default currency.',
+    'edit_rate' => 'Edit exchange rate',
+    'rate_updated' => 'Exchange rate has been successfully updated.',
+    'no_currency' => 'No currencies found.',
+
+];

--- a/packages/admin/resources/lang/en/pages/settings/menu.php
+++ b/packages/admin/resources/lang/en/pages/settings/menu.php
@@ -22,6 +22,8 @@ return [
     'zone_description' => 'Manage shipping, payment, and fulfillment across zones',
     'tax' => 'Taxes',
     'tax_description' => 'Manage how your store charges taxes.',
+    'currency' => 'Currencies',
+    'currency_description' => 'Enable currencies and manage exchange rates.',
     'sales' => 'Sales channels',
     'sales_description' => 'Manage the online and offline channels you sell products on.',
 

--- a/packages/admin/resources/lang/es/pages/settings/currencies.php
+++ b/packages/admin/resources/lang/es/pages/settings/currencies.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+
+    'title' => 'Divisas',
+    'single' => 'Divisa',
+    'code' => 'Código',
+    'symbol' => 'Símbolo',
+    'exchange_rate' => 'Tipo de cambio',
+    'exchange_rate_help' => 'Tasa relativa a la divisa predeterminada de tu tienda. Déjalo en 1 para la divisa predeterminada.',
+    'edit_rate' => 'Editar tipo de cambio',
+    'rate_updated' => 'El tipo de cambio se ha actualizado correctamente.',
+    'no_currency' => 'No se encontraron divisas.',
+
+];

--- a/packages/admin/resources/lang/es/pages/settings/menu.php
+++ b/packages/admin/resources/lang/es/pages/settings/menu.php
@@ -22,6 +22,8 @@ return [
     'zone_description' => 'Gestiona envío, pago y cumplimiento a través de zonas',
     'tax' => 'Impuestos',
     'tax_description' => 'Gestiona cómo tu tienda cobra impuestos.',
+    'currency' => 'Divisas',
+    'currency_description' => 'Activa divisas y gestiona los tipos de cambio.',
     'sales' => 'Canales de venta',
     'sales_description' => 'Gestiona los canales en línea y fuera de línea en los que vendes productos.',
 

--- a/packages/admin/resources/lang/fr/pages/settings/currencies.php
+++ b/packages/admin/resources/lang/fr/pages/settings/currencies.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+
+    'title' => 'Devises',
+    'single' => 'Devise',
+    'code' => 'Code',
+    'symbol' => 'Symbole',
+    'exchange_rate' => 'Taux de change',
+    'exchange_rate_help' => 'Taux par rapport à la devise par défaut de votre boutique. Laissez à 1 pour la devise par défaut.',
+    'edit_rate' => 'Modifier le taux de change',
+    'rate_updated' => 'Le taux de change a été mis à jour avec succès.',
+    'no_currency' => 'Aucune devise trouvée.',
+
+];

--- a/packages/admin/resources/lang/fr/pages/settings/menu.php
+++ b/packages/admin/resources/lang/fr/pages/settings/menu.php
@@ -22,6 +22,8 @@ return [
     'zone_description' => "Gérer l'expédition, le paiement et l'exécution dans toutes les zones",
     'tax' => 'Tax',
     'tax_description' => 'Gérez la façon dont votre boutique facture les taxes.',
+    'currency' => 'Devises',
+    'currency_description' => 'Activez les devises et gérez les taux de change.',
     'sales' => 'Cannaux de vente',
     'sales_description' => 'Gérez les canaux en ligne et hors ligne sur lesquels vous vendez vos produits.',
 

--- a/packages/admin/resources/views/livewire/pages/settings/currencies.blade.php
+++ b/packages/admin/resources/views/livewire/pages/settings/currencies.blade.php
@@ -1,0 +1,19 @@
+<div>
+    <x-shopper::container>
+        <x-shopper::breadcrumb
+            :back="route('shopper.settings.index')"
+            :current="__('shopper::pages/settings/currencies.title')"
+        >
+            <x-untitledui-chevron-left class="size-4 shrink-0 text-gray-300 dark:text-gray-600" aria-hidden="true" />
+            <x-shopper::breadcrumb.link
+                :link="route('shopper.settings.index')"
+                :title="__('shopper::pages/settings/global.menu')"
+            />
+        </x-shopper::breadcrumb>
+        <x-shopper::heading class="my-6" :title="__('shopper::pages/settings/currencies.title')" />
+
+        {{ $this->table }}
+    </x-shopper::container>
+
+    <x-filament-actions::modals />
+</div>

--- a/packages/admin/routes/admin/setting.php
+++ b/packages/admin/routes/admin/setting.php
@@ -19,6 +19,7 @@ Route::get('/payment-methods', config('shopper.components.setting.pages.payment-
 Route::get('/carriers', config('shopper.components.setting.pages.carriers'))->name('carriers');
 Route::get('/zones', config('shopper.components.setting.pages.zones'))->name('zones');
 Route::get('/taxes', config('shopper.components.setting.pages.taxes'))->name('taxes');
+Route::get('/currencies', config('shopper.components.setting.pages.currencies'))->name('currencies');
 
 Route::prefix('team')->group(function (): void {
     Route::get('/', config('shopper.components.setting.pages.team-index'))->name('users');

--- a/packages/admin/src/Livewire/Pages/Settings/Currencies.php
+++ b/packages/admin/src/Livewire/Pages/Settings/Currencies.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Livewire\Pages\Settings;
+
+use Filament\Actions\BulkAction;
+use Filament\Actions\Concerns\InteractsWithActions;
+use Filament\Actions\Contracts\HasActions;
+use Filament\Actions\EditAction;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Concerns\InteractsWithForms;
+use Filament\Forms\Contracts\HasForms;
+use Filament\Notifications\Notification;
+use Filament\Support\Enums\Width;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Columns\ToggleColumn;
+use Filament\Tables\Concerns\InteractsWithTable;
+use Filament\Tables\Contracts\HasTable;
+use Filament\Tables\Filters\TernaryFilter;
+use Filament\Tables\Table;
+use Illuminate\Contracts\View\View;
+use Illuminate\Database\Eloquent\Collection;
+use Livewire\Attributes\Layout;
+use Livewire\Component;
+use Mckenziearts\Icons\Untitledui\Enums\Untitledui;
+use Shopper\Core\Models\Currency;
+
+#[Layout('shopper::components.layouts.setting')]
+class Currencies extends Component implements HasActions, HasForms, HasTable
+{
+    use InteractsWithActions;
+    use InteractsWithForms;
+    use InteractsWithTable;
+
+    public function mount(): void
+    {
+        $this->authorize('access_setting');
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->query(Currency::withoutGlobalScopes()->orderBy('name'))
+            ->columns([
+                TextColumn::make('name')
+                    ->label(__('shopper::forms.label.name'))
+                    ->sortable()
+                    ->searchable(),
+                TextColumn::make('code')
+                    ->label(__('shopper::pages/settings/currencies.code'))
+                    ->badge()
+                    ->color('gray')
+                    ->searchable(),
+                TextColumn::make('symbol')
+                    ->label(__('shopper::pages/settings/currencies.symbol')),
+                TextColumn::make('exchange_rate')
+                    ->label(__('shopper::pages/settings/currencies.exchange_rate'))
+                    ->numeric(decimalPlaces: 4)
+                    ->sortable(),
+                ToggleColumn::make('is_enabled')
+                    ->label(__('shopper::forms.label.status')),
+            ])
+            ->recordActions([
+                EditAction::make('edit')
+                    ->label(__('shopper::forms.actions.edit'))
+                    ->icon(Untitledui::Edit03)
+                    ->iconButton()
+                    ->modalHeading(__('shopper::pages/settings/currencies.edit_rate'))
+                    ->modalWidth(Width::Large)
+                    ->schema([
+                        TextInput::make('exchange_rate')
+                            ->label(__('shopper::pages/settings/currencies.exchange_rate'))
+                            ->helperText(__('shopper::pages/settings/currencies.exchange_rate_help'))
+                            ->numeric()
+                            ->step(0.0001)
+                            ->minValue(0)
+                            ->required(),
+                    ])
+                    ->successNotificationTitle(__('shopper::pages/settings/currencies.rate_updated')),
+            ])
+            ->filters([
+                TernaryFilter::make('is_enabled')
+                    ->label(__('shopper::forms.label.status')),
+            ])
+            ->groupedBulkActions([
+                BulkAction::make('enable')
+                    ->label(__('shopper::forms.actions.enable'))
+                    ->icon(Untitledui::CheckVerified)
+                    ->modalIcon(Untitledui::CheckVerified)
+                    ->modalIconColor('success')
+                    ->requiresConfirmation()
+                    ->action(function (Collection $records): void {
+                        Currency::withoutGlobalScopes()
+                            ->whereIn('id', $records->pluck('id'))
+                            ->update(['is_enabled' => true]);
+
+                        Notification::make()
+                            ->title(__('shopper::notifications.enabled', [
+                                'item' => __('shopper::pages/settings/currencies.single'),
+                            ]))
+                            ->success()
+                            ->send();
+                    })
+                    ->deselectRecordsAfterCompletion(),
+                BulkAction::make('disable')
+                    ->label(__('shopper::forms.actions.disable'))
+                    ->icon(Untitledui::SlashCircle01)
+                    ->requiresConfirmation()
+                    ->color('warning')
+                    ->action(function (Collection $records): void {
+                        Currency::withoutGlobalScopes()
+                            ->whereIn('id', $records->pluck('id'))
+                            ->update(['is_enabled' => false]);
+
+                        Notification::make()
+                            ->title(__('shopper::notifications.disabled', [
+                                'item' => __('shopper::pages/settings/currencies.single'),
+                            ]))
+                            ->success()
+                            ->send();
+                    })
+                    ->deselectRecordsAfterCompletion(),
+            ])
+            ->emptyStateIcon(Untitledui::CurrencyDollarCircle)
+            ->emptyStateDescription(__('shopper::pages/settings/currencies.no_currency'));
+    }
+
+    public function render(): View
+    {
+        return view('shopper::livewire.pages.settings.currencies')
+            ->title(__('shopper::pages/settings/currencies.title'));
+    }
+}

--- a/packages/admin/src/Settings/Items/CurrencySetting.php
+++ b/packages/admin/src/Settings/Items/CurrencySetting.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Settings\Items;
+
+use Shopper\Settings\Setting;
+
+final class CurrencySetting extends Setting
+{
+    public function name(): string
+    {
+        return __('shopper::pages/settings/menu.currency');
+    }
+
+    public function description(): string
+    {
+        return __('shopper::pages/settings/menu.currency_description');
+    }
+
+    public function icon(): string
+    {
+        return 'untitledui-currency-dollar-circle';
+    }
+
+    public function url(): string
+    {
+        return route('shopper.settings.currencies');
+    }
+
+    public function order(): int
+    {
+        return 9;
+    }
+}


### PR DESCRIPTION
## Summary

- Add a dedicated **Settings > Currencies** page to manage all currencies in the database (including disabled ones)
- Bulk actions to enable or disable multiple currencies at once