### PR TITLE
fix: store monetary amounts in smallest currency unit

### DIFF
--- a/packages/admin/resources/views/livewire/components/settings/zones/shipping-options.blade.php
+++ b/packages/admin/resources/views/livewire/components/settings/zones/shipping-options.blade.php
@@ -65,7 +65,7 @@
                             <p class="text-sm text-gray-500 dark:text-gray-400">
                                 {{ __('shopper::forms.label.price') }}:
                                 <span class="font-medium text-gray-700 dark:text-gray-300">
-                                    {{ \Illuminate\Support\Number::currency($shippingOption->price, in: $zone->currency->code) }}
+                                    {{ shopper_money_format($shippingOption->price, $zone->currency->code) }}
                                 </span>
                             </p>
                         </div>

--- a/packages/admin/src/Components/Form/CurrenciesField.php
+++ b/packages/admin/src/Components/Form/CurrenciesField.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Shopper\Components\Form;
 
-use Filament\Forms\Components;
 use Filament\Infolists\Components\TextEntry;
 use Filament\Schemas\Components\Group;
 use Filament\Schemas\Components\Utilities\Get;
@@ -28,36 +27,33 @@ final class CurrenciesField
                         ->label("{$currency->name} ({$currency->symbol})"),
                     Group::make()
                         ->schema([
-                            Components\TextInput::make('amount')  // @phpstan-ignore-line
+                            MoneyInput::make('amount')  // @phpstan-ignore-line
                                 ->label(__('shopper::forms.label.price_amount'))
                                 ->helperText(__('shopper::pages/products.amount_price_help_text'))
                                 ->statePath($currency->id.'.amount')
-                                ->numeric()
                                 ->rules(['regex:/^\d{1,6}(\.\d{0,2})?$/'])
                                 ->required(fn (Get $get): bool => $get($currency->id.'.compare_amount') !== null)
                                 ->suffix($currency->code)
-                                ->live()
-                                ->currencyMask(thousandSeparator: ',', decimalSeparator: '.', precision: 2),
-                            Components\TextInput::make('compare_amount')  // @phpstan-ignore-line
+                                ->currency($currency->code)
+                                ->live(),
+                            MoneyInput::make('compare_amount')  // @phpstan-ignore-line
                                 ->label(__('shopper::forms.label.compare_price'))
                                 ->helperText(__('shopper::pages/products.compare_price_help_text'))
                                 ->statePath($currency->id.'.compare_amount')
                                 ->afterStateUpdated(
                                     fn (?string $state, Set $set): mixed => $state ?? $set($currency->id.'.compare_amount', null)
                                 )
-                                ->numeric()
                                 ->rules(['regex:/^\d{1,6}(\.\d{0,2})?$/'])
                                 ->suffix($currency->code)
-                                ->live()
-                                ->currencyMask(thousandSeparator: ',', decimalSeparator: '.', precision: 2),
-                            Components\TextInput::make('cost_amount')  // @phpstan-ignore-line
+                                ->currency($currency->code)
+                                ->live(),
+                            MoneyInput::make('cost_amount')  // @phpstan-ignore-line
                                 ->label(__('shopper::forms.label.cost_per_item'))
                                 ->helperText(__('shopper::pages/products.cost_per_items_help_text'))
                                 ->statePath($currency->id.'.cost_amount')
-                                ->numeric()
                                 ->rules(['regex:/^\d{1,6}(\.\d{0,2})?$/'])
                                 ->suffix($currency->code)
-                                ->currencyMask(thousandSeparator: ',', decimalSeparator: '.', precision: 2),
+                                ->currency($currency->code),
                         ])
                         ->columns(3),
                     TextEntry::make('placeholder')

--- a/packages/admin/src/Components/Form/MoneyInput.php
+++ b/packages/admin/src/Components/Form/MoneyInput.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Components\Form;
+
+use Closure;
+use Filament\Forms\Components\TextInput;
+
+class MoneyInput extends TextInput
+{
+    protected string|Closure|null $currency = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->numeric();
+
+        $this->afterStateHydrated(function (self $component, $state): void {
+            if ($state === null || $state === '') {
+                return;
+            }
+
+            $currency = $component->getCurrency();
+
+            $component->state(
+                is_no_division_currency($currency) ? $state : (float) $state / 100
+            );
+        });
+
+        $this->dehydrateStateUsing(function ($state): ?int {
+            if ($state === null || $state === '') {
+                return null;
+            }
+
+            $currency = $this->getCurrency();
+
+            return is_no_division_currency($currency)
+                ? (int) $state
+                : (int) round((float) $state * 100);
+        });
+
+        $this->currencyMask(thousandSeparator: ',', decimalSeparator: '.', precision: 2); // @phpstan-ignore method.notFound
+    }
+
+    public function currency(string|Closure $currency): static
+    {
+        $this->currency = $currency;
+
+        return $this;
+    }
+
+    public function getCurrency(): string
+    {
+        $currency = $this->evaluate($this->currency) ?? shopper_currency();
+
+        if (is_no_division_currency($currency)) {
+            $this->currencyMask(thousandSeparator: ',', decimalSeparator: '.', precision: 0); // @phpstan-ignore method.notFound
+        }
+
+        return $currency;
+    }
+}

