### PR TITLE
fix(ui): consistency and accessibility improvements

### DIFF
--- a/packages/admin/resources/views/components/category-tree-item.blade.php
+++ b/packages/admin/resources/views/components/category-tree-item.blade.php
@@ -29,6 +29,7 @@
             @if ($category->children->isNotEmpty())
                 <button
                     type="button"
+                    aria-label="{{ __('shopper::words.collapse') }}"
                     class="rounded p-0.5 text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300"
                     x-on:click="$el.closest('[data-sort-item]').querySelector('[data-children]').classList.toggle('hidden')"
                 >

--- a/packages/admin/src/Livewire/Components/Products/Form/Edit.php
+++ b/packages/admin/src/Livewire/Components/Products/Form/Edit.php
@@ -23,6 +23,7 @@ use Filament\Schemas\Concerns\InteractsWithSchemas;
 use Filament\Schemas\Contracts\HasSchemas;
 use Filament\Schemas\Schema;
 use Filament\Support\Enums\IconSize;
+use Filament\Support\Enums\Width;
 use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
@@ -192,7 +193,7 @@ class Edit extends Component implements HasActions, HasSchemas
                                             ->unique(ProductTag::class, 'slug'),
                                     ])
                                     ->createOptionModalHeading(__('shopper::pages/tags.create'))
-                                    ->createOptionAction(fn (Action $action): Action => $action->modalWidth('md'))
+                                    ->createOptionAction(fn (Action $action): Action => $action->modalWidth(Width::Medium))
                                     ->visible(Feature::enabled('tag')),
                             ])
                             ->visible(

--- a/packages/admin/src/Livewire/Pages/Attribute/Browse.php
+++ b/packages/admin/src/Livewire/Pages/Attribute/Browse.php
@@ -122,7 +122,7 @@ class Browse extends AbstractPageComponent implements HasActions, HasSchemas, Ha
                     ->deselectRecordsAfterCompletion(),
                 BulkAction::make('enabled')
                     ->label(__('shopper::forms.actions.enable'))
-                    ->icon('untitledui-check-verified')
+                    ->icon(Untitledui::CheckVerified)
                     ->action(function (Collection $records): void {
                         $records->each->updateStatus(); // @phpstan-ignore-line
 
@@ -138,7 +138,7 @@ class Browse extends AbstractPageComponent implements HasActions, HasSchemas, Ha
                     ->deselectRecordsAfterCompletion(),
                 BulkAction::make('disabled')
                     ->label(__('shopper::forms.actions.disable'))
-                    ->icon('untitledui-slash-circle-01')
+                    ->icon(Untitledui::SlashCircle01)
                     ->action(function (Collection $records): void {
                         $records->each->updateStatus(false); // @phpstan-ignore-line
 

--- a/packages/admin/src/Livewire/Pages/Brand/Index.php
+++ b/packages/admin/src/Livewire/Pages/Brand/Index.php
@@ -96,7 +96,7 @@ class Index extends AbstractPageComponent implements HasActions, HasSchemas, Has
             ->groupedBulkActions([
                 BulkAction::make('enabled')
                     ->label(__('shopper::forms.actions.enable'))
-                    ->icon('untitledui-check-verified')
+                    ->icon(Untitledui::CheckVerified)
                     ->action(function (Collection $records): void {
                         $records->each->updateStatus(); // @phpstan-ignore-line
 
@@ -112,7 +112,7 @@ class Index extends AbstractPageComponent implements HasActions, HasSchemas, Has
                     ->deselectRecordsAfterCompletion(),
                 BulkAction::make('disabled')
                     ->label(__('shopper::forms.actions.disable'))
-                    ->icon('untitledui-slash-circle-01')
+                    ->icon(Untitledui::SlashCircle01)
                     ->action(function (Collection $records): void {
                         $records->each->updateStatus(false); // @phpstan-ignore-line
 


### PR DESCRIPTION
## Summary

- Add `aria-label` on category tree item toggle button for screen reader accessibility
- Convert string icon references to `Untitledui::` enum in Attribute and Brand bulk actions
- Use `Width::Medium` enum instead of string `'md'` for modal width in product tag creation