### PR TITLE
fix: rename 2FA columns to avoid collision with Laravel Fortify

### DIFF
--- a/packages/admin/resources/views/livewire/components/account/two-factor.blade.php
+++ b/packages/admin/resources/views/livewire/components/account/two-factor.blade.php
@@ -95,7 +95,7 @@
                                 <div
                                     class="mt-4 grid max-w-xl gap-1 rounded-lg bg-gray-50 p-4 text-sm dark:bg-gray-700"
                                 >
-                                    @foreach (json_decode(decrypt($this->user->two_factor_recovery_codes), true) as $code)
+                                    @foreach (json_decode(decrypt($this->user->store_two_factor_recovery_codes), true) as $code)
                                         <span class="leading-5 text-gray-700 dark:text-gray-300">
                                             {{ $code }}
                                         </span>

--- a/packages/admin/resources/views/livewire/components/customers/profile.blade.php
+++ b/packages/admin/resources/views/livewire/components/customers/profile.blade.php
@@ -103,8 +103,8 @@
                         {{ __('shopper::pages/customers.profile.two_factor') }}
                     </dt>
                     <dd class="flex text-sm sm:col-span-2 sm:mt-0">
-                        <x-filament::badge :color="$customer->two_factor_secret ? 'success' : 'gray'" size="sm">
-                            {{ $customer->two_factor_secret ? __('shopper::forms.actions.enable') : __('shopper::forms.actions.disable') }}
+                        <x-filament::badge :color="$customer->store_two_factor_secret ? 'success' : 'gray'" size="sm">
+                            {{ $customer->store_two_factor_secret ? __('shopper::forms.actions.enable') : __('shopper::forms.actions.disable') }}
                         </x-filament::badge>
                     </dd>
                 </div>

--- a/packages/admin/src/Actions/Auth/DisableTwoFactorAuthentication.php
+++ b/packages/admin/src/Actions/Auth/DisableTwoFactorAuthentication.php
@@ -11,8 +11,8 @@ class DisableTwoFactorAuthentication
     public function __invoke(ShopperUser $user): void
     {
         $user->forceFill([
-            'two_factor_secret' => null,
-            'two_factor_recovery_codes' => null,
+            'store_two_factor_secret' => null,
+            'store_two_factor_recovery_codes' => null,
         ])->save();
     }
 }