--- a/packages/admin/src/Livewire/Components/Dashboard/RevenueChart.php
+++ b/packages/admin/src/Livewire/Components/Dashboard/RevenueChart.php
@@ -114,7 +114,9 @@ final class RevenueChart extends ApexChartWidget
                 ->groupByRaw($expr['groupBy'])
                 ->get()
                 ->keyBy(fn ($row): string => $row->getAttribute('year').'-'.$row->getAttribute('month'))
-                ->map(fn ($row): float => (float) $row->getAttribute('total') / 100)
+                ->map(fn ($row): float => is_no_division_currency($currency)
+                    ? (float) $row->getAttribute('total')
+                    : (float) $row->getAttribute('total') / 100)
                 ->all(),
         );
 

--- a/packages/admin/src/Livewire/Components/Dashboard/StatCards.php
+++ b/packages/admin/src/Livewire/Components/Dashboard/StatCards.php
@@ -60,7 +60,7 @@ final class StatCards extends Component
 
         return [
             'label' => __('shopper::pages/dashboard.stats.revenue'),
-            'value' => shopper_money_format($currentMonth / 100, $currency),
+            'value' => shopper_money_format($currentMonth, $currency),
             ...$this->calculateChange($currentMonth, $lastMonth),
             'icon' => 'phosphor-coins-duotone',
             'route' => route('shopper.orders.index'),

--- a/packages/admin/src/Livewire/Components/Products/Pricing.php
+++ b/packages/admin/src/Livewire/Components/Products/Pricing.php
@@ -43,13 +43,13 @@ class Pricing extends Component implements HasActions, HasSchemas, HasTable
                     ->sortable(),
                 TextColumn::make('amount')
                     ->label(__('shopper::forms.label.price'))
-                    ->money(fn ($record) => $record->currencyCode),
+                    ->currency(fn ($record) => $record->currencyCode), // @phpstan-ignore method.notFound
                 TextColumn::make('compare_amount')
                     ->label(__('shopper::forms.label.compare_price'))
-                    ->money(fn ($record) => $record->currencyCode),
+                    ->currency(fn ($record) => $record->currencyCode), // @phpstan-ignore method.notFound
                 TextColumn::make('cost_amount')
                     ->label(__('shopper::forms.label.cost_per_item'))
-                    ->money(fn ($record) => $record->currencyCode),
+                    ->currency(fn ($record) => $record->currencyCode), // @phpstan-ignore method.notFound
             ])
             ->recordActions([
                 Action::make('edit')

--- a/packages/admin/src/Livewire/SlideOvers/CollectionRules.php
+++ b/packages/admin/src/Livewire/SlideOvers/CollectionRules.php
@@ -70,7 +70,10 @@ class CollectionRules extends SlideOverComponent implements HasActions, HasSchem
                         $rule = Rule::tryFrom($data['rule'] ?? '');
 
                         if ($rule?->isPrice() && isset($data['value'])) {
-                            $data['value'] = (string) ((int) $data['value'] / 100);
+                            $currency = shopper_currency();
+                            $data['value'] = is_no_division_currency($currency)
+                                ? $data['value']
+                                : (string) ((int) $data['value'] / 100);
                         } elseif ($rule?->isBoolean() && isset($data['value'])) {
                             $data['boolean_value'] = $data['value'];
                         } elseif ($rule?->isDate() && isset($data['value'])) {
@@ -170,7 +173,10 @@ class CollectionRules extends SlideOverComponent implements HasActions, HasSchem
         }
 
         if ($rule?->isPrice()) {
-            $data['value'] = (string) ((int) ((float) $data['value'] * 100));
+            $currency = shopper_currency();
+            $data['value'] = is_no_division_currency($currency)
+                ? (string) (int) $data['value']
+                : (string) ((int) ((float) $data['value'] * 100));
         }
 
         return $data;

--- a/packages/admin/src/Livewire/SlideOvers/DiscountForm.php
+++ b/packages/admin/src/Livewire/SlideOvers/DiscountForm.php
@@ -157,6 +157,25 @@ class DiscountForm extends SlideOverComponent implements HasActions, HasSchemas
                                             default => null
                                         }
                                     )
+                                    ->afterStateHydrated(function (TextInput $component, $state): void {
+                                        if ($this->discount->exists && $this->discount->type === DiscountType::FixedAmount && $state) {
+                                            $currency = $this->discount->zone?->currency_code ?? shopper_currency(); // @phpstan-ignore nullsafe.neverNull
+                                            $component->state(
+                                                is_no_division_currency($currency) ? $state : $state / 100
+                                            );
+                                        }
+                                    })
+                                    ->dehydrateStateUsing(function (Get $get, $state) {
+                                        if ($get('type') !== DiscountType::FixedAmount->value) {
+                                            return (int) $state;
+                                        }
+
+                                        $currency = $get('zone_id')
+                                            ? Zone::query()->find($get('zone_id'))->currency_code
+                                            : shopper_currency();
+
+                                        return is_no_division_currency($currency) ? (int) $state : (int) round((float) $state * 100);
+                                    })
                                     ->numeric()
                                     ->required(),
                             ]),
