### PR TITLE
fix: pre-release audit fixes for v2.7

### DIFF
--- a/packages/admin/resources/views/livewire/components/products/variant-stock.blade.php
+++ b/packages/admin/resources/views/livewire/components/products/variant-stock.blade.php
@@ -21,7 +21,7 @@
                 </x-shopper::tables.table-head>
             </thead>
             <tbody class="divide-y divide-gray-100 dark:divide-white/10" x-max="1">
-                @foreach ($inventories as $inventory)
+                @foreach ($this->inventories as $inventory)
                     <tr>
                         <x-shopper::tables.table-cell class="whitespace-no-wrap">
                             <div class="flex items-center gap-2">

--- a/packages/admin/resources/views/livewire/pages/settings/taxes.blade.php
+++ b/packages/admin/resources/views/livewire/pages/settings/taxes.blade.php
@@ -35,7 +35,7 @@
                 </x-slot>
 
                 <div class="divide-y divide-gray-200 dark:divide-white/10">
-                    @forelse ($taxZones as $taxZone)
+                    @forelse ($this->taxZones as $taxZone)
                         <label
                             wire:key="tax-zone-{{ $taxZone->id }}"
                             for="tax-zone-{{ $taxZone->id }}"

--- a/packages/admin/resources/views/livewire/pages/settings/zones.blade.php
+++ b/packages/admin/resources/views/livewire/pages/settings/zones.blade.php
@@ -35,7 +35,7 @@
                 </x-slot>
 
                 <div class="divide-y divide-gray-200 dark:divide-white/10">
-                    @forelse ($zones as $zone)
+                    @forelse ($this->zones as $zone)
                         <label
                             wire:key="{{ $zone->slug }}"
                             for="{{ $zone->slug }}"

--- a/packages/admin/src/Livewire/Components/Products/VariantStock.php
+++ b/packages/admin/src/Livewire/Components/Products/VariantStock.php
@@ -14,12 +14,17 @@ use Filament\Schemas\Concerns\InteractsWithSchemas;
 use Filament\Schemas\Contracts\HasSchemas;
 use Filament\Support\Enums\Width;
 use Illuminate\Contracts\View\View;
+use Illuminate\Database\Eloquent\Collection;
+use Livewire\Attributes\Computed;
 use Livewire\Component;
 use Mckenziearts\Icons\Untitledui\Enums\Untitledui;
 use Shopper\Core\Models\Inventory;
 use Shopper\Core\Models\InventoryHistory;
 use Shopper\Traits\HandlesAuthorizationExceptions;
 
+/**
+ * @property-read Collection<int, Inventory> $inventories
+ */
 class VariantStock extends Component implements HasActions, HasSchemas
 {
     use HandlesAuthorizationExceptions;
@@ -86,10 +91,17 @@ class VariantStock extends Component implements HasActions, HasSchemas
             });
     }
 
+    /**
+     * @return Collection<int, Inventory>
+     */
+    #[Computed]
+    public function inventories(): Collection
+    {
+        return Inventory::query()->get();
+    }
+
     public function render(): View
     {
-        return view('shopper::livewire.components.products.variant-stock', [
-            'inventories' => Inventory::query()->get(),
-        ]);
+        return view('shopper::livewire.components.products.variant-stock');
     }
 }

--- a/packages/admin/src/Livewire/Pages/Settings/Taxes.php
+++ b/packages/admin/src/Livewire/Pages/Settings/Taxes.php
@@ -5,18 +5,23 @@ declare(strict_types=1);
 namespace Shopper\Livewire\Pages\Settings;
 
 use Illuminate\Contracts\View\View;
+use Illuminate\Database\Eloquent\Collection;
+use Livewire\Attributes\Computed;
 use Livewire\Attributes\Layout;
 use Livewire\Attributes\Url;
 use Livewire\Component;
 use Shopper\Core\Models\TaxZone;
 use Shopper\Traits\HandlesAuthorizationExceptions;
 
