### PR TITLE
refactor: allow attributes on virtual products

### DIFF
--- a/packages/core/src/Models/Product.php
+++ b/packages/core/src/Models/Product.php
@@ -116,7 +116,7 @@ class Product extends Model implements HasReviews, Priceable, ProductContract, S
 
     public function canUseAttributes(): bool
     {
-        return $this->isStandard() || $this->isVariant();
+        return $this->isStandard() || $this->isVariant() || $this->isVirtual();
     }
 
     public function canUseVariants(): bool

--- a/tests/Core/Models/ProductTest.php
+++ b/tests/Core/Models/ProductTest.php
@@ -196,7 +196,10 @@ describe(Product::class, function (): void {
             ->and($standard->canUseAttributes())->toBeTrue()
             ->and($standard->canUseVariants())->toBeFalse()
             ->and($variant->canUseVariants())->toBeTrue()
-            ->and($virtual->canUseShipping())->toBeFalse();
+            ->and($variant->canUseAttributes())->toBeTrue()
+            ->and($virtual->canUseShipping())->toBeFalse()
+            ->and($virtual->canUseAttributes())->toBeTrue()
+            ->and($virtual->canUseVariants())->toBeFalse();
     });
 
     it('has brand relationship', function (): void {


### PR DESCRIPTION
## Summary

- Allow virtual products to use attributes (`canUseAttributes()` now returns `true` for Virtual type)
- Add comprehensive test assertions for all product type capabilities (Virtual + attributes, Variant + attributes)
- Add `planning/product-types-analysis.md` documenting the full product type matrix, storefront cart logic, and admin tab visibility

Virtual products like software, courses, or ebooks can have meaningful attributes (OS, language, version, level, duration). Restricting attributes to Standard and Variant types was an artificial limitation that didn't match real e-commerce needs.