@@ -287,6 +306,25 @@ class DiscountForm extends SlideOverComponent implements HasActions, HasSchemas
                                     default => null
                                 }
                             )
+                            ->afterStateHydrated(function (TextInput $component, $state): void {
+                                if ($this->discount->exists && $this->discount->min_required === DiscountRequirement::Price->value && $state) {
+                                    $currency = $this->discount->zone?->currency_code ?? shopper_currency(); // @phpstan-ignore nullsafe.neverNull
+                                    $component->state(
+                                        is_no_division_currency($currency) ? $state : (string) ((int) $state / 100)
+                                    );
+                                }
+                            })
+                            ->dehydrateStateUsing(function (Get $get, $state) {
+                                if ($get('min_required') !== DiscountRequirement::Price->value) {
+                                    return $state;
+                                }
+
+                                $currency = $get('zone_id')
+                                    ? Zone::query()->find($get('zone_id'))->currency_code
+                                    : shopper_currency();
+
+                                return is_no_division_currency($currency) ? (string) (int) $state : (string) ((int) round((float) $state * 100));
+                            })
                             ->required(
                                 fn (Get $get): bool => $get('min_required') !== DiscountRequirement::None->value
                             )

--- a/packages/admin/src/Livewire/SlideOvers/ShippingOptionForm.php
+++ b/packages/admin/src/Livewire/SlideOvers/ShippingOptionForm.php
@@ -18,6 +18,7 @@ use Filament\Schemas\Contracts\HasSchemas;
 use Filament\Schemas\Schema;
 use Laravelcm\LivewireSlideOvers\SlideOverComponent;
 use Livewire\Attributes\Computed;
+use Shopper\Components\Form\MoneyInput;
 use Shopper\Components\Separator;
 use Shopper\Contracts\SlideOverForm;
 use Shopper\Core\Models\CarrierOption;
@@ -80,13 +81,12 @@ class ShippingOptionForm extends SlideOverComponent implements HasActions, HasSc
                             ->label(__('shopper::forms.label.name'))
                             ->placeholder('Standard option...')
                             ->required(),
-                        TextInput::make('price') // @phpstan-ignore-line
+                        MoneyInput::make('price')
                             ->label(__('shopper::forms.label.price'))
-                            ->numeric()
                             ->required()
                             ->rules(['regex:/^\d{1,6}(\.\d{0,2})?$/'])
                             ->suffix($this->zone->currency->code)
-                            ->currencyMask(thousandSeparator: ',', decimalSeparator: '.', precision: 2),
+                            ->currency($this->zone->currency->code),
                         Select::make('carrier_id')
                             ->label(__('shopper::pages/settings/carriers.title'))
                             ->options($this->zone->carriers->pluck('name', 'id'))