+/**
+ * @property-read Collection<int, TaxZone> $taxZones
+ */
 #[Layout('shopper::components.layouts.setting')]
 class Taxes extends Component
 {
     use HandlesAuthorizationExceptions;
 
-    #[Url(as: 'zone', except: '')]
+    #[Url(as: 'tax-zone', except: '')]
     public ?int $currentTaxZoneId = null;
 
     public function mount(): void
@@ -31,11 +36,18 @@ class Taxes extends Component
         $this->dispatch('tax-zone.changed', currentTaxZoneId: $value);
     }
 
+    /**
+     * @return Collection<int, TaxZone>
+     */
+    #[Computed]
+    public function taxZones(): Collection
+    {
+        return TaxZone::with('country')->get();
+    }
+
     public function render(): View
     {
-        return view('shopper::livewire.pages.settings.taxes', [
-            'taxZones' => TaxZone::with('country')->get(),
-        ])
+        return view('shopper::livewire.pages.settings.taxes')
             ->title(__('shopper::pages/settings/taxes.title'));
     }
 }

--- a/packages/admin/src/Livewire/Pages/Settings/Zones.php
+++ b/packages/admin/src/Livewire/Pages/Settings/Zones.php
@@ -5,12 +5,17 @@ declare(strict_types=1);
 namespace Shopper\Livewire\Pages\Settings;
 
 use Illuminate\Contracts\View\View;
+use Illuminate\Database\Eloquent\Collection;
+use Livewire\Attributes\Computed;
 use Livewire\Attributes\Layout;
 use Livewire\Attributes\Url;
 use Livewire\Component;
 use Shopper\Core\Models\Zone;
 use Shopper\Traits\HandlesAuthorizationExceptions;
 
+/**
+ * @property-read Collection<int, Zone> $zones
+ */
 #[Layout('shopper::components.layouts.setting')]
 class Zones extends Component
 {
@@ -31,11 +36,18 @@ class Zones extends Component
         $this->dispatch('zone.changed', currentZoneId: $value);
     }
 
+    /**
+     * @return Collection<int, Zone>
+     */
+    #[Computed]
+    public function zones(): Collection
+    {
+        return Zone::with(['carriers', 'countries'])->get();
+    }
+
     public function render(): View
     {
-        return view('shopper::livewire.pages.settings.zones', [
-            'zones' => Zone::with(['carriers', 'countries'])->get(),
-        ])
+        return view('shopper::livewire.pages.settings.zones')
             ->title(__('shopper::pages/settings/zones.title'));
     }
 }

--- a/packages/admin/src/Livewire/SlideOvers/DiscountForm.php
+++ b/packages/admin/src/Livewire/SlideOvers/DiscountForm.php
@@ -71,7 +71,9 @@ class DiscountForm extends SlideOverComponent implements HasActions, HasSchemas,
 
     public function mount(?int $discountId = null): void
     {
-        abort_unless($this->authorize('add_discounts') || $this->authorize('edit_discounts'), 403);
+        $user = shopper()->auth()->user();
+
+        abort_unless($user->can('add_discounts') || $user->can('edit_discounts'), 403);
 
         $this->discount = $discountId
             ? Discount::query()->find($discountId)
@@ -361,6 +363,8 @@ class DiscountForm extends SlideOverComponent implements HasActions, HasSchemas,
 
     public function store(): void
     {
+        $this->authorize($this->discount->id ? 'edit_discounts' : 'add_discounts');
+
         $data = $this->form->getState();
         $discountFormValues = Arr::except($data, ['products', 'customers', 'usage_number']);
 

--- a/packages/admin/src/Livewire/SlideOvers/ManagePricing.php
+++ b/packages/admin/src/Livewire/SlideOvers/ManagePricing.php
@@ -129,7 +129,7 @@ class ManagePricing extends SlideOverComponent implements HasActions, HasSchemas
                 [
                     'amount' => $price->amount,
                     'compare_amount' => $price->compare_amount === 0 ? null : $price->compare_amount,
-                    'cost_amount' => $price->cost_amount === 0 ? null : $price->compare_amount,
+                    'cost_amount' => $price->cost_amount === 0 ? null : $price->cost_amount,
                 ]
             );
         }

