### PR TITLE
refactor: make gender field optional

### DIFF
--- a/packages/admin/database/migrations/2026_03_28_113115_make_gender_column_nullable.php
+++ b/packages/admin/database/migrations/2026_03_28_113115_make_gender_column_nullable.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Shopper\Core\Helpers\Migration;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', static function (Blueprint $table): void {
+            $table->string('gender')->nullable()->change();
+        });
+    }
+};

--- a/packages/admin/resources/views/livewire/components/customers/profile.blade.php
+++ b/packages/admin/resources/views/livewire/components/customers/profile.blade.php
@@ -64,20 +64,22 @@
                     </div>
                 </dd>
             </div>
-            <div class="space-y-1 p-4 sm:grid sm:grid-cols-3 sm:gap-4">
-                <dt class="text-sm leading-5 font-medium text-gray-500 dark:text-gray-400">
-                    {{ __('shopper::forms.label.gender') }}
-                </dt>
-                <dd
-                    class="flex items-center space-x-4 text-sm leading-5 text-gray-900 sm:col-span-2 sm:mt-0 dark:text-white"
-                >
-                    <div class="grow">
-                        <span class="capitalize">
-                            {{ $customer->gender }}
-                        </span>
-                    </div>
-                </dd>
-            </div>
+            @if ($customer->gender)
+                <div class="space-y-1 p-4 sm:grid sm:grid-cols-3 sm:gap-4">
+                    <dt class="text-sm leading-5 font-medium text-gray-500 dark:text-gray-400">
+                        {{ __('shopper::forms.label.gender') }}
+                    </dt>
+                    <dd
+                        class="flex items-center space-x-4 text-sm leading-5 text-gray-900 sm:col-span-2 sm:mt-0 dark:text-white"
+                    >
+                        <div class="grow">
+                            <span class="capitalize">
+                                {{ $customer->gender->getLabel() }}
+                            </span>
+                        </div>
+                    </dd>
+                </div>
+            @endif
         </dl>
     </x-shopper::card>
 

--- a/packages/admin/src/Components/Form/GenderField.php
+++ b/packages/admin/src/Components/Form/GenderField.php
@@ -15,6 +15,6 @@ final class GenderField
         return Select::make('gender')
             ->label(__('shopper::forms.label.gender'))
             ->options(GenderType::options())
-            ->default(GenderType::Female->value);
+            ->placeholder(__('shopper::forms.label.gender'));
     }
 }

--- a/packages/admin/src/Console/UserCommand.php
+++ b/packages/admin/src/Console/UserCommand.php
@@ -8,11 +8,9 @@ use Exception;
 use Illuminate\Console\Command;
 use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\Hash;
-use Shopper\Core\Enum\GenderType;
 
 use function Laravel\Prompts\info;
 use function Laravel\Prompts\password;
-use function Laravel\Prompts\select;
 use function Laravel\Prompts\text;
 
 final class UserCommand extends Command
@@ -53,12 +51,6 @@ final class UserCommand extends Command
             required: true,
         );
 
-        $gender = select(
-            label: 'Select your gender',
-            options: GenderType::options(),
-            default: GenderType::Male(),
-        );
-
         $password = password(
             label: 'Choose a Password',
             required: true,
@@ -75,7 +67,6 @@ final class UserCommand extends Command
             'email' => $email,
             'first_name' => $first_name,
             'last_name' => $last_name,
-            'gender' => $gender,
             'password' => Hash::make($password),
             'last_login_at' => now()->toDateTimeString(),
             'email_verified_at' => now()->toDateTimeString(),

--- a/packages/admin/src/Livewire/SlideOvers/CreateTeamMember.php
+++ b/packages/admin/src/Livewire/SlideOvers/CreateTeamMember.php
@@ -132,8 +132,8 @@ class CreateTeamMember extends SlideOverComponent implements HasActions, HasSche
             'password' => Hash::make(
                 value: $data['password']
             ),
-            'phone_number' => $data['first_name'],
-            'gender' => $data['gender'],
+            'phone_number' => $data['phone_number'] ?? null,
+            'gender' => $data['gender'] ?? null,
             'email_verified_at' => now()->toDateTimeString(),
         ]);
 

--- a/packages/admin/src/Models/Contracts/ShopperUser.php
+++ b/packages/admin/src/Models/Contracts/ShopperUser.php
@@ -20,7 +20,7 @@ use Shopper\Core\Models\Order;
  * @property-read string $last_name
  * @property-read string $email
  * @property-read bool $opt_in
- * @property-read GenderType $gender
+ * @property-read ?GenderType $gender
  * @property-read string $avatar_type
  * @property-read ?string $timezone
  * @property-read ?string $avatar_location

--- a/packages/core/src/Models/Contracts/ShopperUser.php
+++ b/packages/core/src/Models/Contracts/ShopperUser.php
@@ -20,7 +20,7 @@ use Shopper\Core\Models\Order;
  * @property-read string $last_name
  * @property-read string $email
  * @property-read bool $opt_in
- * @property-read GenderType $gender
+ * @property-read ?GenderType $gender
  * @property-read string $avatar_type
  * @property-read ?string $timezone
  * @property-read ?string $avatar_location

--- a/tests/Core/Stubs/UserFactory.php
+++ b/tests/Core/Stubs/UserFactory.php
@@ -30,7 +30,7 @@ class UserFactory extends Factory
             'last_name' => $this->faker->lastName(),
             'email' => $this->faker->unique()->safeEmail(),
             'email_verified_at' => now(),
-            'gender' => $this->faker->randomElement(GenderType::values()),
+            'gender' => $this->faker->optional()->randomElement(GenderType::values()),
             'password' => self::$password ??= Hash::make('password'),
             'remember_token' => Str::random(10),
         ];


### PR DESCRIPTION
## Summary

- Make the `gender` column nullable in the database via a new migration
- Remove the forced default (`Female`) from `GenderField` component, replaced with a placeholder
- Remove the gender prompt from the `shopper:user` admin creation command
- Handle nullable gender in `CreateTeamMember` slide-over (also fixes a bug where `phone_number` was assigned `first_name`)
- Update `ShopperUser` contracts (core + admin) to reflect `?GenderType`
- Conditionally display gender in the customer profile view using `->getLabel()`
- Update `UserFactory` to occasionally generate `null` gender values

Gender is a sensitive personal data point (GDPR) that most e-commerce businesses don't need. This change makes it fully optional — merchants who need it can still collect it, but it's no longer forced.