--- a/packages/cart/src/Discounts/DiscountCalculator.php
+++ b/packages/cart/src/Discounts/DiscountCalculator.php
@@ -124,7 +124,7 @@ final readonly class DiscountCalculator
      */
     private function applyFixedAmount(Discount $discount, Collection $lines, CartPipelineContext $context): int
     {
-        $fixedAmount = (int) $discount->getRawOriginal('value');
+        $fixedAmount = $discount->value;
         $applicableSubtotal = $lines->sum(fn (CartLine $line): int => $context->lineSubtotals[$line->id] ?? 0);
 
         if ($applicableSubtotal === 0) {

--- a/packages/cart/src/Models/CartLine.php
+++ b/packages/cart/src/Models/CartLine.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Shopper\Cart\Models;
 
 use Carbon\CarbonInterface;
-use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -75,14 +74,6 @@ class CartLine extends Model implements CartLineContract
     public function taxLines(): HasMany
     {
         return $this->hasMany(CartLineTaxLine::class);
-    }
-
-    protected function unitPriceAmount(): Attribute
-    {
-        return Attribute::make(
-            get: fn (float|int $value): float|int => $value / 100,
-            set: fn (float|int $value): int => (int) round($value * 100),
-        );
     }
 
     protected function casts(): array

--- a/packages/cart/src/Models/CartLineAdjustment.php
+++ b/packages/cart/src/Models/CartLineAdjustment.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Shopper\Cart\Models;
 
 use Carbon\CarbonInterface;
-use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Shopper\Core\Models\Discount;
@@ -44,13 +43,5 @@ class CartLineAdjustment extends Model
     public function discount(): BelongsTo
     {
         return $this->belongsTo(config('shopper.models.discount'), 'discount_id');
-    }
-
-    protected function amount(): Attribute
-    {
-        return Attribute::make(
-            get: fn (float|int $value): float|int => $value / 100,
-            set: fn (float|int $value): int => (int) round($value * 100),
-        );
     }
 }

--- a/packages/cart/src/Models/CartLineTaxLine.php
+++ b/packages/cart/src/Models/CartLineTaxLine.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Shopper\Cart\Models;
 
 use Carbon\CarbonInterface;
-use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Shopper\Core\Models\TaxRate;
@@ -46,14 +45,6 @@ class CartLineTaxLine extends Model
     public function taxRate(): BelongsTo
     {
         return $this->belongsTo(config('shopper.models.tax_rate'), 'tax_rate_id');
-    }
-
-    protected function amount(): Attribute
-    {
-        return Attribute::make(
-            get: fn (float|int $value): float|int => $value / 100,
-            set: fn (float|int $value): int => (int) round($value * 100),
-        );
     }
 
     protected function casts(): array

--- a/packages/cart/src/Pipelines/CalculateLines.php
+++ b/packages/cart/src/Pipelines/CalculateLines.php
@@ -11,7 +11,7 @@ final class CalculateLines
     public function handle(CartPipelineContext $context, Closure $next): mixed
     {
         foreach ($context->cart->lines as $line) {
-            $subtotal = (int) $line->getRawOriginal('unit_price_amount') * $line->quantity;
+            $subtotal = $line->unit_price_amount * $line->quantity;
             $context->lineSubtotals[$line->id] = $subtotal;
             $context->subtotal += $subtotal;
         }

--- a/packages/cart/src/Pipelines/CalculateTax.php
+++ b/packages/cart/src/Pipelines/CalculateTax.php
@@ -31,7 +31,7 @@ final readonly class CalculateTax
         );
 
         foreach ($context->cart->lines as $line) {
-            $discountAmount = (int) $line->adjustments->sum(fn ($adj) => $adj->getRawOriginal('amount'));
+            $discountAmount = (int) $line->adjustments->sum('amount');
             $taxableAmount = ($context->lineSubtotals[$line->id] ?? 0) - $discountAmount;
 
             if ($taxableAmount <= 0) {
@@ -49,7 +49,7 @@ final readonly class CalculateTax
                     'code' => $taxLine->code ?? $taxLine->name,
                     'name' => $taxLine->name,
                     'rate' => $taxLine->rate,
-                    'amount' => $taxLine->amount / 100,
+                    'amount' => $taxLine->amount,
                     'tax_rate_id' => $taxLine->taxRateId,
                 ]);
 

--- a/packages/cart/src/Pipelines/CartPipelineRunner.php
+++ b/packages/cart/src/Pipelines/CartPipelineRunner.php
@@ -25,11 +25,6 @@ final class CartPipelineRunner
             ->through(config('shopper.cart.pipelines.cart'))
             ->thenReturn();
 
-        $context->subtotal /= 100;
-        $context->discountTotal /= 100;
-        $context->taxTotal /= 100;
-        $context->total /= 100;
-
         return $context;
     }
 }

--- a/packages/core/database/factories/PriceFactory.php
+++ b/packages/core/database/factories/PriceFactory.php
@@ -26,9 +26,9 @@ class PriceFactory extends Factory
         return [
             'priceable_type' => Product::class,
             'priceable_id' => Product::factory(),
-            'amount' => $this->faker->randomFloat(min: 100, max: 500),
-            'compare_amount' => $this->faker->randomFloat(min: 80, max: 400),
-            'cost_amount' => $this->faker->randomFloat(min: 50, max: 200),
+            'amount' => $this->faker->numberBetween(10000, 50000),
+            'compare_amount' => $this->faker->numberBetween(8000, 40000),
+            'cost_amount' => $this->faker->numberBetween(5000, 20000),
             'currency_id' => Currency::factory(),
         ];
     }

--- a/packages/core/src/Actions/CreateOrderTaxLinesAction.php
+++ b/packages/core/src/Actions/CreateOrderTaxLinesAction.php
@@ -49,11 +49,11 @@ final readonly class CreateOrderTaxLinesAction
                 $itemTaxTotal += $taxLine->amount;
             }
 
-            $item->updateQuietly(['tax_amount' => $itemTaxTotal / 100]);
+            $item->updateQuietly(['tax_amount' => $itemTaxTotal]);
             $orderTaxTotal += $itemTaxTotal;
         }
 
-        $order->updateQuietly(['tax_amount' => $orderTaxTotal / 100]);
+        $order->updateQuietly(['tax_amount' => $orderTaxTotal]);
     }
 
     private function resolveCountryCode(Order $order): ?string

--- a/packages/core/src/Models/CarrierOption.php
+++ b/packages/core/src/Models/CarrierOption.php
@@ -6,7 +6,6 @@ namespace Shopper\Core\Models;
 
 use Carbon\CarbonInterface;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -80,13 +79,5 @@ class CarrierOption extends Model implements CarrierOptionContract
             'metadata' => 'array',
             'is_enabled' => 'boolean',
         ];
