### PR TITLE
[3.x] fix(panel): replace serialize() with json_encode() + fix empty state permissions

### DIFF
--- a/packages/admin/resources/views/livewire/tables/empty-states/attributes.blade.php
+++ b/packages/admin/resources/views/livewire/tables/empty-states/attributes.blade.php
@@ -2,7 +2,7 @@
     :title="__('shopper::pages/attributes.title')"
     :content="__('shopper::pages/attributes.content')"
     :button="__('shopper::pages/attributes.add')"
-    permission="add_attributes"
+    permission="attributes.create"
     panel="{ component: 'shopper-slide-overs.attribute-form' }"
 >
     <div class="shrink-0">

--- a/packages/admin/resources/views/livewire/tables/empty-states/brands.blade.php
+++ b/packages/admin/resources/views/livewire/tables/empty-states/brands.blade.php
@@ -3,7 +3,7 @@
     :content="__('shopper::pages/brands.content')"
     :button="__('shopper::forms.actions.add_label', ['label' => __('shopper::pages/brands.single')])"
     panel="{ component: 'shopper-slide-overs.brand-form' }"
-    permission="add_brands"
+    permission="brands.create"
 >
     <div class="shrink-0">
         <svg

--- a/packages/admin/resources/views/livewire/tables/empty-states/categories.blade.php
+++ b/packages/admin/resources/views/livewire/tables/empty-states/categories.blade.php
@@ -2,7 +2,7 @@
     :title="__('shopper::pages/categories.title')"
     :content="__('shopper::pages/categories.content')"
     :button="__('shopper::forms.actions.add_label', ['label' => __('shopper::pages/categories.single')])"
-    permission="add_categories"
+    permission="categories.create"
     panel="{ component: 'shopper-slide-overs.category-form' }"
 >
     <div class="shrink-0">

--- a/packages/admin/resources/views/livewire/tables/empty-states/collections.blade.php
+++ b/packages/admin/resources/views/livewire/tables/empty-states/collections.blade.php
@@ -2,7 +2,7 @@
     :title="__('shopper::pages/collections.title')"
     :content="__('shopper::pages/collections.content')"
     :button="__('shopper::forms.actions.add_label', ['label' => __('shopper::pages/collections.single')])"
-    permission="add_collections"
+    permission="collections.create"
     panel="{ component: 'shopper-slide-overs.add-collection-form' }"
 >
     <div class="shrink-0">

--- a/packages/admin/resources/views/livewire/tables/empty-states/customers.blade.php
+++ b/packages/admin/resources/views/livewire/tables/empty-states/customers.blade.php
@@ -2,7 +2,7 @@
     :title="__('shopper::pages/customers.title')"
     :content="__('shopper::pages/customers.content')"
     :button="__('shopper::forms.actions.add_label', ['label' => __('shopper::pages/customers.single')])"
-    permission="add_customers"
+    permission="customers.create"
     :url="route('shopper.customers.create')"
 >
     <div class="shrink-0">

--- a/packages/admin/resources/views/livewire/tables/empty-states/discounts.blade.php
+++ b/packages/admin/resources/views/livewire/tables/empty-states/discounts.blade.php
@@ -2,7 +2,7 @@
     :title="__('shopper::pages/discounts.title')"
     :content="__('shopper::pages/discounts.description')"
     :button="__('shopper::forms.actions.add_label', ['label' => __('shopper::pages/discounts.single')])"
-    permission="add_discounts"
+    permission="discounts.create"
     panel="{ component: 'shopper-slide-overs.discount-form' }"
 >
     <div class="shrink-0">

--- a/packages/admin/resources/views/livewire/tables/empty-states/products.blade.php
+++ b/packages/admin/resources/views/livewire/tables/empty-states/products.blade.php
@@ -3,7 +3,7 @@
     :content="__('shopper::pages/products.content')"
     :button="__('shopper::forms.actions.add_label', ['label' => __('shopper::pages/products.single')])"
     panel="{ component: 'shopper-slide-overs.add-product' }"
-    permission="add_products"
+    permission="products.create"
     class="lg:pb-0"
 >
     <div class="shrink-0">

--- a/packages/admin/resources/views/livewire/tables/empty-states/suppliers.blade.php
+++ b/packages/admin/resources/views/livewire/tables/empty-states/suppliers.blade.php
@@ -3,7 +3,7 @@
     :content="__('shopper::pages/suppliers.content')"
     :button="__('shopper::forms.actions.add_label', ['label' => __('shopper::pages/suppliers.single')])"
     panel="{ component: 'shopper-slide-overs.supplier-form' }"
-    permission="add_suppliers"
+    permission="suppliers.create"
 >
     <div class="shrink-0">
         <svg

--- a/packages/admin/src/Livewire/Components/SlideOverPanel.php
+++ b/packages/admin/src/Livewire/Components/SlideOverPanel.php
@@ -51,7 +51,7 @@ class SlideOverPanel extends Component
             throw new Exception("[{$componentClass}] does not implement [{$requiredInterface}] interface.");
         }
 
-        $id = md5($component.serialize($arguments));
+        $id = md5($component.json_encode($arguments));
 
         $arguments = collect($arguments)
             ->merge($this->resolveComponentProps($arguments, new $componentClass))


### PR DESCRIPTION
## Summary

- **`SlideOverPanel`**: replace `serialize(\$arguments)` with `json_encode(\$arguments)` for component ID generation. `serialize()` is non-deterministic on Eloquent models (eager-loaded attributes produce different output for the same model) and throws a fatal exception when arguments contain non-serializable objects like closures.
- **Empty states**: fix 8 views in `tables/empty-states/` that still referenced old permission names (`add_brands`, `add_products`…) instead of the dot-notation format introduced in #452 (`brands.create`, `products.create`…). The "Add" button was hidden for all users regardless of their role.