### PR TITLE
Define PanelContract method signatures

### DIFF
--- a/packages/admin/src/Contracts/PanelContract.php
+++ b/packages/admin/src/Contracts/PanelContract.php
@@ -4,4 +4,19 @@ declare(strict_types=1);
 
 namespace Shopper\Contracts;
 
-interface PanelContract {}
+interface PanelContract
+{
+    public static function closePanelOnClickAway(): bool;
+
+    public static function closePanelOnEscape(): bool;
+
+    public static function closePanelOnEscapeIsForceful(): bool;
+
+    public static function dispatchCloseEvent(): bool;
+
+    public static function destroyOnClose(): bool;
+
+    public static function panelMaxWidth(): string;
+
+    public static function panelMaxWidthClass(): string;
+}


### PR DESCRIPTION
## Summary

- Enrich the empty `PanelContract` interface with the 7 static method signatures already implemented in `SlideOverComponent`
- Ensures type safety when `SlideOverPanel::openPanel()` calls these methods on any `PanelContract` implementor
- No behavioral change — `SlideOverComponent` already implements all methods