### PR TITLE
Migrate SlideOverPanel to #[On] attributes and extract close-icon component

### DIFF
--- a/packages/admin/resources/views/components/form-slider-over.blade.php
+++ b/packages/admin/resources/views/components/form-slider-over.blade.php
@@ -10,17 +10,7 @@
             <h2 class="text-lg font-medium text-gray-900 dark:text-white">
                 {{ $title }}
             </h2>
-            <div class="ml-3 flex h-7 items-center gap-2">
-                <x-shopper::escape />
-                <button
-                    type="button"
-                    class="rounded-md bg-white text-gray-400 outline-none hover:text-gray-500 dark:bg-gray-900 dark:text-gray-500 dark:hover:text-gray-300"
-                    wire:click="$dispatch('closePanel')"
-                >
-                    <span class="sr-only">Close panel</span>
-                    <x-untitledui-x class="size-6" stroke-width="1.5" aria-hidden="true" />
-                </button>
-            </div>
+            <x-shopper::close-icon />
         </div>
 
         @if ($description)

--- a/packages/admin/resources/views/livewire/slide-overs/add-product-form.blade.php
+++ b/packages/admin/resources/views/livewire/slide-overs/add-product-form.blade.php
@@ -4,17 +4,7 @@
             <h2 class="text-lg font-medium text-gray-900 dark:text-white">
                 {{ __('shopper::forms.actions.add_label', ['label' => __('shopper::pages/products.single')]) }}
             </h2>
-            <div class="ml-3 flex h-7 items-center gap-2">
-                <x-shopper::escape />
-                <button
-                    type="button"
-                    class="rounded-md bg-white text-gray-400 outline-none hover:text-gray-500 dark:bg-gray-900 dark:text-gray-500 dark:hover:text-gray-300"
-                    wire:click="$dispatch('closePanel')"
-                >
-                    <span class="sr-only">Close panel</span>
-                    <x-untitledui-x class="size-6" stroke-width="1.5" aria-hidden="true" />
-                </button>
-            </div>
+            <x-shopper::close-icon />
         </div>
     </header>
 

--- a/packages/admin/resources/views/livewire/slide-overs/add-variant.blade.php
+++ b/packages/admin/resources/views/livewire/slide-overs/add-variant.blade.php
@@ -4,17 +4,7 @@
             <h2 class="text-lg font-medium text-gray-900 dark:text-white">
                 {{ __('shopper::pages/products.modals.variants.add') }}
             </h2>
-            <div class="ml-3 flex h-7 items-center gap-2">
-                <x-shopper::escape />
-                <button
-                    type="button"
-                    class="focus:ring-primary-500 rounded-md bg-white text-gray-400 outline-none hover:text-gray-500 focus:ring-2 focus:ring-offset-2 dark:bg-gray-900 dark:text-gray-500 dark:ring-offset-gray-900 dark:hover:text-gray-300"
-                    wire:click="$dispatch('closePanel')"
-                >
-                    <span class="sr-only">Close panel</span>
-                    <x-untitledui-x class="size-6" stroke-width="1.5" aria-hidden="true" />
-                </button>
-            </div>
+            <x-shopper::close-icon />
         </div>
     </header>
 

--- a/packages/admin/resources/views/livewire/slide-overs/attribute-values.blade.php
+++ b/packages/admin/resources/views/livewire/slide-overs/attribute-values.blade.php
@@ -10,17 +10,7 @@
                         {{ $attribute->name }}
                     </x-filament::badge>
                 </div>
-                <div class="ml-3 flex h-7 items-center gap-2">
-                    <x-shopper::escape />
-                    <button
-                        type="button"
-                        class="rounded-md bg-white text-gray-400 hover:text-gray-500 focus:outline-none dark:bg-gray-900 dark:text-gray-500 dark:hover:text-gray-300"
-                        wire:click="$dispatch('closePanel')"
-                    >
-                        <span class="sr-only">Close panel</span>
-                        <x-untitledui-x class="size-6" stroke-width="1.5" aria-hidden="true" />
-                    </button>
-                </div>
+                <x-shopper::close-icon />
             </div>
             <div class="mt-1">
                 <p class="text-sm text-gray-500 dark:text-gray-400">

--- a/packages/admin/resources/views/livewire/slide-overs/choose-product-attributes.blade.php
+++ b/packages/admin/resources/views/livewire/slide-overs/choose-product-attributes.blade.php
@@ -4,17 +4,7 @@
             <h2 class="text-lg font-medium text-gray-900 dark:text-white">
                 {{ __('shopper::pages/products.attributes.choose') }}
             </h2>
-            <div class="ml-3 flex h-7 items-center gap-2">
-                <x-shopper::escape />
-                <button
-                    type="button"
-                    class="focus:ring-primary-500 rounded-md bg-white text-gray-400 outline-none hover:text-gray-500 focus:ring-2 focus:ring-offset-2 dark:bg-gray-900 dark:text-gray-500 dark:ring-offset-gray-900 dark:hover:text-gray-300"
-                    wire:click="$dispatch('closePanel')"
-                >
-                    <span class="sr-only">Close panel</span>
-                    <x-untitledui-x class="size-6" stroke-width="1.5" aria-hidden="true" />
-                </button>
-            </div>
+            <x-shopper::close-icon />
         </div>
     </header>
 