--- a/packages/cart/src/CartManager.php
+++ b/packages/cart/src/CartManager.php
@@ -6,6 +6,7 @@ namespace Shopper\Cart;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\DB;
 use InvalidArgumentException;
 use Shopper\Cart\Events\CouponApplied;
 use Shopper\Cart\Events\CouponRemoved;
@@ -20,6 +21,7 @@ use Shopper\Core\Contracts\Priceable;
 use Shopper\Core\Enum\AddressType;
 use Shopper\Core\Models\Contracts\Stockable;
 use Shopper\Core\Models\Discount;
+use Throwable;
 
 final readonly class CartManager
 {
@@ -29,57 +31,66 @@ final readonly class CartManager
 
     /**
      * @param  array<string, mixed>|null  $metadata
+     *
+     * @throws Throwable
      */
     public function add(Cart $cart, Priceable&Model $purchasable, int $quantity = 1, ?array $metadata = null): CartLine
     {
         $this->guardQuantity($quantity);
         $this->guardCompleted($cart);
 
-        $existing = $cart->lines()
-            ->where('purchasable_type', $purchasable->getMorphClass())
-            ->where('purchasable_id', $purchasable->getKey())
-            ->first();
+        return DB::transaction(function () use ($cart, $purchasable, $quantity, $metadata): CartLine {
+            $existing = $cart->lines()
+                ->where('purchasable_type', $purchasable->getMorphClass())
+                ->where('purchasable_id', $purchasable->getKey())
+                ->lockForUpdate()
+                ->first();
 
-        $requestedQuantity = $existing ? $existing->quantity + $quantity : $quantity;
-        $this->guardStock($purchasable, $requestedQuantity);
+            $requestedQuantity = $existing ? $existing->quantity + $quantity : $quantity;
+            $this->guardStock($purchasable, $requestedQuantity);
 
-        if ($existing) {
-            $existing->update([
-                'quantity' => $requestedQuantity,
+            if ($existing) {
+                $existing->update([
+                    'quantity' => $requestedQuantity,
+                ]);
+
+                return $existing->refresh();
+            }
+
+            $price = $purchasable->getPrice($cart->currency_code);
+
+            return $cart->lines()->create([
+                'purchasable_type' => $purchasable->getMorphClass(),
+                'purchasable_id' => $purchasable->getKey(),
+                'quantity' => $quantity,
+                'unit_price_amount' => $price ? $price->amount : 0,
+                'metadata' => $metadata,
             ]);
-
-            return $existing->refresh();
-        }
-
-        $price = $purchasable->getPrice($cart->currency_code);
-
-        return $cart->lines()->create([
-            'purchasable_type' => $purchasable->getMorphClass(),
-            'purchasable_id' => $purchasable->getKey(),
-            'quantity' => $quantity,
-            'unit_price_amount' => $price ? $price->amount : 0,
-            'metadata' => $metadata,
-        ]);
+        });
     }
 
     /**
      * @param  array{quantity?: int, metadata?: array<string, mixed>|null}  $data
+     *
+     * @throws Throwable
      */
     public function update(Cart $cart, int $lineId, array $data): CartLine
     {
         $this->guardCompleted($cart);
 
-        /** @var CartLine $line */
-        $line = $cart->lines()->findOrFail($lineId);
+        return DB::transaction(function () use ($cart, $lineId, $data): CartLine {
+            /** @var CartLine $line */
+            $line = $cart->lines()->lockForUpdate()->findOrFail($lineId);
 
-        if (isset($data['quantity'])) {
-            $this->guardQuantity($data['quantity']);
-            $this->guardStock($line->purchasable, $data['quantity']);
-        }
+            if (isset($data['quantity'])) {
+                $this->guardQuantity($data['quantity']);
+                $this->guardStock($line->purchasable, $data['quantity']);
+            }
 
-        $line->update(Arr::only($data, ['quantity', 'metadata']));
+            $line->update(Arr::only($data, ['quantity', 'metadata']));
 
-        return $line->refresh();
+            return $line->refresh();
+        });
     }
 
     public function remove(Cart $cart, int $lineId): void

--- a/packages/cart/src/Pipelines/CartPipelineContext.php
+++ b/packages/cart/src/Pipelines/CartPipelineContext.php
@@ -8,13 +8,13 @@ use Shopper\Cart\Models\Cart;
 
 final class CartPipelineContext
 {
-    public int|float $subtotal = 0;
+    public int $subtotal = 0;
 
-    public int|float $discountTotal = 0;
+    public int $discountTotal = 0;
 
-    public int|float $taxTotal = 0;
+    public int $taxTotal = 0;
 
-    public int|float $total = 0;
+    public int $total = 0;
 
     public bool $taxInclusive = false;
 

--- a/packages/core/src/Models/InventoryHistory.php
+++ b/packages/core/src/Models/InventoryHistory.php
@@ -30,7 +30,7 @@ use Shopper\Core\Models\Contracts\ShopperUser;
  * @property-read CarbonInterface $created_at
  * @property-read CarbonInterface $updated_at
  * @property-read Inventory $inventory
- * @property-read Model&ShopperUser $suer
+ * @property-read Model&ShopperUser $user
  */
 class InventoryHistory extends Model implements InventoryHistoryContract
 {

--- a/packages/core/src/Models/Order.php
+++ b/packages/core/src/Models/Order.php
@@ -115,7 +115,12 @@ class Order extends Model implements OrderContract
             OrderStatus::Cancelled,
             OrderStatus::Archived,
         ], true)
-            && $this->shipping_status === ShippingStatus::Unfulfilled;
+            && ! in_array($this->shipping_status, [
+                ShippingStatus::Delivered,
+                ShippingStatus::PartiallyDelivered,
+                ShippingStatus::Returned,
+                ShippingStatus::PartiallyReturned,
+            ], true);
     }
 
     public function isNotCancelled(): bool

--- a/packages/core/src/Models/OrderItem.php
+++ b/packages/core/src/Models/OrderItem.php
@@ -19,8 +19,8 @@ use Shopper\Core\Models\Contracts\OrderItem as OrderItemContract;
  * @property-read int $id
  * @property-read string $name
  * @property-read int $quantity
- * @property-read float|int|null $unit_price_amount
- * @property-read float|int|null $total
+ * @property-read int $unit_price_amount
+ * @property-read int $total
  * @property-read string $sku
  * @property-read int $product_id
  * @property-read string $product_type
@@ -112,7 +112,7 @@ class OrderItem extends Model implements OrderItemContract
     protected function total(): Attribute
     {
         return Attribute::make(
-            get: fn (): int|float => ($this->unit_price_amount * $this->quantity) - $this->discount_amount
+            get: fn (): int => ($this->unit_price_amount * $this->quantity) - $this->discount_amount
         );
     }
 }

--- a/packages/stripe/src/StripeDriver.php
+++ b/packages/stripe/src/StripeDriver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Shopper\Stripe;
 
+use Illuminate\Support\Str;
 use Shopper\Payment\DataTransferObjects\PaymentResult;
 use Shopper\Payment\DataTransferObjects\WebhookResult;
 use Shopper\Payment\Drivers\Driver;
@@ -70,7 +71,11 @@ final class StripeDriver extends Driver
                 $params['metadata'] = $context['metadata'];
             }
 
