### PR TITLE
fix: add close button to review detail slide-over and standardize close icon

### DIFF
--- a/.github/workflows/monorepo-split.yml
+++ b/.github/workflows/monorepo-split.yml
@@ -20,6 +20,7 @@ jobs:
           - shipping
           - stripe
           - types
+          - upgrade
         include:
           - package: admin
             repository: admin
@@ -37,6 +38,8 @@ jobs:
             repository: stripe
           - package: types
             repository: shopper-types
+          - package: upgrade
+            repository: upgrade
     steps:
       - uses: actions/checkout@v6
       - name: Monorepo Split of ${{ matrix.package }}

--- a/packages/admin/resources/views/components/escape.blade.php
+++ b/packages/admin/resources/views/components/escape.blade.php
@@ -1,7 +1,0 @@
-@blaze(fold: true)
-
-<span
-    class="inline-flex items-center rounded-md bg-gray-100 px-2 py-1 text-xs text-gray-500 dark:bg-gray-800 dark:text-gray-500"
->
-    esc
-</span>

--- a/packages/admin/resources/views/livewire/slide-overs/abandoned-cart-detail.blade.php
+++ b/packages/admin/resources/views/livewire/slide-overs/abandoned-cart-detail.blade.php
@@ -25,17 +25,7 @@
                         </span>
                     </p>
                 </div>
-                <div class="ml-3 flex h-7 items-center">
-                    <x-shopper::escape />
-                    <button
-                        type="button"
-                        class="rounded-md bg-white text-gray-400 outline-none hover:text-gray-500 dark:bg-gray-900 dark:text-gray-500 dark:hover:text-gray-300"
-                        wire:click="$dispatch('closePanel')"
-                    >
-                        <span class="sr-only">Close panel</span>
-                        <x-untitledui-x class="size-6" stroke-width="1.5" aria-hidden="true" />
-                    </button>
-                </div>
+                <x-livewire-slide-over::close-icon />
             </div>
 
             <div class="mt-6 rounded-xl bg-gray-50 p-4 dark:bg-gray-950">

--- a/packages/admin/resources/views/livewire/slide-overs/related-products-list.blade.php
+++ b/packages/admin/resources/views/livewire/slide-overs/related-products-list.blade.php
@@ -5,17 +5,7 @@
                 <h2 class="text-lg font-medium text-gray-900 dark:text-white">
                     {{ __('shopper::pages/products.related.modal.title') }}
                 </h2>
-                <div class="flex h-7 items-center gap-2">
-                    <x-shopper::escape />
-                    <button
-                        type="button"
-                        class="rounded-md bg-white text-gray-400 hover:text-gray-500 dark:bg-gray-900 dark:text-gray-500 dark:hover:text-gray-300"
-                        wire:click="$dispatch('closePanel')"
-                    >
-                        <span class="sr-only">Close panel</span>
-                        <x-untitledui-x class="size-6" stroke-width="1.5" aria-hidden="true" />
-                    </button>
-                </div>
+                <x-livewire-slide-over::close-icon />
             </div>
         </header>
         <div class="mt-6 flex-1 px-4 sm:px-6">

--- a/packages/admin/resources/views/livewire/slide-overs/review-detail.blade.php
+++ b/packages/admin/resources/views/livewire/slide-overs/review-detail.blade.php
@@ -1,9 +1,12 @@
 <x-shopper::slideover-card>
     <div class="h-0 flex-1 overflow-y-auto py-4">
         <div class="px-4">
-            <h2 class="font-heading text-2xl font-bold text-gray-900 dark:text-white">
-                {{ $review->reviewrateable->name }}
-            </h2>
+            <div class="flex items-start justify-between">
+                <h2 class="font-heading text-2xl font-bold text-gray-900 dark:text-white">
+                    {{ $review->reviewrateable->name }}
+                </h2>
+                <x-livewire-slide-over::close-icon />
+            </div>
 
             <div class="mt-8">
                 <x-shopper::section-heading


### PR DESCRIPTION
## Summary

- Add missing close button to the `ReviewDetail` slide-over using `<x-livewire-slide-over::close-icon />`
- Replace custom close button markup and deprecated `<x-shopper::escape />` component with the standard `<x-livewire-slide-over::close-icon />` in `AbandonedCartDetail` and `RelatedProductsList` slide-overs
- Remove the now-unused `escape.blade.php` Blade component