-    }
-
-    protected function price(): Attribute
-    {
-        return Attribute::make(
-            get: fn (int $value): int => $value / 100,
-            set: fn (int $value): int => $value * 100,
-        );
     }
 }

--- a/packages/core/src/Models/CollectionRule.php
+++ b/packages/core/src/Models/CollectionRule.php
@@ -48,7 +48,7 @@ class CollectionRule extends Model implements CollectionRuleContract
     public function getFormattedValue(): string
     {
         if ($this->rule->isPrice()) {
-            return shopper_money_format((int) $this->value / 100);
+            return shopper_money_format((int) $this->value);
         }
 
         if ($this->rule->isBoolean()) {

--- a/packages/core/src/Models/Discount.php
+++ b/packages/core/src/Models/Discount.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Shopper\Core\Models;
 
 use Carbon\CarbonInterface;
-use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -77,18 +76,6 @@ class Discount extends Model implements DiscountContract
     protected static function newFactory(): DiscountFactory
     {
         return DiscountFactory::new();
-    }
-
-    protected function value(): Attribute
-    {
-        return Attribute::make(
-            get: fn (int $value): int => $this->type === DiscountType::FixedAmount
-                ? $value / 100
-                : $value,
-            set: fn (int $value): int => $this->type === DiscountType::FixedAmount
-                ? $value * 100
-                : $value,
-        );
     }
 
     protected function casts(): array

--- a/packages/core/src/Models/Order.php
+++ b/packages/core/src/Models/Order.php
@@ -6,7 +6,6 @@ namespace Shopper\Core\Models;
 
 use Carbon\CarbonInterface;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -291,22 +290,6 @@ class Order extends Model implements OrderContract
     protected static function newFactory(): OrderFactory
     {
         return OrderFactory::new();
-    }
-
-    protected function priceAmount(): Attribute
-    {
-        return Attribute::make(
-            get: fn (int|float|null $value): int|float => ($value ?? 0) / 100,
-            set: fn (int|float $value): int => (int) round($value * 100),
-        );
-    }
-
-    protected function taxAmount(): Attribute
-    {
-        return Attribute::make(
-            get: fn (int|float|null $value): int|float => ($value ?? 0) / 100,
-            set: fn (int|float $value): int => (int) round($value * 100),
-        );
     }
 
     protected function casts(): array

--- a/packages/core/src/Models/OrderItem.php
+++ b/packages/core/src/Models/OrderItem.php
@@ -109,30 +109,6 @@ class OrderItem extends Model implements OrderItemContract
         ];
     }
 
-    protected function unitPriceAmount(): Attribute
-    {
-        return Attribute::make(
-            get: fn (float|int $value): float|int => $value / 100,
-            set: fn (float|int $value): int => (int) round($value * 100),
-        );
-    }
-
-    protected function taxAmount(): Attribute
-    {
-        return Attribute::make(
-            get: fn (float|int $value): float|int => $value / 100,
-            set: fn (float|int $value): int => (int) round($value * 100),
-        );
-    }
-
-    protected function discountAmount(): Attribute
-    {
-        return Attribute::make(
-            get: fn (float|int $value): float|int => $value / 100,
-            set: fn (float|int $value): int => (int) round($value * 100),
-        );
-    }
-
     protected function total(): Attribute
     {
         return Attribute::make(

--- a/packages/core/src/Models/Price.php
+++ b/packages/core/src/Models/Price.php
@@ -91,28 +91,4 @@ class Price extends Model implements PriceContract
     {
         return PriceFactory::new();
     }
-
-    protected function amount(): Attribute
-    {
-        return Attribute::make(
-            get: fn (?int $value): float|int|null => $value ? $value / 100 : null,
-            set: fn (int|float|null $value): ?int => $value ? (int) round($value * 100) : null,
-        );
-    }
-
-    protected function compareAmount(): Attribute
-    {
-        return Attribute::make(
-            get: fn (?int $value): float|int|null => $value ? $value / 100 : null,
-            set: fn (int|float|null $value): ?int => $value ? (int) round($value * 100) : null,
-        );
-    }
-
-    protected function costAmount(): Attribute
-    {
-        return Attribute::make(
-            get: fn (?int $value): float|int|null => $value ? $value / 100 : null,
-            set: fn (int|float|null $value): ?int => $value ? (int) round($value * 100) : null,
-        );
-    }
 }

--- a/packages/core/src/Queries/CollectionProductsQuery.php
+++ b/packages/core/src/Queries/CollectionProductsQuery.php
@@ -144,8 +144,11 @@ final class CollectionProductsQuery
             default => '=',
         };
 