--- a/packages/admin/src/Actions/Auth/EnableTwoFactorAuthentication.php
+++ b/packages/admin/src/Actions/Auth/EnableTwoFactorAuthentication.php
@@ -16,8 +16,8 @@ class EnableTwoFactorAuthentication
     public function __invoke(ShopperUser $user): void
     {
         $user->forceFill([
-            'two_factor_secret' => encrypt($this->provider->generateSecretKey()),
-            'two_factor_recovery_codes' => encrypt(json_encode(
+            'store_two_factor_secret' => encrypt($this->provider->generateSecretKey()),
+            'store_two_factor_recovery_codes' => encrypt(json_encode(
                 Collection::times(8, fn (): string => RecoveryCode::generate())->all()
             )),
         ])->save();

--- a/packages/admin/src/Actions/Auth/GenerateNewRecoveryCodes.php
+++ b/packages/admin/src/Actions/Auth/GenerateNewRecoveryCodes.php
@@ -12,7 +12,7 @@ class GenerateNewRecoveryCodes
     public function __invoke(ShopperUser $user): void
     {
         $user->forceFill([
-            'two_factor_recovery_codes' => encrypt(json_encode(
+            'store_two_factor_recovery_codes' => encrypt(json_encode(
                 Collection::times(8, fn (): string => RecoveryCode::generate())->all()
             )),
         ])->save();

--- a/packages/admin/src/Livewire/Components/Account/TwoFactor.php
+++ b/packages/admin/src/Livewire/Components/Account/TwoFactor.php
@@ -105,7 +105,7 @@ class TwoFactor extends Component implements HasActions, HasForms
     #[Computed]
     public function enabled(): bool
     {
-        return ! empty($this->user->two_factor_secret);
+        return ! empty($this->user->store_two_factor_secret);
     }
 
     public function render(): View

--- a/packages/admin/src/Livewire/Pages/Auth/Login.php
+++ b/packages/admin/src/Livewire/Pages/Auth/Login.php
@@ -161,7 +161,7 @@ final class Login extends Component implements HasForms
     private function shouldChallenge(mixed $user): bool
     {
         return config('shopper.auth.2fa_enabled')
-            && $user->two_factor_secret
+            && $user->store_two_factor_secret
             && in_array(TwoFactorAuthenticatable::class, class_uses_recursive($user));
     }
 
@@ -182,7 +182,7 @@ final class Login extends Component implements HasForms
             $user->replaceRecoveryCode($validCode);
         } else {
             $isValid = app(TwoFactorAuthenticationProvider::class)->verify(
-                decrypt($user->two_factor_secret),
+                decrypt($user->store_two_factor_secret),
                 $data['code'],
             );
 

--- a/packages/admin/src/Traits/InteractsWithShopper.php
+++ b/packages/admin/src/Traits/InteractsWithShopper.php
@@ -15,8 +15,8 @@ use Shopper\Core\Models\Traits\HasDiscounts;
 use Spatie\Permission\Traits\HasRoles;
 
 /**
- * @property-read ?string $two_factor_recovery_codes
- * @property-read ?string $two_factor_secret
+ * @property-read ?string $store_two_factor_recovery_codes
+ * @property-read ?string $store_two_factor_secret
  * @property-read Collection<int, Order> $orders
  * @property-read Collection<int, Address> $addresses
  */

--- a/packages/admin/src/Traits/TwoFactorAuthenticatable.php
+++ b/packages/admin/src/Traits/TwoFactorAuthenticatable.php
@@ -17,16 +17,16 @@ trait TwoFactorAuthenticatable
 {
     public function recoveryCodes(): array
     {
-        return json_decode(decrypt($this->two_factor_recovery_codes), true);
+        return json_decode(decrypt($this->store_two_factor_recovery_codes), true);
     }
 
     public function replaceRecoveryCode(string $code): void
     {
         $this->forceFill([
-            'two_factor_recovery_codes' => encrypt(str_replace(
+            'store_two_factor_recovery_codes' => encrypt(str_replace(
                 $code,
                 RecoveryCode::generate(),
-                decrypt($this->two_factor_recovery_codes)
+                decrypt($this->store_two_factor_recovery_codes)
             )),
         ])->save();
     }
@@ -48,7 +48,7 @@ trait TwoFactorAuthenticatable
         return app(TwoFactorAuthenticationProvider::class)->qrCodeUrl(
             config('app.name'),
             $this->email,
-            decrypt($this->two_factor_secret)
+            decrypt($this->store_two_factor_secret)
         );
     }
 }

--- a/packages/core/database/migrations/2026_03_10_000000_rename_two_factor_columns_on_users_table.php
+++ b/packages/core/database/migrations/2026_03_10_000000_rename_two_factor_columns_on_users_table.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Shopper\Core\Helpers\Migration;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', static function (Blueprint $table): void {
+            $table->renameColumn('two_factor_secret', 'store_two_factor_secret');
+            $table->renameColumn('two_factor_recovery_codes', 'store_two_factor_recovery_codes');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', static function (Blueprint $table): void {
+            $table->renameColumn('store_two_factor_secret', 'two_factor_secret');
+            $table->renameColumn('store_two_factor_recovery_codes', 'two_factor_recovery_codes');
+        });
+    }
+};

--- a/tests/Admin/Actions/Auth/TwoFactorAuthenticationActionsTest.php
+++ b/tests/Admin/Actions/Auth/TwoFactorAuthenticationActionsTest.php
@@ -20,10 +20,10 @@ describe('EnableTwoFactorAuthentication', function (): void {
 
         $action($user);
 
-        expect($user->two_factor_secret)->not->toBeNull()
-            ->and($user->two_factor_recovery_codes)->not->toBeNull();
+        expect($user->store_two_factor_secret)->not->toBeNull()
+            ->and($user->store_two_factor_recovery_codes)->not->toBeNull();
 
-        $recoveryCodes = json_decode(decrypt($user->two_factor_recovery_codes), true);
+        $recoveryCodes = json_decode(decrypt($user->store_two_factor_recovery_codes), true);
         expect($recoveryCodes)->toHaveCount(8);
 
         Event::assertDispatched(TwoFactorAuthenticationEnabled::class);
@@ -35,10 +35,10 @@ describe('EnableTwoFactorAuthentication', function (): void {
 
         $action($user);
 
-        $secret = decrypt($user->two_factor_secret);
+        $secret = decrypt($user->store_two_factor_secret);
         expect($secret)->toBeString()->not->toBeEmpty();
 
-        $recoveryCodes = json_decode(decrypt($user->two_factor_recovery_codes), true);
+        $recoveryCodes = json_decode(decrypt($user->store_two_factor_recovery_codes), true);
         expect($recoveryCodes)->toBeArray();
 
         foreach ($recoveryCodes as $code) {
@@ -50,47 +50,47 @@ describe('EnableTwoFactorAuthentication', function (): void {
 describe('DisableTwoFactorAuthentication', function (): void {
     it('can disable two factor authentication', function (): void {
         $user = User::factory()->create([
-            'two_factor_secret' => encrypt('secret'),
-            'two_factor_recovery_codes' => encrypt(json_encode(['code1', 'code2'])),
+            'store_two_factor_secret' => encrypt('secret'),
+            'store_two_factor_recovery_codes' => encrypt(json_encode(['code1', 'code2'])),
         ]);
 
         $action = app(DisableTwoFactorAuthentication::class);
         $action($user);
 
-        expect($user->fresh()->two_factor_secret)->toBeNull()
-            ->and($user->fresh()->two_factor_recovery_codes)->toBeNull();
+        expect($user->fresh()->store_two_factor_secret)->toBeNull()
+            ->and($user->fresh()->store_two_factor_recovery_codes)->toBeNull();
     });
 })->group('two-factor', 'actions');
 
 describe('GenerateNewRecoveryCodes', function (): void {
     it('can generate new recovery codes', function (): void {
         $user = User::factory()->create([
-            'two_factor_secret' => encrypt('secret'),
-            'two_factor_recovery_codes' => encrypt(json_encode(['old-code'])),
+            'store_two_factor_secret' => encrypt('secret'),
+            'store_two_factor_recovery_codes' => encrypt(json_encode(['old-code'])),
         ]);
 
-        $oldCodes = $user->two_factor_recovery_codes;
+        $oldCodes = $user->store_two_factor_recovery_codes;
 
         $action = app(GenerateNewRecoveryCodes::class);
         $action($user);
 
-        expect($user->fresh()->two_factor_recovery_codes)->not->toBe($oldCodes);
+        expect($user->fresh()->store_two_factor_recovery_codes)->not->toBe($oldCodes);
 
-        $newCodes = json_decode(decrypt($user->fresh()->two_factor_recovery_codes), true);
+        $newCodes = json_decode(decrypt($user->fresh()->store_two_factor_recovery_codes), true);
         expect($newCodes)->toHaveCount(8);
     });
 
     it('keeps the two factor secret when regenerating codes', function (): void {
         $user = User::factory()->create([
-            'two_factor_secret' => encrypt('original-secret'),
-            'two_factor_recovery_codes' => encrypt(json_encode(['old-code'])),
+            'store_two_factor_secret' => encrypt('original-secret'),
+            'store_two_factor_recovery_codes' => encrypt(json_encode(['old-code'])),
         ]);
 
-        $originalSecret = $user->two_factor_secret;
+        $originalSecret = $user->store_two_factor_secret;
 
         $action = app(GenerateNewRecoveryCodes::class);
         $action($user);
 
-        expect($user->fresh()->two_factor_secret)->toBe($originalSecret);
+        expect($user->fresh()->store_two_factor_secret)->toBe($originalSecret);
     });
 })->group('two-factor', 'actions');

--- a/tests/Admin/Auth/LoginTwoFactorTest.php
+++ b/tests/Admin/Auth/LoginTwoFactorTest.php
@@ -16,8 +16,8 @@ beforeEach(function (): void {
     $this->secret = $google2fa->generateSecretKey();
 
     $this->user = User::factory()->create([
-        'two_factor_secret' => encrypt($this->secret),
-        'two_factor_recovery_codes' => encrypt(json_encode([
+        'store_two_factor_secret' => encrypt($this->secret),
+        'store_two_factor_recovery_codes' => encrypt(json_encode([
             'recovery-code-1',
             'recovery-code-2',
         ])),
@@ -109,7 +109,7 @@ describe('Login Two-Factor Authentication', function (): void {
             ->set('twoFactorData.recovery_code', 'recovery-code-1')
             ->call('authenticate');
 
-        $recoveryCodes = json_decode(decrypt($this->user->fresh()->two_factor_recovery_codes), true);
+        $recoveryCodes = json_decode(decrypt($this->user->fresh()->store_two_factor_recovery_codes), true);
 
         expect($recoveryCodes)->not->toContain('recovery-code-1');
     });
@@ -142,8 +142,8 @@ describe('Login Two-Factor Authentication', function (): void {
 
     it('does not challenge user without two factor secret', function (): void {
         $userWithout2fa = User::factory()->create([
-            'two_factor_secret' => null,
-            'two_factor_recovery_codes' => null,
+            'store_two_factor_secret' => null,
+            'store_two_factor_recovery_codes' => null,
         ]);
 
         Livewire::test(Login::class)

--- a/tests/Admin/Livewire/Components/Account/TwoFactorTest.php
+++ b/tests/Admin/Livewire/Components/Account/TwoFactorTest.php
@@ -41,16 +41,16 @@ describe(TwoFactor::class, function (): void {
 
         $user = $this->user->fresh();
 
-        expect($user->two_factor_secret)->not->toBeNull()
-            ->and($user->two_factor_recovery_codes)->not->toBeNull();
+        expect($user->store_two_factor_secret)->not->toBeNull()
+            ->and($user->store_two_factor_recovery_codes)->not->toBeNull();
 
         Event::assertDispatched(TwoFactorAuthenticationEnabled::class);
     });
 
     it('shows enabled state when user has two factor secret', function (): void {
         $this->user->forceFill([
-            'two_factor_secret' => encrypt('secret'),
-            'two_factor_recovery_codes' => encrypt(json_encode(['code1', 'code2'])),
+            'store_two_factor_secret' => encrypt('secret'),
+            'store_two_factor_recovery_codes' => encrypt(json_encode(['code1', 'code2'])),
         ])->save();
 
         Livewire::test(TwoFactor::class)
@@ -59,8 +59,8 @@ describe(TwoFactor::class, function (): void {
 
     it('can show recovery codes', function (): void {
         $this->user->forceFill([
-            'two_factor_secret' => encrypt('secret'),
-            'two_factor_recovery_codes' => encrypt(json_encode(['code1', 'code2'])),
+            'store_two_factor_secret' => encrypt('secret'),
+            'store_two_factor_recovery_codes' => encrypt(json_encode(['code1', 'code2'])),
         ])->save();
 
         Livewire::test(TwoFactor::class)
@@ -70,11 +70,11 @@ describe(TwoFactor::class, function (): void {
 
     it('can regenerate recovery codes', function (): void {
         $this->user->forceFill([
-            'two_factor_secret' => encrypt('original-secret'),
-            'two_factor_recovery_codes' => encrypt(json_encode(['old-code'])),
+            'store_two_factor_secret' => encrypt('original-secret'),
+            'store_two_factor_recovery_codes' => encrypt(json_encode(['old-code'])),
         ])->save();
 
-        $oldCodes = $this->user->two_factor_recovery_codes;
+        $oldCodes = $this->user->store_two_factor_recovery_codes;
 
         Livewire::test(TwoFactor::class)
             ->call('regenerateRecoveryCodes', app(GenerateNewRecoveryCodes::class))
@@ -82,13 +82,13 @@ describe(TwoFactor::class, function (): void {
 
         $user = $this->user->fresh();
 
-        expect($user->two_factor_recovery_codes)->not->toBe($oldCodes);
+        expect($user->store_two_factor_recovery_codes)->not->toBe($oldCodes);
     });
 
     it('can disable two factor authentication', function (): void {
         $this->user->forceFill([
-            'two_factor_secret' => encrypt('secret'),
-            'two_factor_recovery_codes' => encrypt(json_encode(['code1', 'code2'])),
+            'store_two_factor_secret' => encrypt('secret'),
+            'store_two_factor_recovery_codes' => encrypt(json_encode(['code1', 'code2'])),
         ])->save();
 
         Livewire::test(TwoFactor::class)
@@ -96,8 +96,8 @@ describe(TwoFactor::class, function (): void {
 
         $user = $this->user->fresh();
 
-        expect($user->two_factor_secret)->toBeNull()
-            ->and($user->two_factor_recovery_codes)->toBeNull();
+        expect($user->store_two_factor_secret)->toBeNull()
+            ->and($user->store_two_factor_recovery_codes)->toBeNull();
     });
 
     it('returns authenticated user from user property', function (): void {

--- a/tests/Core/Stubs/User.php
+++ b/tests/Core/Stubs/User.php
@@ -23,8 +23,8 @@ class User extends Authenticatable implements ShopperUser
         'remember_token',
         'last_login_at',
         'last_login_ip',
-        'two_factor_recovery_codes',
-        'two_factor_secret',
+        'store_two_factor_recovery_codes',
+        'store_two_factor_secret',
     ];
 
     protected static function newFactory(): UserFactory


### PR DESCRIPTION
## Summary

- Rename `two_factor_secret` → `store_two_factor_secret`
- Rename `two_factor_recovery_codes` → `store_two_factor_recovery_codes`
- Add migration `2026_03_10_000000_rename_two_factor_columns_on_users_table` to handle existing installations

Fixes the column collision that occurs when Shopper is used alongside Laravel starter kits shipping with Fortify's built-in 2FA system (e.g. Breeze with 2FA, Jetstream).