### PR TITLE
fix(types): sync TypeScript type definitions with database schema

### DIFF
--- a/packages/types/src/inventory.ts
+++ b/packages/types/src/inventory.ts
@@ -54,7 +54,7 @@ export interface InventoryHistory extends Entity {
   /** The description of the history entry. */
   description: string | null
   /** The user ID who made the adjustment. */
-  user_id: number
+  user_id: number | null
   /** The inventory ID. */
   inventory_id: number
   /** The ID of the stockable entity. */

--- a/packages/types/src/order.ts
+++ b/packages/types/src/order.ts
@@ -139,10 +139,12 @@ export interface OrderItem extends Entity {
   name: string
   /** The quantity of the order item. */
   quantity: number
-  /** The unit price amount. */
-  unit_price_amount: number | null
+  /** The unit price amount (in cents). */
+  unit_price_amount: number
   /** The tax amount (in cents). */
   tax_amount: number
+  /** The discount amount (in cents). */
+  discount_amount: number
   /** The computed total (unit_price_amount * quantity). */
   total: number
   /** The SKU of the order item. */
@@ -204,7 +206,7 @@ export interface OrderShipping extends Entity {
   /** The shipment status. */
   status: ShipmentStatus | null
   /** The date the order was shipped. */
-  shipped_at: DateEntity
+  shipped_at: DateEntity | null
   /** The date the order was received. */
   received_at: DateEntity | null
   /** The date the order was returned. */
@@ -263,9 +265,9 @@ export interface OrderShippingEvent {
  */
 export interface OrderRefund extends Entity {
   /** The reason for the refund. */
-  refund_reason: string | null
+  reason: string | null
   /** The refund amount (in cents). */
-  refund_amount: number | null
+  amount: number
   /** The refund status. */
   status: OrderRefundStatus
   /** Additional notes. */

--- a/packages/types/src/product.ts
+++ b/packages/types/src/product.ts
@@ -46,6 +46,8 @@ export interface Product extends Entity, SEOFields, ShippingFields {
   featured: boolean
   /** Whether the product is visible. */
   is_visible: boolean
+  /** Whether backorders are allowed. */
+  allow_backorder: boolean
   /** The type of the product. */
   type: ProductType | null
   /** The published at date of the product. */


### PR DESCRIPTION
## Summary

- Add missing `allow_backorder` field to `Product` interface
- Add missing `discount_amount` field to `OrderItem` interface
- Fix `unit_price_amount` nullability on `OrderItem` (NOT NULL in DB)
- Fix `shipped_at` nullability on `OrderShipping` (nullable in DB)
- Rename `OrderRefund` fields `refund_reason`/`refund_amount` to match actual DB columns `reason`/`amount`
- Fix `OrderRefund.amount` nullability (NOT NULL in DB)
- Fix `InventoryHistory.user_id` nullability (nullable in DB)