### PR TITLE
chore(stripe): upgrade stripe-php from ^16.0 to ^19.0

### DIFF
--- a/packages/stripe/composer.json
+++ b/packages/stripe/composer.json
@@ -5,7 +5,7 @@
   "require": {
     "php": "^8.3",
     "shopper/payment": "*",
-    "stripe/stripe-php": "^16.0"
+    "stripe/stripe-php": "^19.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
## Summary

Upgrade `stripe/stripe-php` from `^16.0` to `^19.0`.

All breaking changes introduced in v17, v18, and v19 affect V2 APIs, removed Invoice methods, and custom `StripeClient` implementations — none of which are used in this package. The package exclusively uses stable V1 APIs (`paymentIntents`, `refunds`, `Webhook::constructEvent`) which remain unchanged across all three major versions.

No code changes required.