-        $query->whereHas('prices', function (Builder $subQuery) use ($column, $operator, $rule): void {
-            $subQuery->where($column, $operator, (int) $rule->value);
+        $currencyId = shopper_setting('default_currency_id');
+
+        $query->whereHas('prices', function (Builder $subQuery) use ($column, $operator, $rule, $currencyId): void {
+            $subQuery->where($column, $operator, (int) $rule->value)
+                ->where('currency_id', $currencyId);
         });
     }
 

--- a/packages/core/src/Taxes/OrderItemTaxAdapter.php
+++ b/packages/core/src/Taxes/OrderItemTaxAdapter.php
@@ -17,7 +17,7 @@ final readonly class OrderItemTaxAdapter implements TaxableItem
 
     public function getTaxableAmount(): int
     {
-        return (int) $this->item->getRawOriginal('unit_price_amount');
+        return $this->item->unit_price_amount;
     }
 
     public function getQuantity(): int

--- a/packages/core/src/helpers.php
+++ b/packages/core/src/helpers.php
@@ -86,9 +86,11 @@ if (! function_exists('shopper_currency')) {
 if (! function_exists('shopper_money_format')) {
     function shopper_money_format(int|float $amount, ?string $currency = null): string
     {
+        $currency = $currency ?? shopper_currency();
+
         return (string) Number::currency(
-            number: $amount,
-            in: $currency ?? shopper_currency(),
+            number: is_no_division_currency($currency) ? $amount : $amount / 100,
+            in: $currency,
             locale: app()->getLocale()
         );
     }

--- a/packages/shipping/src/DataTransferObjects/ShippingRate.php
+++ b/packages/shipping/src/DataTransferObjects/ShippingRate.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Shopper\Shipping\DataTransferObjects;
 
-use Illuminate\Support\Number;
-
 final readonly class ShippingRate
 {
     public function __construct(
@@ -20,7 +18,7 @@ final readonly class ShippingRate
 
     public function formattedAmount(): string
     {
-        return Number::format($this->amount / 100, 2);
+        return shopper_money_format($this->amount, $this->currency);
     }
 
     /**

--- a/packages/shipping/src/Services/CarrierRateService.php
+++ b/packages/shipping/src/Services/CarrierRateService.php
@@ -150,7 +150,7 @@ final class CarrierRateService
         return $query->get()->map(fn (CarrierOption $option): ShippingRate => new ShippingRate(
             serviceCode: $option->id,
             serviceName: $option->name,
-            amount: $option->getRawOriginal('price'),
+            amount: $option->price,
             currency: $zone->currency->code ?? shopper_currency(),
             carrierCode: $carrier->slug ?? $carrier->name,
         ));

--- a/tests/Admin/Livewire/SlideOvers/ManagePricingTest.php
+++ b/tests/Admin/Livewire/SlideOvers/ManagePricingTest.php
@@ -103,7 +103,7 @@ describe(ManagePricing::class, function (): void {
         $product->refresh();
 
         expect($product->prices)->toHaveCount(1)
-            ->and($product->prices->first()->amount)->toBe(100);
+            ->and($product->prices->first()->amount)->toBe(10000);
     });
 
     it('dispatches event after saving pricing', function (): void {

--- a/tests/Admin/Livewire/SlideOvers/ShippingOptionFormTest.php
+++ b/tests/Admin/Livewire/SlideOvers/ShippingOptionFormTest.php
@@ -58,7 +58,7 @@ describe(ShippingOptionForm::class, function (): void {
             'zone_id' => $this->zone->id,
             'carrier_id' => $this->carrier->id,
             'name' => 'Express Shipping',
-            'price' => 15.99,
+            'price' => 1599,
         ]);
 
         $component = Livewire::test(ShippingOptionForm::class, [

--- a/tests/Admin/Livewire/SlideOvers/ShippingOptionFormTest.php
+++ b/tests/Admin/Livewire/SlideOvers/ShippingOptionFormTest.php
@@ -109,7 +109,7 @@ describe(ShippingOptionForm::class, function (): void {
         expect($option)->not->toBeNull()
             ->and($option->zone_id)->toBe($this->zone->id)
             ->and($option->carrier_id)->toBe($this->carrier->id)
-            ->and($option->price)->toBe(10)
+            ->and($option->price)->toBe(1000)
             ->and($option->description)->toBe('Delivery within 3-5 business days')
             ->and($option->is_enabled)->toBeTrue();
     });
@@ -137,7 +137,7 @@ describe(ShippingOptionForm::class, function (): void {
         $option->refresh();
 
         expect($option->name)->toBe('Updated Name')
-            ->and($option->price)->toBe(15);
+            ->and($option->price)->toBe(1500);
     });
 
     it('validates required fields', function (): void {

--- a/tests/Admin/TestCase.php
+++ b/tests/Admin/TestCase.php
@@ -23,7 +23,6 @@ use Livewire\LivewireServiceProvider;
 use Livewire\Mechanisms\DataStore;
 use Mckenziearts\BladeUntitledUIIcons\BladeUntitledUIIconsServiceProvider;
 use Milon\Barcode\BarcodeServiceProvider;
-use RyanChandler\BladeCaptureDirective\BladeCaptureDirectiveServiceProvider;
 use Shopper\Cart\CartServiceProvider;
 use Shopper\Core\CoreServiceProvider;
 use Shopper\Payment\PaymentServiceProvider;
@@ -68,7 +67,6 @@ abstract class TestCase extends \Tests\TestCase
             LivewireServiceProvider::class,
             ActionsServiceProvider::class,
             BarcodeServiceProvider::class,
-            BladeCaptureDirectiveServiceProvider::class,
             BladeHeroiconsServiceProvider::class,
             BladeUntitledUIIconsServiceProvider::class,
             BladePhosphorIconsServiceProvider::class,

--- a/tests/Cart/Feature/CartCalculationTest.php
+++ b/tests/Cart/Feature/CartCalculationTest.php
@@ -33,7 +33,7 @@ beforeEach(function (): void {
 
     $this->product = Product::factory()->standard()->create();
     $this->product->prices()->create([
-        'amount' => 25,
+        'amount' => 2500,
         'currency_id' => $this->currency->id,
     ]);
     $this->product->load('prices');
@@ -52,13 +52,13 @@ describe(CalculateLines::class, function (): void {
         $context = $this->cartManager->calculate($this->cart);
 
         expect($context)->toBeInstanceOf(CartPipelineContext::class)
-            ->and($context->subtotal)->toBe(50);
+            ->and($context->subtotal)->toBe(5000);
     });
 
     it('calculates subtotal for multiple lines', function (): void {
         $product2 = Product::factory()->standard()->create();
         $product2->prices()->create([
-            'amount' => 10,
+            'amount' => 1000,
             'currency_id' => $this->currency->id,
         ]);
         $product2->load('prices');
@@ -69,7 +69,7 @@ describe(CalculateLines::class, function (): void {
 
         $context = $this->cartManager->calculate($this->cart);
 
-        expect($context->subtotal)->toBe(80);
+        expect($context->subtotal)->toBe(8000);
     });
 
     it('calculates total without discount or tax', function (): void {
@@ -77,7 +77,7 @@ describe(CalculateLines::class, function (): void {
 
         $context = $this->cartManager->calculate($this->cart);
 
-        expect($context->total)->toBe(25)
+        expect($context->total)->toBe(2500)
             ->and($context->discountTotal)->toBe(0)
             ->and($context->taxTotal)->toBe(0);
     });
@@ -100,15 +100,15 @@ describe(CalculateLines::class, function (): void {
 
         $context = $this->cartManager->calculate($this->cart->refresh());
 
-        expect($context->subtotal)->toBe(50)
-            ->and($context->discountTotal)->toBe(10)
-            ->and($context->total)->toBe(40);
+        expect($context->subtotal)->toBe(5000)
+            ->and($context->discountTotal)->toBe(1000)
+            ->and($context->total)->toBe(4000);
     });
 
     it('applies fixed amount discount distributed across lines', function (): void {
         $product2 = Product::factory()->standard()->create();
         $product2->prices()->create([
-            'amount' => 15,
+            'amount' => 1500,
             'currency_id' => $this->currency->id,
         ]);
         $product2->load('prices');
@@ -118,7 +118,7 @@ describe(CalculateLines::class, function (): void {
             'code' => 'FLAT10',
             'is_active' => true,
             'type' => DiscountType::FixedAmount,
-            'value' => 10,
+            'value' => 1000,
             'apply_to' => DiscountApplyTo::Order,
             'eligibility' => DiscountEligibility::Everyone,
             'min_required' => DiscountRequirement::None,
@@ -132,9 +132,9 @@ describe(CalculateLines::class, function (): void {
 
         $context = $this->cartManager->calculate($this->cart->refresh());
 
-        expect($context->subtotal)->toBe(40)
-            ->and($context->discountTotal)->toBe(10)
-            ->and($context->total)->toBe(30);
+        expect($context->subtotal)->toBe(4000)
+            ->and($context->discountTotal)->toBe(1000)
+            ->and($context->total)->toBe(3000);
     });
 
     it('calculates tax on lines after discount', function (): void {
@@ -164,10 +164,10 @@ describe(CalculateLines::class, function (): void {
 
         $context = $this->cartManager->calculate($this->cart->refresh());
 
-        expect($context->subtotal)->toBe(25)
-            ->and($context->taxTotal)->toBe(2.5)
+        expect($context->subtotal)->toBe(2500)
+            ->and($context->taxTotal)->toBe(250)
             ->and($context->taxInclusive)->toBeFalse()
-            ->and($context->total)->toBe(27.5);
+            ->and($context->total)->toBe(2750);
     });
 
     it('handles tax inclusive mode', function (): void {
@@ -233,6 +233,6 @@ describe(CalculateLines::class, function (): void {
         $context = $this->cartManager->calculate($this->cart->refresh());
 
         expect($context->discountTotal)->toBe(0)
-            ->and($context->total)->toBe(25);
+            ->and($context->total)->toBe(2500);
     });
 })->group('cart', 'cart-calculation');

--- a/tests/Core/Models/CarrierOptionTest.php
+++ b/tests/Core/Models/CarrierOptionTest.php
@@ -62,11 +62,11 @@ describe(CarrierOption::class, function (): void {
             ->and($carrierOption->metadata)->toBe($metadata);
     });
 
-    it('converts price accessor and mutator correctly', function (): void {
+    it('stores price in smallest currency unit without conversion', function (): void {
         $carrierOption = CarrierOption::factory()->create();
-        $carrierOption->update(['price' => 10]);
+        $carrierOption->update(['price' => 1000]);
 
-        expect($carrierOption->fresh()->price)->toBe(10)
+        expect($carrierOption->fresh()->price)->toBe(1000)
             ->and($carrierOption->fresh()->getAttributes()['price'])->toBe(1000);
     });
 })->group('carrier', 'models');

--- a/tests/Core/Models/PriceTest.php
+++ b/tests/Core/Models/PriceTest.php
@@ -56,7 +56,7 @@ describe(Price::class, function (): void {
         expect($price->compare_amount)->toBe(1500);
     });
 
-    it('converts amount accessor and mutator correctly', function (): void {
+    it('stores amount in smallest currency unit without conversion', function (): void {
         $currency = Currency::query()->first();
         /** @var Product $product */
         $product = Product::factory()->create();
@@ -65,14 +65,14 @@ describe(Price::class, function (): void {
             'priceable_id' => $product->id,
             'priceable_type' => $product->getMorphClass(),
             'currency_id' => $currency->id,
-            'amount' => 50,
+            'amount' => 5000,
         ]);
 
-        expect($price->fresh()->amount)->toBe(50)
+        expect($price->fresh()->amount)->toBe(5000)
             ->and($price->fresh()->getAttributes()['amount'])->toBe(5000);
     });
 
-    it('converts compare_amount accessor and mutator correctly', function (): void {
+    it('stores compare_amount in smallest currency unit without conversion', function (): void {
         $currency = Currency::query()->first();
         /** @var Product $product */
         $product = Product::factory()->create();
@@ -81,15 +81,15 @@ describe(Price::class, function (): void {
             'priceable_id' => $product->id,
             'priceable_type' => $product->getMorphClass(),
             'currency_id' => $currency->id,
-            'amount' => 50,
-            'compare_amount' => 75,
+            'amount' => 5000,
+            'compare_amount' => 7500,
         ]);
 
-        expect($price->fresh()->compare_amount)->toBe(75)
+        expect($price->fresh()->compare_amount)->toBe(7500)
             ->and($price->fresh()->getAttributes()['compare_amount'])->toBe(7500);
     });
 
-    it('converts cost_amount accessor and mutator correctly', function (): void {
+    it('stores cost_amount in smallest currency unit without conversion', function (): void {
         $currency = Currency::query()->first();
         /** @var Product $product */
         $product = Product::factory()->create();
@@ -98,11 +98,11 @@ describe(Price::class, function (): void {
             'priceable_id' => $product->id,
             'priceable_type' => $product->getMorphClass(),
             'currency_id' => $currency->id,
-            'amount' => 50,
-            'cost_amount' => 30,
+            'amount' => 5000,
+            'cost_amount' => 3000,
         ]);
 
-        expect($price->fresh()->cost_amount)->toBe(30)
+        expect($price->fresh()->cost_amount)->toBe(3000)
             ->and($price->fresh()->getAttributes()['cost_amount'])->toBe(3000);
     });
 


### PR DESCRIPTION
## Summary

- Adopts the Stripe/Shopify standard: all monetary values are stored in the smallest currency unit (cents for USD/EUR/GBP, raw value for zero-decimal currencies like XAF/JPY)
- Removes all Eloquent price accessor get/set pairs that unconditionally divided/multiplied by 100
- Adds `MoneyInput` Filament component that handles UI ↔ DB conversion (hydrate/dehydrate) with currency awareness via `is_no_division_currency()`
- Fixes `shopper_money_format()` to convert from smallest unit to display value
- Fixes `CollectionProductsQuery` price rules to filter by default currency

### Breaking changes

- All monetary model properties (`price_amount`, `unit_price_amount`, `amount`, `tax_amount`, `discount_amount`, `price`, `value`) now return raw smallest-unit values instead of human-readable values
- `shopper_money_format()` now expects smallest-unit values as input
- Cart pipeline (`CartPipelineRunner`) returns amounts in smallest unit
- Developers must pass smallest-unit values when creating prices, orders, or cart lines programmatically

### Models affected

`Order`, `OrderItem`, `Price`, `CarrierOption`, `CartLine`, `CartLineTaxLine`, `CartLineAdjustment`, `Discount`

### Files changed (33)

**Core models** — accessor removal
**Cart pipelines** — removed `/100` compensations and `getRawOriginal()` workarounds
**Admin forms** — `MoneyInput` component, `->currency()` macro instead of `->money()`
**Helpers** — `shopper_money_format()` currency-aware division
**Tests** — updated to use smallest-unit values