### PR TITLE
chore(ci): update GitHub Actions workflows for v2.x

### DIFF
--- a/.github/workflows/monorepo-split.yml
+++ b/.github/workflows/monorepo-split.yml
@@ -2,8 +2,6 @@ name: monorepo-split
 
 on:
   push:
-    branches:
-      - '*.x'
     tags:
       - '*'
 
@@ -49,7 +47,7 @@ jobs:
           package_directory: 'packages/${{ matrix.package }}'
           repository_organization: 'shopperlabs'
           repository_name: '${{ matrix.repository }}'
-          branch: ${{ github.ref_type == 'tag' && '2.x' || github.ref_name }}
-          tag: ${{ github.ref_type == 'tag' && github.ref_name || '' }}
+          branch: 2.x
+          tag: ${{ github.ref_name }}
           user_name: 'Arthur Monney'
           user_email: 'monneylobe@gmail.com'

--- a/.github/workflows/npm-build.yml
+++ b/.github/workflows/npm-build.yml
@@ -3,7 +3,7 @@ name: Builds assets
 on:
   pull_request:
     branches:
-      - '*.x'
+      - 2.x
     types:
       - closed
 
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.base.ref }}
+          ref: 2.x
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -35,5 +35,5 @@ jobs:
       - name: Commit changes
         uses: stefanzweifel/git-auto-commit-action@v7
         with:
-          branch: ${{ github.ref_name }}
+          branch: 2.x
           commit_message: "chore: Build assets"

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -2,8 +2,6 @@ name: Code Quality
 
 on:
   push:
-    branches:
-      - '*.x'
   pull_request:
 
 concurrency:
@@ -11,30 +9,74 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  quality:
+  phpstan:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: [8.5, 8.4, 8.3]
+        laravel: [12.*, 11.*]
+        dependency-version: [prefer-stable]
+        include:
+          - laravel: 12.*
+            testbench: 10.*
+          - laravel: 11.*
+            testbench: 9.*
+          - php: 8.5
+            pest: ^4.0
+            pest-plugin-laravel: ^4.0
+          - php: 8.4
+            pest: ^4.0
+            pest-plugin-laravel: ^4.0
+          - php: 8.3
+            pest: ^4.0
+            pest-plugin-laravel: ^4.0
+    name: PHP${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
-        with:
-          ref: ${{ github.head_ref }}
-      - name: Cache dependencies
+      - name: Cache Composer dependencies
         uses: actions/cache@v5
         with:
           path: ~/.composer/cache/files
-          key: quality-php-8.4-composer-${{ hashFiles('composer.json') }}
+          key: composer-${{ matrix.php }}-${{ matrix.laravel }}-${{ hashFiles('composer.json') }}
+          restore-keys: |
+            composer-${{ matrix.php }}-${{ matrix.laravel }}-
+            composer-${{ matrix.php }}-
+      - name: Cache PHPStan result
+        uses: actions/cache@v5
+        with:
+          path: /tmp/phpstan
+          key: phpstan-${{ matrix.php }}-${{ matrix.laravel }}-${{ github.sha }}
+          restore-keys: |
+            phpstan-${{ matrix.php }}-${{ matrix.laravel }}-
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.4
+          php-version: ${{ matrix.php }}
           extensions: mbstring, pdo, pdo_sqlite, intl, gd, exif, iconv, imagick
           tools: composer:v2
           coverage: none
       - name: Install dependencies
-        run: composer install --no-interaction
-      - name: Run Rector
-        run: composer test:refactor
-      - name: Run Laravel Pint
-        run: composer test:lint
+        run: |
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "pestphp/pest:${{ matrix.pest }}" "pestphp/pest-plugin-laravel:${{ matrix.pest-plugin-laravel }}" --no-interaction --no-update
+          composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
       - name: Run PHPStan
         run: composer test:types
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.4
+          extensions: mbstring, pdo, pdo_sqlite, intl
+          tools: composer:v2
+          coverage: none
+      - name: Install dependencies
+        run: composer install --no-interaction
+      - name: Run Laravel Pint
+        run: composer test:lint

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,8 +2,6 @@ name: tests
 
 on:
   push:
-    branches:
-      - '*.x'
   pull_request:
 
 concurrency:
@@ -25,6 +23,9 @@ jobs:
             testbench: 10.*
           - laravel: 11.*
             testbench: 9.*
+        exclude:
+          - laravel: 11.*
+            php: 8.5
     name: PHP:${{ matrix.php }} - Laravel:${{ matrix.laravel }} - DB:${{ matrix.db }}
     services:
       mysql:
@@ -78,6 +79,8 @@ jobs:
             echo "Waiting for Postgres ($i) ..." && sleep 2
           done
           echo "Postgres did not become ready in time" && exit
+      - name: Cache Blade views
+        run: ./vendor/bin/testbench view:cache
       - name: Execute tests
         run: ./vendor/bin/pest --configuration=phpunit.${{ matrix.db }}.xml --parallel
         env:


### PR DESCRIPTION
## Summary

- Replace dynamic branch conditions with hardcoded `2.x` in `monorepo-split.yml`, switch trigger to tags-only
- Update `quality.yml`: PHPStan matrix (PHP 8.3–8.5 × Laravel 11/12), add PHPStan result cache, add separate `lint` job for Pint, remove Rector
- Update `tests.yml`: remove PHP 8.2, add L11+PHP8.5 exclude, add Blade view cache step
- Update `npm-build.yml`: hardcode `2.x` branch references