--- a/packages/admin/resources/views/livewire/slide-overs/collection-products-list.blade.php
+++ b/packages/admin/resources/views/livewire/slide-overs/collection-products-list.blade.php
@@ -5,17 +5,7 @@
                 <h2 class="text-lg font-medium text-gray-900 dark:text-white">
                     {{ __('shopper::pages/collections.modal.title') }}
                 </h2>
-                <div class="ml-3 flex h-7 items-center gap-2">
-                    <x-shopper::escape />
-                    <button
-                        type="button"
-                        class="focus:ring-primary-500 rounded-md bg-white text-gray-400 hover:text-gray-500 focus:ring-2 focus:ring-offset-2 focus:outline-none dark:bg-gray-900 dark:text-gray-500 dark:ring-offset-gray-900 dark:hover:text-gray-300"
-                        wire:click="$dispatch('closePanel')"
-                    >
-                        <span class="sr-only">Close panel</span>
-                        <x-untitledui-x class="size-6" stroke-width="1.5" aria-hidden="true" />
-                    </button>
-                </div>
+                <x-shopper::close-icon />
             </div>
         </header>
         <div class="mt-6 flex-1 px-4 sm:px-6">

--- a/packages/admin/resources/views/livewire/slide-overs/create-shipping-label.blade.php
+++ b/packages/admin/resources/views/livewire/slide-overs/create-shipping-label.blade.php
@@ -4,17 +4,7 @@
             <h2 class="text-lg font-medium text-gray-900 dark:text-white">
                 {{ __('shopper::pages/orders.create_shipping_label') }}
             </h2>
-            <div class="ml-3 flex h-7 items-center gap-2">
-                <x-shopper::escape />
-                <button
-                    type="button"
-                    class="rounded-md bg-white text-gray-400 outline-none hover:text-gray-500 dark:bg-gray-900 dark:text-gray-500 dark:hover:text-gray-300"
-                    wire:click="$dispatch('closePanel')"
-                >
-                    <span class="sr-only">Close panel</span>
-                    <x-untitledui-x class="size-6" stroke-width="1.5" aria-hidden="true" />
-                </button>
-            </div>
+            <x-shopper::close-icon />
         </div>
     </header>
 

--- a/packages/admin/resources/views/livewire/slide-overs/shipment-detail.blade.php
+++ b/packages/admin/resources/views/livewire/slide-overs/shipment-detail.blade.php
@@ -68,17 +68,7 @@
                         </span>
                     </p>
                 </div>
-                <div class="ml-3 flex h-7 items-center gap-2">
-                    <x-shopper::escape />
-                    <button
-                        type="button"
-                        class="rounded-md bg-white text-gray-400 outline-none hover:text-gray-500 dark:bg-gray-900 dark:text-gray-500 dark:hover:text-gray-300"
-                        wire:click="$dispatch('closePanel')"
-                    >
-                        <span class="sr-only">Close panel</span>
-                        <x-untitledui-x class="size-6" stroke-width="1.5" aria-hidden="true" />
-                    </button>
-                </div>
+                <x-shopper::close-icon />
             </div>
 
             @if ($shippingAddress || $carrier)

--- a/packages/admin/src/Livewire/Components/SlideOverPanel.php
+++ b/packages/admin/src/Livewire/Components/SlideOverPanel.php
@@ -10,6 +10,7 @@ use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Reflector;
+use Livewire\Attributes\On;
 use Livewire\Component;
 use Livewire\Mechanisms\ComponentRegistry;
 use ReflectionClass;
@@ -39,6 +40,7 @@ class SlideOverPanel extends Component
      *
      * @throws ReflectionException
      */
+    #[On('openPanel')]
     public function openPanel(string $component, array $arguments = [], array $panelAttributes = []): void
     {
         $requiredInterface = PanelContract::class;
@@ -95,20 +97,10 @@ class SlideOverPanel extends Component
             ->filter();
     }
 
+    #[On('destroyComponent')]
     public function destroyComponent(string $id): void
     {
         unset($this->components[$id]);
-    }
-
-    /**
-     * @return array<string>
-     */
-    public function getListeners(): array
-    {
-        return [
-            'openPanel',
-            'destroyComponent',
-        ];
     }
 
     public function render(): View

--- a/packages/admin/src/Livewire/SlideOvers/ReOrderCategories.php
+++ b/packages/admin/src/Livewire/SlideOvers/ReOrderCategories.php
@@ -43,7 +43,7 @@ class ReOrderCategories extends SlideOverComponent
     {
         return view('shopper::livewire.slide-overs.re-order-categories', [
             'categories' => resolve(Category::class)::query()
-                ->with('children')
+                ->with('children.children.children')
                 ->whereNull('parent_id')
                 ->orderBy('position')
                 ->get(),


### PR DESCRIPTION
## Summary

- Replace `getListeners()` with `#[On]` attributes on `openPanel()` and `destroyComponent()` methods for Livewire 4 consistency
- Extract inline close button markup into reusable `<x-shopper::close-icon />` component across 8 slideover views
- Fix lazy loading on nested categories by eager-loading 3 levels deep (`children.children.children`)