-            $intent = $this->getClient()->paymentIntents->create($params);
+            $idempotencyKey = $context['idempotency_key'] ?? Str::uuid()->toString();
+
+            $intent = $this->getClient()->paymentIntents->create($params, [
+                'idempotency_key' => $idempotencyKey,
+            ]);
 
             return new PaymentResult(
                 success: true,
@@ -81,6 +86,7 @@ final class StripeDriver extends Driver
                 data: [
                     'stripe_status' => $intent->status,
                     'publishable_key' => $this->publishableKey,
+                    'idempotency_key' => $idempotencyKey,
                 ],
             );
         } catch (ApiErrorException $e) {
@@ -147,7 +153,9 @@ final class StripeDriver extends Driver
                 $params['reason'] = $reason;
             }
 
-            $refund = $this->getClient()->refunds->create($params);
+            $refund = $this->getClient()->refunds->create($params, [
+                'idempotency_key' => Str::uuid()->toString(),
+            ]);
 
             return new PaymentResult(
                 success: $refund->status === 'succeeded',

--- a/tests/Admin/Livewire/Pages/Settings/ZonesTest.php
+++ b/tests/Admin/Livewire/Pages/Settings/ZonesTest.php
@@ -36,6 +36,6 @@ describe(Zones::class, function (): void {
 
         $component = Livewire::test(Zones::class);
 
-        expect($component->viewData('zones')->count())->toBe(2);
+        expect($component->instance()->zones->count())->toBe(2);
     });
 })->group('livewire', 'settings', 'zones');

