### PR TITLE
refactor: split TwoFactorAuthenticatable into SOLID interfaces and traits

### DIFF
--- a/packages/admin/resources/lang/en/pages/auth.php
+++ b/packages/admin/resources/lang/en/pages/auth.php
@@ -44,6 +44,9 @@ return [
         'use_recovery_code' => 'Use a recovery code',
         'use_authentication_code' => 'Use an authentication code',
         'action' => 'Login',
+        'recovery_not_enabled' => 'Recovery codes are not enabled for this account.',
+        'invalid_recovery_code' => 'The provided two factor recovery code was invalid.',
+        'invalid_code' => 'The provided two factor authentication code was invalid.',
     ],
 
     'account' => [

--- a/packages/admin/resources/lang/es/pages/auth.php
+++ b/packages/admin/resources/lang/es/pages/auth.php
@@ -42,6 +42,9 @@ return [
         'use_recovery_code' => 'Usar un código de recuperación',
         'use_authentication_code' => 'Usar un código de autenticación',
         'action' => 'Iniciar sesión',
+        'recovery_not_enabled' => 'Los códigos de recuperación no están habilitados para esta cuenta.',
+        'invalid_recovery_code' => 'El código de recuperación proporcionado no es válido.',
+        'invalid_code' => 'El código de autenticación de dos factores proporcionado no es válido.',
     ],
 
     'account' => [

--- a/packages/admin/resources/lang/fr/pages/auth.php
+++ b/packages/admin/resources/lang/fr/pages/auth.php
@@ -43,6 +43,9 @@ return [
         'use_recovery_code' => 'Utiliser un code de récupération',
         'use_authentication_code' => 'Utiliser un code d\'authentification',
         'action' => 'Connexion',
+        'recovery_not_enabled' => 'Les codes de récupération ne sont pas activés pour ce compte.',
+        'invalid_recovery_code' => 'Le code de récupération fourni est invalide.',
+        'invalid_code' => 'Le code d\'authentification à deux facteurs fourni est invalide.',
     ],
 
     'account' => [

--- a/packages/admin/resources/views/livewire/components/account/two-factor.blade.php
+++ b/packages/admin/resources/views/livewire/components/account/two-factor.blade.php
@@ -95,7 +95,7 @@
                                 <div
                                     class="mt-4 grid max-w-xl gap-1 rounded-lg bg-gray-50 p-4 text-sm dark:bg-gray-700"
                                 >
-                                    @foreach (json_decode(decrypt($this->user->store_two_factor_recovery_codes), true) as $code)
+                                    @foreach ($this->user->getStoreAuthenticationRecoveryCodes() as $code)
                                         <span class="leading-5 text-gray-700 dark:text-gray-300">
                                             {{ $code }}
                                         </span>

--- a/packages/admin/src/Actions/Auth/DisableTwoFactorAuthentication.php
+++ b/packages/admin/src/Actions/Auth/DisableTwoFactorAuthentication.php
@@ -4,15 +4,17 @@ declare(strict_types=1);
 
 namespace Shopper\Actions\Auth;
 
-use Shopper\Models\Contracts\ShopperUser;
+use Shopper\Contracts\HasStoreAuthentication;
+use Shopper\Contracts\HasStoreAuthenticationRecovery;
 
 class DisableTwoFactorAuthentication
 {
-    public function __invoke(ShopperUser $user): void
+    public function __invoke(HasStoreAuthentication $user): void
     {
-        $user->forceFill([
-            'store_two_factor_secret' => null,
-            'store_two_factor_recovery_codes' => null,
-        ])->save();
+        $user->saveStoreAuthenticationSecret(null);
+
+        if ($user instanceof HasStoreAuthenticationRecovery) {
+            $user->saveStoreAuthenticationRecoveryCodes(null);
+        }
     }
 }

--- a/packages/admin/src/Actions/Auth/EnableTwoFactorAuthentication.php
+++ b/packages/admin/src/Actions/Auth/EnableTwoFactorAuthentication.php
@@ -5,22 +5,24 @@ declare(strict_types=1);
 namespace Shopper\Actions\Auth;
 
 use Illuminate\Support\Collection;
+use Shopper\Contracts\HasStoreAuthentication;
+use Shopper\Contracts\HasStoreAuthenticationRecovery;
 use Shopper\Contracts\TwoFactorAuthenticationProvider;
 use Shopper\Events\TwoFactor\TwoFactorAuthenticationEnabled;
-use Shopper\Models\Contracts\ShopperUser;
 
 class EnableTwoFactorAuthentication
 {
     public function __construct(protected TwoFactorAuthenticationProvider $provider) {}
 
-    public function __invoke(ShopperUser $user): void
+    public function __invoke(HasStoreAuthentication $user): void
     {
-        $user->forceFill([
-            'store_two_factor_secret' => encrypt($this->provider->generateSecretKey()),
-            'store_two_factor_recovery_codes' => encrypt(json_encode(
+        $user->saveStoreAuthenticationSecret($this->provider->generateSecretKey());
+
+        if ($user instanceof HasStoreAuthenticationRecovery) {
+            $user->saveStoreAuthenticationRecoveryCodes(
                 Collection::times(8, fn (): string => RecoveryCode::generate())->all()
-            )),
-        ])->save();
+            );
+        }
 
         TwoFactorAuthenticationEnabled::dispatch($user);
     }

--- a/packages/admin/src/Actions/Auth/GenerateNewRecoveryCodes.php
+++ b/packages/admin/src/Actions/Auth/GenerateNewRecoveryCodes.php
@@ -5,16 +5,14 @@ declare(strict_types=1);
 namespace Shopper\Actions\Auth;
 
 use Illuminate\Support\Collection;
-use Shopper\Models\Contracts\ShopperUser;
+use Shopper\Contracts\HasStoreAuthenticationRecovery;
 
 class GenerateNewRecoveryCodes
 {
-    public function __invoke(ShopperUser $user): void
+    public function __invoke(HasStoreAuthenticationRecovery $user): void
     {
-        $user->forceFill([
-            'store_two_factor_recovery_codes' => encrypt(json_encode(
-                Collection::times(8, fn (): string => RecoveryCode::generate())->all()
-            )),
-        ])->save();
+        $user->saveStoreAuthenticationRecoveryCodes(
+            Collection::times(8, fn (): string => RecoveryCode::generate())->all()
+        );
     }
 }

--- a/packages/admin/src/Contracts/HasStoreAuthentication.php
+++ b/packages/admin/src/Contracts/HasStoreAuthentication.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Contracts;
+
+interface HasStoreAuthentication
+{
+    public function getStoreAuthenticationSecret(): ?string;
+
+    public function saveStoreAuthenticationSecret(?string $secret): void;
+
+    public function getStoreAuthenticationHolderName(): string;
+
+    public function getStoreAuthenticationQrCodeSvg(): string;
+
+    public function getStoreAuthenticationQrCodeUrl(): string;
+}

--- a/packages/admin/src/Contracts/HasStoreAuthenticationRecovery.php
+++ b/packages/admin/src/Contracts/HasStoreAuthenticationRecovery.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Contracts;
+
+interface HasStoreAuthenticationRecovery
+{
+    /** @return ?array<string> */
+    public function getStoreAuthenticationRecoveryCodes(): ?array;
+
+    /** @param ?array<string> $codes */
+    public function saveStoreAuthenticationRecoveryCodes(?array $codes): void;
+
+    public function replaceStoreAuthenticationRecoveryCode(string $code): void;
+}

--- a/packages/admin/src/Livewire/Components/Account/TwoFactor.php
+++ b/packages/admin/src/Livewire/Components/Account/TwoFactor.php
@@ -16,12 +16,13 @@ use Livewire\Component;
 use Shopper\Actions\Auth\DisableTwoFactorAuthentication;
 use Shopper\Actions\Auth\EnableTwoFactorAuthentication;
 use Shopper\Actions\Auth\GenerateNewRecoveryCodes;
-use Shopper\Models\Contracts\ShopperUser;
+use Shopper\Contracts\HasStoreAuthentication;
+use Shopper\Contracts\HasStoreAuthenticationRecovery;
 use Shopper\Traits\ConfirmsPasswords;
 use Shopper\Traits\HandlesAuthorizationExceptions;
 
 /**
- * @property-read ShopperUser $user
+ * @property-read HasStoreAuthentication&HasStoreAuthenticationRecovery $user
  */
 class TwoFactor extends Component implements HasActions, HasSchemas
 {
@@ -98,16 +99,16 @@ class TwoFactor extends Component implements HasActions, HasSchemas
     }
 
     #[Computed]
-    public function user(): ShopperUser
+    public function user(): HasStoreAuthentication
     {
-        /** @var ShopperUser */
+        /** @var HasStoreAuthentication */
         return shopper()->auth()->user();
     }
 
     #[Computed]
     public function enabled(): bool
     {
-        return ! empty($this->user->store_two_factor_secret);
+        return $this->user->getStoreAuthenticationSecret() !== null;
     }
 
     public function render(): View

--- a/packages/admin/src/Livewire/Pages/Auth/Login.php
+++ b/packages/admin/src/Livewire/Pages/Auth/Login.php
@@ -18,10 +18,11 @@ use Illuminate\Validation\ValidationException;
 use Livewire\Attributes\Layout;
 use Livewire\Attributes\Locked;
 use Livewire\Component;
+use Shopper\Contracts\HasStoreAuthentication;
+use Shopper\Contracts\HasStoreAuthenticationRecovery;
 use Shopper\Contracts\LoginResponse;
 use Shopper\Contracts\TwoFactorAuthenticationProvider;
 use Shopper\Facades\Shopper;
-use Shopper\Traits\TwoFactorAuthenticatable;
 
 /**
  * @property-read Schema $form
@@ -161,8 +162,8 @@ final class Login extends Component implements HasSchemas
     private function shouldChallenge(mixed $user): bool
     {
         return config('shopper.auth.2fa_enabled')
-            && $user->store_two_factor_secret
-            && in_array(TwoFactorAuthenticatable::class, class_uses_recursive($user));
+            && $user instanceof HasStoreAuthentication
+            && $user->getStoreAuthenticationSecret();
     }
 
     private function verifyTwoFactorCode(mixed $user): mixed
@@ -170,12 +171,19 @@ final class Login extends Component implements HasSchemas
         $data = $this->twoFactorForm->getState();
 
         if ($this->useRecoveryCode) {
-            $validCode = collect($user->getStoreAuthenticationRecoveryCodes())
-                ->first(fn ($code): bool => hash_equals($data['recovery_code'], $code));
-
-            if (! $validCode) {
+            if (! $user instanceof HasStoreAuthenticationRecovery) {
                 throw ValidationException::withMessages([
-                    'twoFactorData.recovery_code' => __('The provided two factor recovery code was invalid.'),
+                    'twoFactorData.recovery_code' => __('shopper::pages/auth.two_factor.recovery_not_enabled'),
+                ]);
+            }
+
+            /** @var ?string $validCode */
+            $validCode = collect($user->getStoreAuthenticationRecoveryCodes())
+                ->first(fn (string $code): bool => hash_equals($data['recovery_code'], $code));
+
+            if ($validCode === null) {
+                throw ValidationException::withMessages([
+                    'twoFactorData.recovery_code' => __('shopper::pages/auth.two_factor.invalid_recovery_code'),
                 ]);
             }
 
@@ -188,7 +196,7 @@ final class Login extends Component implements HasSchemas
 
             if (! $isValid) {
                 throw ValidationException::withMessages([
-                    'twoFactorData.code' => __('The provided two factor authentication code was invalid.'),
+                    'twoFactorData.code' => __('shopper::pages/auth.two_factor.invalid_code'),
                 ]);
             }
         }

--- a/packages/admin/src/Traits/InteractsWithShopper.php
+++ b/packages/admin/src/Traits/InteractsWithShopper.php
@@ -15,8 +15,6 @@ use Shopper\Core\Models\Traits\HasDiscounts;
 use Spatie\Permission\Traits\HasRoles;
 
 /**
- * @property-read ?string $store_two_factor_recovery_codes
- * @property-read ?string $store_two_factor_secret
  * @property-read Collection<int, Order> $orders
  * @property-read Collection<int, Address> $addresses
  */
@@ -25,7 +23,6 @@ trait InteractsWithShopper
     use HasDiscounts;
     use HasProfilePhoto;
     use HasRoles;
-    use TwoFactorAuthenticatable;
 
     public static function bootInteractsWithShopper(): void
     {

--- a/packages/admin/src/Traits/InteractsWithStoreAuthentication.php
+++ b/packages/admin/src/Traits/InteractsWithStoreAuthentication.php
@@ -10,25 +10,28 @@ use BaconQrCode\Renderer\ImageRenderer;
 use BaconQrCode\Renderer\RendererStyle\Fill;
 use BaconQrCode\Renderer\RendererStyle\RendererStyle;
 use BaconQrCode\Writer;
-use Shopper\Actions\Auth\RecoveryCode;
 use Shopper\Contracts\TwoFactorAuthenticationProvider;
 
-trait TwoFactorAuthenticatable
+/**
+ * @property ?string $store_two_factor_secret
+ */
+trait InteractsWithStoreAuthentication
 {
-    public function getStoreAuthenticationRecoveryCodes(): array
+    public function getStoreAuthenticationSecret(): ?string
     {
-        return json_decode(decrypt($this->store_two_factor_recovery_codes), true);
+        return $this->store_two_factor_secret;
     }
 
-    public function replaceStoreAuthenticationRecoveryCode(string $code): void
+    public function saveStoreAuthenticationSecret(?string $secret): void
     {
         $this->forceFill([
-            'store_two_factor_recovery_codes' => encrypt(str_replace(
-                $code,
-                RecoveryCode::generate(),
-                decrypt($this->store_two_factor_recovery_codes)
-            )),
+            'store_two_factor_secret' => $secret !== null ? encrypt($secret) : null,
         ])->save();
+    }
+
+    public function getStoreAuthenticationHolderName(): string
+    {
+        return $this->email;
     }
 
     public function getStoreAuthenticationQrCodeSvg(): string
@@ -47,7 +50,7 @@ trait TwoFactorAuthenticatable
     {
         return app(TwoFactorAuthenticationProvider::class)->qrCodeUrl(
             config('app.name'),
-            $this->email,
+            $this->getStoreAuthenticationHolderName(),
             decrypt($this->store_two_factor_secret)
         );
     }

--- a/packages/admin/src/Traits/InteractsWithStoreAuthenticationRecovery.php
+++ b/packages/admin/src/Traits/InteractsWithStoreAuthenticationRecovery.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Traits;
+
+use Shopper\Actions\Auth\RecoveryCode;
+
+/**
+ * @property ?string $store_two_factor_recovery_codes
+ */
+trait InteractsWithStoreAuthenticationRecovery
+{
+    /** @return ?array<string> */
+    public function getStoreAuthenticationRecoveryCodes(): ?array
+    {
+        if ($this->store_two_factor_recovery_codes === null) {
+            return null;
+        }
+
+        return json_decode(decrypt($this->store_two_factor_recovery_codes), true);
+    }
+
+    /** @param ?array<string> $codes */
+    public function saveStoreAuthenticationRecoveryCodes(?array $codes): void
+    {
+        $this->forceFill([
+            'store_two_factor_recovery_codes' => $codes !== null ? encrypt(json_encode($codes)) : null,
+        ])->save();
+    }
+
+    public function replaceStoreAuthenticationRecoveryCode(string $code): void
+    {
+        $this->forceFill([
+            'store_two_factor_recovery_codes' => encrypt(str_replace(
+                $code,
+                RecoveryCode::generate(),
+                decrypt($this->store_two_factor_recovery_codes)
+            )),
+        ])->save();
+    }
+}

--- a/tests/Core/Stubs/User.php
+++ b/tests/Core/Stubs/User.php
@@ -7,13 +7,19 @@ namespace Tests\Core\Stubs;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Shopper\Contracts\HasStoreAuthentication;
+use Shopper\Contracts\HasStoreAuthenticationRecovery;
 use Shopper\Models\Contracts\ShopperUser;
 use Shopper\Traits\InteractsWithShopper;
+use Shopper\Traits\InteractsWithStoreAuthentication;
+use Shopper\Traits\InteractsWithStoreAuthenticationRecovery;
 
-class User extends Authenticatable implements ShopperUser
+class User extends Authenticatable implements HasStoreAuthentication, HasStoreAuthenticationRecovery, ShopperUser
 {
     use HasFactory;
     use InteractsWithShopper;
+    use InteractsWithStoreAuthentication;
+    use InteractsWithStoreAuthenticationRecovery;
     use Notifiable;
 
     protected $guarded = [];


### PR DESCRIPTION
## Summary

- Cherry-pick of #467 from 2.x to 3.x
- Splits monolithic `TwoFactorAuthenticatable` trait into SOLID interfaces and traits
- `HasStoreAuthentication` + `InteractsWithStoreAuthentication` for 2FA secret/QR code
- `HasStoreAuthenticationRecovery` + `InteractsWithStoreAuthenticationRecovery` for recovery codes
- 2FA is now opt-in via separate traits instead of being bundled in `InteractsWithShopper`
- Adds i18n keys for 2FA validation messages (en, fr, es)