--- a/tests/Core/Models/OrderTest.php
+++ b/tests/Core/Models/OrderTest.php
@@ -65,14 +65,22 @@ describe(Order::class, function (): void {
             ->and($shipped->isShipped())->toBeTrue();
     });
 
-    it('checks `canBeCancelled()` requires pending shipping and non-terminal status', function (): void {
+    it('checks `canBeCancelled()` blocks delivered/returned and terminal order statuses', function (): void {
         $canCancel = Order::factory()->create([
             'status' => OrderStatus::Processing,
             'shipping_status' => ShippingStatus::Unfulfilled,
         ]);
-        $cannotCancelShipped = Order::factory()->create([
+        $canCancelShipped = Order::factory()->create([
             'status' => OrderStatus::Processing,
             'shipping_status' => ShippingStatus::Shipped,
+        ]);
+        $cannotCancelDelivered = Order::factory()->create([
+            'status' => OrderStatus::Processing,
+            'shipping_status' => ShippingStatus::Delivered,
+        ]);
+        $cannotCancelReturned = Order::factory()->create([
+            'status' => OrderStatus::Processing,
+            'shipping_status' => ShippingStatus::Returned,
         ]);
         $alreadyCancelled = Order::factory()->create([
             'status' => OrderStatus::Cancelled,
@@ -84,7 +92,9 @@ describe(Order::class, function (): void {
         ]);
 
         expect($canCancel->canBeCancelled())->toBeTrue()
-            ->and($cannotCancelShipped->canBeCancelled())->toBeFalse()
+            ->and($canCancelShipped->canBeCancelled())->toBeTrue()
+            ->and($cannotCancelDelivered->canBeCancelled())->toBeFalse()
+            ->and($cannotCancelReturned->canBeCancelled())->toBeFalse()
             ->and($alreadyCancelled->canBeCancelled())->toBeFalse()
             ->and($archived->canBeCancelled())->toBeFalse();
     });

--- a/tests/Core/Workflows/Order/OrderCancellationTest.php
+++ b/tests/Core/Workflows/Order/OrderCancellationTest.php
@@ -27,19 +27,37 @@ describe('Order cancellation rules', function (): void {
         expect($order->canBeCancelled())->toBeTrue();
     });
 
-    it('blocks cancellation when items are shipped', function (): void {
+    it('allows cancellation when items are shipped', function (): void {
         $order = Order::factory()->create([
             'status' => OrderStatus::Processing,
             'shipping_status' => ShippingStatus::Shipped,
         ]);
 
-        expect($order->canBeCancelled())->toBeFalse();
+        expect($order->canBeCancelled())->toBeTrue();
     });
 
-    it('blocks cancellation when items are partially shipped', function (): void {
+    it('allows cancellation when items are partially shipped', function (): void {
         $order = Order::factory()->create([
             'status' => OrderStatus::Processing,
             'shipping_status' => ShippingStatus::PartiallyShipped,
+        ]);
+
+        expect($order->canBeCancelled())->toBeTrue();
+    });
+
+    it('blocks cancellation when items are delivered', function (): void {
+        $order = Order::factory()->create([
+            'status' => OrderStatus::Processing,
+            'shipping_status' => ShippingStatus::Delivered,
+        ]);
+
+        expect($order->canBeCancelled())->toBeFalse();
+    });
+
+    it('blocks cancellation when items are returned', function (): void {
+        $order = Order::factory()->create([
+            'status' => OrderStatus::Processing,
+            'shipping_status' => ShippingStatus::Returned,
         ]);
 
         expect($order->canBeCancelled())->toBeFalse();

--- a/tests/Stripe/StripeDriverTest.php
+++ b/tests/Stripe/StripeDriverTest.php
@@ -115,6 +115,8 @@ describe(StripeDriver::class, function (): void {
                     fn (array $params): bool => $params['amount'] === 5000
                     && $params['currency'] === 'usd'
                     && $params['capture_method'] === 'manual'
+                ), Mockery::on(
+                    fn (array $opts): bool => isset($opts['idempotency_key'])
                 ))
                 ->andReturn($intent);
 
@@ -140,6 +142,8 @@ describe(StripeDriver::class, function (): void {
                     fn (array $params): bool => $params['payment_method'] === 'pm_test_123'
                     && $params['customer'] === 'cus_test_456'
                     && $params['metadata'] === ['order_id' => 'ORD-001']
+                ), Mockery::on(
+                    fn (array $opts): bool => isset($opts['idempotency_key'])
                 ))
                 ->andReturn(PaymentIntent::constructFrom([
                     'id' => 'pi_test_456',
@@ -164,7 +168,7 @@ describe(StripeDriver::class, function (): void {
 
             $mocks->paymentIntents->shouldReceive('create')
                 ->once()
-                ->with(Mockery::on(fn (array $params): bool => $params['currency'] === 'eur'))
+                ->with(Mockery::on(fn (array $params): bool => $params['currency'] === 'eur'), Mockery::type('array'))
                 ->andReturn(PaymentIntent::constructFrom([
                     'id' => 'pi_test',
                     'status' => 'requires_payment_method',
@@ -366,6 +370,8 @@ describe(StripeDriver::class, function (): void {
                     fn (array $params): bool => $params['payment_intent'] === 'pi_test_123'
                     && $params['amount'] === 5000
                     && ! isset($params['reason'])
+                ), Mockery::on(
+                    fn (array $opts): bool => isset($opts['idempotency_key'])
                 ))
                 ->andReturn($refund);
 
@@ -393,6 +399,8 @@ describe(StripeDriver::class, function (): void {
                 ->with(Mockery::on(
                     fn (array $params): bool => $params['amount'] === 2500
                     && $params['reason'] === 'requested_by_customer'
+                ), Mockery::on(
+                    fn (array $opts): bool => isset($opts['idempotency_key'])
                 ))
                 ->andReturn($refund);
 


### PR DESCRIPTION
## Summary

- Fix `ManagePricing` cost_amount incorrectly mapped to compare_amount (data corruption)
- Fix `DiscountForm` authorization pattern using `can()` instead of `authorize()` for OR logic
- Add authorization re-check on `DiscountForm::store()` method
- Enforce strict `int` types on `CartPipelineContext` monetary fields (was `int|float`)
- Fix `OrderItem::total` return type from `int|float` to `int`
- Fix `InventoryHistory` PHPDoc typo (`$suer` → `$user`)
- Move `render()` queries to `#[Computed]` in `VariantStock`, `Zones`, `Taxes`
- Update Blade views to use `$this->` for computed properties
- Relax `canBeCancelled()` to allow cancellation for shipped/partially shipped orders (block only delivered/returned)
- Add Stripe idempotency keys on payment intent creation and refunds
- Wrap `CartManager::add()`/`update()` in DB transactions with `lockForUpdate()`