### PR TITLE
feat: add starter kit export command and simplify kit:init

### DIFF
--- a/packages/admin/src/Console/KitExportCommand.php
+++ b/packages/admin/src/Console/KitExportCommand.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
+use RuntimeException;
+use Shopper\StarterKit\Exporter;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+use function Laravel\Prompts\confirm;
+
+#[AsCommand(name: 'shopper:kit:export')]
+final class KitExportCommand extends Command
+{
+    protected $signature = 'shopper:kit:export
+        {path : The path to the starter kit directory}
+        {--clear : Clear the export path before exporting (preserves .git)}';
+
+    protected $description = 'Export your project files into a starter kit';
+
+    public function handle(Filesystem $files): int
+    {
+        $path = $this->resolvePath();
+
+        $this->newLine();
+        $this->line('  <fg=#3B82F6>◆</> Exporting starter kit');
+        $this->newLine();
+
+        if (! $files->isDirectory($path)) {
+            if (! confirm("  Path [{$path}] does not exist. Create it?")) {
+                return self::SUCCESS;
+            }
+
+            $files->makeDirectory($path, 0755, true);
+        }
+
+        try {
+            $exporter = new Exporter(
+                command: $this,
+                files: $files,
+                exportPath: $path,
+                clear: (bool) $this->option('clear'),
+            );
+
+            $exporter->export();
+        } catch (RuntimeException $exception) {
+            $this->newLine();
+            $this->line('  <fg=#EF4444;options=bold>✗ Export failed.</>');
+            $this->line("  <fg=#94A3B8>{$exception->getMessage()}</>");
+            $this->newLine();
+
+            return self::FAILURE;
+        }
+
+        $this->newLine();
+        $this->line('  <fg=#22C55E;options=bold>✓ Starter kit exported successfully!</>');
+        $this->newLine();
+        $this->line("  <fg=#475569>Exported to:</> <options=bold>{$path}</>");
+        $this->newLine();
+
+        return self::SUCCESS;
+    }
+
+    private function resolvePath(): string
+    {
+        $path = $this->argument('path');
+
+        if (str_starts_with($path, '/')) {
+            return $path;
+        }
+
+        return base_path($path);
+    }
+}

--- a/packages/admin/src/Console/KitInitCommand.php
+++ b/packages/admin/src/Console/KitInitCommand.php
@@ -4,20 +4,20 @@ declare(strict_types=1);
 
 namespace Shopper\Console;
 
-use Closure;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
-use stdClass;
+use Shopper\StarterKit\Concerns\HasConsoleTask;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 use function Laravel\Prompts\confirm;
-use function Laravel\Prompts\spin;
 use function Laravel\Prompts\text;
 use function Laravel\Prompts\warning;
 
 #[AsCommand(name: 'shopper:kit:init')]
 final class KitInitCommand extends Command
 {
+    use HasConsoleTask;
+
     protected $signature = 'shopper:kit:init
         {--path= : Directory where the kit will be created}';
 
@@ -69,25 +69,20 @@ final class KitInitCommand extends Command
 
         $this->newLine();
 
-        $this->task('Creating directory structure', function () use ($files, $directory): void {
-            $files->makeDirectory($directory.'/resources/views', 0755, true);
-            $files->makeDirectory($directory.'/resources/css', 0755, true);
-            $files->makeDirectory($directory.'/resources/js', 0755, true);
-            $files->makeDirectory($directory.'/routes', 0755, true);
-
-            $files->put($directory.'/resources/views/.gitkeep', '');
-            $files->put($directory.'/resources/css/.gitkeep', '');
-            $files->put($directory.'/resources/js/.gitkeep', '');
-            $files->put($directory.'/routes/.gitkeep', '');
+        $this->task('Creating directory', function () use ($files, $directory): void {
+            $files->makeDirectory($directory, 0755, true);
         });
 
-        $this->task('Generating composer.json', function () use ($files, $directory, $package, $description): void {
+        $this->task('Generating composer.json', function () use ($files, $directory, $package, $description, $author): void {
             $files->put($directory.'/composer.json', json_encode([
                 'name' => $package,
                 'description' => $description,
-                'type' => 'shopper-starter-kit',
                 'license' => 'MIT',
-                'require' => new stdClass,
+                'authors' => [
+                    [
+                        'name' => $author,
+                    ],
+                ],
             ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
         });
 
@@ -146,8 +141,10 @@ final class KitInitCommand extends Command
         $this->line("  <fg=#475569>Created at:</> <options=bold>{$directory}</>");
         $this->newLine();
         $this->line('  <fg=#475569>Next steps:</>');
-        $this->line('  <fg=#3B82F6>→</> Add your storefront files (<options=bold>resources/</>, <options=bold>routes/</>)');
+        $relativePath = $this->relativePath($directory);
+
         $this->line('  <fg=#3B82F6>→</> Edit <options=bold>shopper-kit.yaml</> to configure export_paths');
+        $this->line('  <fg=#3B82F6>→</> Run <options=bold>php artisan shopper:kit:export '.$relativePath.'</> to export files from your project');
         $this->line('  <fg=#3B82F6>→</> Publish on GitHub or Packagist');
         $this->newLine();
 
@@ -162,16 +159,22 @@ final class KitInitCommand extends Command
 
         $name = explode('/', $package)[1];
 
-        return getcwd().'/'.$name;
+        return base_path($name);
     }
 
-    private function task(string $title, Closure $callback): void
+    private function relativePath(string $absolutePath): string
     {
-        spin(callback: $callback, message: $title);
+        $basePath = base_path().'/';
 
-        $width = 52;
-        $dots = str_repeat('.', max(1, $width - mb_strlen($title)));
+        if (str_starts_with($absolutePath, $basePath)) {
+            return mb_substr($absolutePath, mb_strlen($basePath));
+        }
 
-        $this->output->writeln("  <fg=#94A3B8>{$title}</> <fg=#334155>{$dots}</> <fg=#22C55E>✓</>");
+        return $absolutePath;
+    }
+
+    private function taskOutput(): \Symfony\Component\Console\Output\OutputInterface
+    {
+        return $this->output;
     }
 }

--- a/packages/admin/src/ShopperServiceProvider.php
+++ b/packages/admin/src/ShopperServiceProvider.php
@@ -69,6 +69,7 @@ final class ShopperServiceProvider extends PackageServiceProvider
             ->hasCommands([
                 Console\ComponentPublishCommand::class,
                 Console\InstallCommand::class,
+                Console\KitExportCommand::class,
                 Console\KitInitCommand::class,
                 Console\KitInstallCommand::class,
                 Console\PublishCommand::class,

--- a/packages/admin/src/StarterKit/Concerns/HasConsoleTask.php
+++ b/packages/admin/src/StarterKit/Concerns/HasConsoleTask.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\StarterKit\Concerns;
+
+use Closure;
+
+use function Laravel\Prompts\spin;
+
+trait HasConsoleTask
+{
+    private function task(string $title, Closure $callback): void
+    {
+        spin(callback: $callback, message: $title);
+
+        $width = 52;
+        $dots = str_repeat('.', max(1, $width - mb_strlen($title)));
+
+        $this->taskOutput()->writeln("  <fg=#94A3B8>{$title}</> <fg=#334155>{$dots}</> <fg=#22C55E>✓</>");
+    }
+}

--- a/packages/admin/src/StarterKit/Exporter.php
+++ b/packages/admin/src/StarterKit/Exporter.php
@@ -1,0 +1,341 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\StarterKit;
+
+use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
+use RuntimeException;
+use Shopper\StarterKit\Concerns\HasConsoleTask;
+use Shopper\StarterKit\Exceptions\InvalidManifestException;
+use Shopper\StarterKit\Exceptions\ManifestNotFoundException;
+use Symfony\Component\Yaml\Yaml;
+
+use function Laravel\Prompts\warning;
+
+final class Exporter
+{
+    use HasConsoleTask;
+
+    private const string MANIFEST_FILE = 'shopper-kit.yaml';
+
+    /** @var list<string> */
+    private const array FORBIDDEN_EXPORTS = [
+        'composer.json',
+        'composer.lock',
+        'shopper-kit.yaml',
+        '.env',
+        'vendor',
+        'node_modules',
+        '.git',
+    ];
+
+    private Manifest $manifest;
+
+    public function __construct(
+        private readonly Command $command,
+        private readonly Filesystem $files,
+        private readonly string $exportPath,
+        private readonly bool $clear = false,
+    ) {}
+
+    public function export(): void
+    {
+        $this
+            ->loadManifest()
+            ->validateExportPaths()
+            ->validateDependencies()
+            ->clearExportPath()
+            ->copyFiles()
+            ->versionDependencies()
+            ->exportManifest()
+            ->exportComposerJson();
+    }
+
+    private function loadManifest(): self
+    {
+        $manifestPath = mb_rtrim($this->exportPath, '/').'/'.self::MANIFEST_FILE;
+
+        try {
+            $this->manifest = Manifest::fromPath($manifestPath);
+        } catch (ManifestNotFoundException) {
+            $this->abort("No shopper-kit.yaml found at [{$this->exportPath}]. Run shopper:kit:init first.");
+        } catch (InvalidManifestException $exception) {
+            $this->abort($exception->getMessage());
+        }
+
+        return $this;
+    }
+
+    private function validateExportPaths(): self
+    {
+        foreach ($this->manifest->exportPaths as $path) {
+            if ($this->isForbidden($path)) {
+                $this->abort("Export path [{$path}] is forbidden and cannot be exported.");
+            }
+
+            $sourcePath = base_path($path);
+
+            if (! $this->files->exists($sourcePath)) {
+                $this->abort("Export path [{$path}] does not exist in your project.");
+            }
+        }
+
+        return $this;
+    }
+
+    private function validateDependencies(): self
+    {
+        $composerJson = $this->readProjectComposerJson();
+
+        if ($composerJson === null) {
+            return $this;
+        }
+
+        $installed = array_merge(
+            $composerJson['require'] ?? [],
+            $composerJson['require-dev'] ?? [],
+        );
+
+        foreach (array_keys($this->manifest->dependencies) as $package) {
+            if (! isset($installed[$package])) {
+                warning("  Dependency [{$package}] is listed in shopper-kit.yaml but not installed in your project.");
+            }
+        }
+
+        foreach (array_keys($this->manifest->devDependencies) as $package) {
+            if (! isset($installed[$package])) {
+                warning("  Dev dependency [{$package}] is listed in shopper-kit.yaml but not installed in your project.");
+            }
+        }
+
+        return $this;
+    }
+
+    private function clearExportPath(): self
+    {
+        if (! $this->clear) {
+            return $this;
+        }
+
+        $this->task('Clearing export path', function (): void {
+            $gitPath = mb_rtrim($this->exportPath, '/').'/.git';
+            $hasGit = $this->files->isDirectory($gitPath);
+            $tempGitPath = sys_get_temp_dir().'/shopper-kit-git-'.bin2hex(random_bytes(8));
+
+            if ($hasGit) {
+                $this->files->moveDirectory($gitPath, $tempGitPath);
+            }
+
+            foreach ($this->files->glob(mb_rtrim($this->exportPath, '/').'/*') as $item) {
+                if ($this->files->isDirectory($item)) {
+                    $this->files->deleteDirectory($item);
+                } else {
+                    $this->files->delete($item);
+                }
+            }
+
+            // Also remove hidden files (except .git which was moved)
+            foreach ($this->files->glob(mb_rtrim($this->exportPath, '/').'/.[!.]*') as $item) {
+                if ($this->files->isDirectory($item)) {
+                    $this->files->deleteDirectory($item);
+                } else {
+                    $this->files->delete($item);
+                }
+            }
+
+            if ($hasGit) {
+                $this->files->moveDirectory($tempGitPath, $gitPath);
+            }
+        });
+
+        return $this;
+    }
+
+    private function copyFiles(): self
+    {
+        $this->task('Exporting files', function (): void {
+            foreach ($this->manifest->exportPaths as $exportPath) {
+                $sourcePath = base_path($exportPath);
+                $targetPath = mb_rtrim($this->exportPath, '/').'/'.$exportPath;
+
+                if ($this->files->isDirectory($sourcePath)) {
+                    $this->copyDirectory($sourcePath, $targetPath);
+                } else {
+                    $this->copySingleFile($sourcePath, $targetPath);
+                }
+            }
+        });
+
+        return $this;
+    }
+
+    private function versionDependencies(): self
+    {
+        $composerJson = $this->readProjectComposerJson();
+
+        if ($composerJson === null) {
+            return $this;
+        }
+
+        $require = $composerJson['require'] ?? [];
+        $requireDev = $composerJson['require-dev'] ?? [];
+
+        $this->manifest = new Manifest(
+            name: $this->manifest->name,
+            description: $this->manifest->description,
+            version: $this->manifest->version,
+            author: $this->manifest->author,
+            url: $this->manifest->url,
+            shopperConstraint: $this->manifest->shopperConstraint,
+            phpConstraint: $this->manifest->phpConstraint,
+            laravelConstraint: $this->manifest->laravelConstraint,
+            exportPaths: $this->manifest->exportPaths,
+            dependencies: $this->resolveVersions($this->manifest->dependencies, $require),
+            devDependencies: $this->resolveVersions($this->manifest->devDependencies, $requireDev),
+            postInstall: $this->manifest->postInstall,
+        );
+
+        return $this;
+    }
+
+    private function exportManifest(): self
+    {
+        $this->task('Writing shopper-kit.yaml', function (): void {
+            $yaml = $this->buildYaml();
+
+            $this->files->put(
+                mb_rtrim($this->exportPath, '/').'/'.self::MANIFEST_FILE,
+                $yaml,
+            );
+        });
+
+        return $this;
+    }
+
+    private function buildYaml(): string
+    {
+        $sections = [];
+
+        $sections[] = Yaml::dump([
+            'name' => $this->manifest->name,
+            'description' => $this->manifest->description,
+            'version' => $this->manifest->version,
+            'author' => $this->manifest->author,
+            'url' => $this->manifest->url,
+        ]);
+
+        $sections[] = Yaml::dump([
+            'shopper' => $this->manifest->shopperConstraint,
+            'php' => $this->manifest->phpConstraint,
+            'laravel' => $this->manifest->laravelConstraint,
+        ]);
+
+        $sections[] = Yaml::dump(['export_paths' => $this->manifest->exportPaths], 4, 2);
+
+        if ($this->manifest->dependencies !== []) {
+            $sections[] = Yaml::dump(['dependencies' => $this->manifest->dependencies], 4, 2);
+        }
+
+        if ($this->manifest->devDependencies !== []) {
+            $sections[] = Yaml::dump(['dev_dependencies' => $this->manifest->devDependencies], 4, 2);
+        }
+
+        if ($this->manifest->postInstall !== []) {
+            $sections[] = Yaml::dump(['post_install' => $this->manifest->postInstall], 4, 2);
+        }
+
+        return implode("\n", $sections);
+    }
+
+    private function exportComposerJson(): self
+    {
+        $composerJsonPath = mb_rtrim($this->exportPath, '/').'/composer.json';
+
+        if (! $this->files->exists($composerJsonPath)) {
+            return $this;
+        }
+
+        // Touch the file to update its modification time
+        touch($composerJsonPath);
+
+        return $this;
+    }
+
+    private function copyDirectory(string $sourcePath, string $targetPath): void
+    {
+        foreach ($this->files->allFiles($sourcePath) as $file) {
+            $relativePath = $file->getRelativePathname();
+            $fileTargetPath = mb_rtrim($targetPath, '/').'/'.$relativePath;
+
+            $this->copySingleFile($file->getPathname(), $fileTargetPath);
+        }
+    }
+
+    private function copySingleFile(string $sourcePath, string $targetPath): void
+    {
+        $directory = dirname($targetPath);
+
+        if (! $this->files->isDirectory($directory)) {
+            $this->files->makeDirectory($directory, 0755, true);
+        }
+
+        $this->files->copy($sourcePath, $targetPath);
+    }
+
+    /**
+     * @param  array<string, string>  $manifestDeps
+     * @param  array<string, string>  $composerDeps
+     * @return array<string, string>
+     */
+    private function resolveVersions(array $manifestDeps, array $composerDeps): array
+    {
+        $resolved = [];
+
+        foreach ($manifestDeps as $package => $version) {
+            $resolved[$package] = $composerDeps[$package] ?? $version;
+        }
+
+        return $resolved;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function readProjectComposerJson(): ?array
+    {
+        $composerJsonPath = base_path('composer.json');
+
+        if (! $this->files->exists($composerJsonPath)) {
+            return null;
+        }
+
+        $composerJson = json_decode($this->files->get($composerJsonPath), true);
+
+        return is_array($composerJson) ? $composerJson : null;
+    }
+
+    private function taskOutput(): \Symfony\Component\Console\Output\OutputInterface
+    {
+        return $this->command->getOutput();
+    }
+
+    private function isForbidden(string $path): bool
+    {
+        $normalized = mb_ltrim($path, '/');
+
+        foreach (self::FORBIDDEN_EXPORTS as $forbidden) {
+            if ($normalized === $forbidden || str_starts_with($normalized, $forbidden.'/')) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function abort(string $message): never
+    {
+        throw new RuntimeException($message);
+    }
+}

--- a/packages/admin/src/StarterKit/Installer.php
+++ b/packages/admin/src/StarterKit/Installer.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Shopper\StarterKit;
 
-use Closure;
 use Composer\InstalledVersions;
 use Composer\Semver\Semver;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Facades\Http;
 use RuntimeException;
+use Shopper\StarterKit\Concerns\HasConsoleTask;
 use Shopper\StarterKit\Exceptions\InvalidManifestException;
 use Shopper\StarterKit\Exceptions\ManifestNotFoundException;
 use Symfony\Component\Process\Process;
@@ -23,6 +23,8 @@ use function Laravel\Prompts\warning;
 
 final class Installer
 {
+    use HasConsoleTask;
+
     private const string MANIFEST_FILE = 'shopper-kit.yaml';
 
     /** @var list<string> */
@@ -503,14 +505,9 @@ final class Installer
         return $process;
     }
 
-    private function task(string $title, Closure $callback): void
+    private function taskOutput(): \Symfony\Component\Console\Output\OutputInterface
     {
-        spin(callback: $callback, message: $title);
-
-        $width = 52;
-        $dots = str_repeat('.', max(1, $width - mb_strlen($title)));
-
-        $this->command->getOutput()->writeln("  <fg=#94A3B8>{$title}</> <fg=#334155>{$dots}</> <fg=#22C55E>✓</>");
+        return $this->command->getOutput();
     }
 
     private function abort(string $message): never

--- a/tests/Admin/StarterKit/KitExportCommandTest.php
+++ b/tests/Admin/StarterKit/KitExportCommandTest.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Filesystem\Filesystem;
+
+uses(Tests\Admin\TestCase::class);
+
+beforeEach(function (): void {
+    $this->tempDir = sys_get_temp_dir().'/shopper-kit-export-test-'.uniqid();
+    $this->kitDir = $this->tempDir.'/my-kit';
+
+    mkdir($this->kitDir, 0755, true);
+});
+
+afterEach(function (): void {
+    (new Filesystem)->deleteDirectory($this->tempDir);
+});
+
+function createManifest(string $kitDir, array $overrides = []): void
+{
+    $defaults = [
+        'name' => 'Test Kit',
+        'description' => 'A test starter kit',
+        'version' => '1.0.0',
+        'author' => 'acme',
+        'url' => 'https://github.com/acme/test-kit',
+        'shopper' => '^2.7',
+        'php' => '^8.3',
+        'laravel' => '^11.0|^12.0',
+        'export_paths' => ['resources/views', 'routes/web.php'],
+        'dependencies' => [],
+        'post_install' => [],
+    ];
+
+    $data = array_merge($defaults, $overrides);
+
+    $yaml = "name: \"{$data['name']}\"\n";
+    $yaml .= "description: \"{$data['description']}\"\n";
+    $yaml .= "version: \"{$data['version']}\"\n";
+    $yaml .= "author: \"{$data['author']}\"\n";
+    $yaml .= "url: \"{$data['url']}\"\n";
+    $yaml .= "shopper: \"{$data['shopper']}\"\n";
+    $yaml .= "php: \"{$data['php']}\"\n";
+    $yaml .= "laravel: \"{$data['laravel']}\"\n";
+    $yaml .= "export_paths:\n";
+
+    foreach ($data['export_paths'] as $path) {
+        $yaml .= "  - {$path}\n";
+    }
+
+    file_put_contents($kitDir.'/shopper-kit.yaml', $yaml);
+}
+
+function createProjectFiles(string $baseDir): void
+{
+    @mkdir($baseDir.'/resources/views', 0755, true);
+    @mkdir($baseDir.'/routes', 0755, true);
+
+    file_put_contents($baseDir.'/resources/views/home.blade.php', '<h1>Home</h1>');
+    file_put_contents($baseDir.'/resources/views/product.blade.php', '<h1>Product</h1>');
+    file_put_contents($baseDir.'/routes/web.php', '<?php // routes');
+}
+
+it('exports project files to the kit directory', function (): void {
+    createProjectFiles(base_path());
+    createManifest($this->kitDir);
+
+    $this->artisan('shopper:kit:export', ['path' => $this->kitDir])
+        ->assertSuccessful();
+
+    expect($this->kitDir.'/resources/views/home.blade.php')->toBeFile()
+        ->and($this->kitDir.'/resources/views/product.blade.php')->toBeFile()
+        ->and($this->kitDir.'/routes/web.php')->toBeFile()
+        ->and($this->kitDir.'/shopper-kit.yaml')->toBeFile()
+        ->and(file_get_contents($this->kitDir.'/resources/views/home.blade.php'))->toBe('<h1>Home</h1>');
+});
+
+it('fails when `shopper-kit.yaml` is missing from the kit directory', function (): void {
+    $this->artisan('shopper:kit:export', ['path' => $this->kitDir])
+        ->assertFailed();
+});
+
+it('fails when an export path does not exist in the project', function (): void {
+    createManifest($this->kitDir, [
+        'export_paths' => ['resources/views', 'app/NonExistent'],
+    ]);
+
+    createProjectFiles(base_path());
+
+    $this->artisan('shopper:kit:export', ['path' => $this->kitDir])
+        ->assertFailed();
+});
+
+it('fails when a forbidden path is in `export_paths`', function (): void {
+    createManifest($this->kitDir, [
+        'export_paths' => ['resources/views', '.env'],
+    ]);
+
+    createProjectFiles(base_path());
+
+    $this->artisan('shopper:kit:export', ['path' => $this->kitDir])
+        ->assertFailed();
+});
+
+it('clears the export path while preserving `.git`', function (): void {
+    createProjectFiles(base_path());
+    createManifest($this->kitDir);
+
+    // Create a .git directory and an old file
+    mkdir($this->kitDir.'/.git', 0755, true);
+    file_put_contents($this->kitDir.'/.git/HEAD', 'ref: refs/heads/main');
+    file_put_contents($this->kitDir.'/old-file.txt', 'should be deleted');
+
+    $this->artisan('shopper:kit:export', ['path' => $this->kitDir, '--clear' => true])
+        ->assertSuccessful();
+
+    expect($this->kitDir.'/.git/HEAD')->toBeFile()
+        ->and(file_get_contents($this->kitDir.'/.git/HEAD'))->toBe('ref: refs/heads/main')
+        ->and($this->kitDir.'/old-file.txt')->not->toBeFile()
+        ->and($this->kitDir.'/resources/views/home.blade.php')->toBeFile();
+});
+
+it('versions dependencies from the project `composer.json`', function (): void {
+    createProjectFiles(base_path());
+    createManifest($this->kitDir, [
+        'export_paths' => ['resources/views'],
+    ]);
+
+    // Add a dependency that exists in the project's composer.json
+    $yaml = file_get_contents($this->kitDir.'/shopper-kit.yaml');
+    $yaml .= "\ndependencies:\n  laravel/framework: \"^11.0\"\n";
+    file_put_contents($this->kitDir.'/shopper-kit.yaml', $yaml);
+
+    $this->artisan('shopper:kit:export', ['path' => $this->kitDir])
+        ->assertSuccessful();
+
+    $exportedYaml = file_get_contents($this->kitDir.'/shopper-kit.yaml');
+
+    // Should have picked up the real version constraint from the project's composer.json
+    $composerJson = json_decode(file_get_contents(base_path('composer.json')), true);
+    $realVersion = $composerJson['require']['laravel/framework'] ?? null;
+
+    if ($realVersion === null) {
+        expect($exportedYaml)->toContain('laravel/framework');
+
+        return;
+    }
+
+    expect($exportedYaml)->toContain('laravel/framework')
+        ->and($exportedYaml)->toContain($realVersion);
+});
+
+it('asks to create the export directory if it does not exist', function (): void {
+    $newDir = $this->tempDir.'/new-kit';
+
+    $this->artisan('shopper:kit:export', ['path' => $newDir])
+        ->expectsConfirmation("  Path [{$newDir}] does not exist. Create it?", 'yes')
+        ->assertFailed(); // Fails because shopper-kit.yaml doesn't exist after dir creation
+
+    expect($newDir)->toBeDirectory();
+});

--- a/tests/Admin/StarterKit/KitInitCommandTest.php
+++ b/tests/Admin/StarterKit/KitInitCommandTest.php
@@ -28,11 +28,7 @@ it('scaffolds a complete starter kit structure', function (): void {
 
     expect($kitDir.'/composer.json')->toBeFile()
         ->and($kitDir.'/shopper-kit.yaml')->toBeFile()
-        ->and($kitDir.'/README.md')->toBeFile()
-        ->and($kitDir.'/resources/views/.gitkeep')->toBeFile()
-        ->and($kitDir.'/resources/css/.gitkeep')->toBeFile()
-        ->and($kitDir.'/resources/js/.gitkeep')->toBeFile()
-        ->and($kitDir.'/routes/.gitkeep')->toBeFile();
+        ->and($kitDir.'/README.md')->toBeFile();
 });
 
 it('generates valid JSON in `composer.json`', function (): void {
@@ -50,8 +46,8 @@ it('generates valid JSON in `composer.json`', function (): void {
     expect($composerJson)
         ->name->toBe('acme/starter-json')
         ->description->toBe('Testing JSON output')
-        ->type->toBe('shopper-starter-kit')
-        ->license->toBe('MIT');
+        ->license->toBe('MIT')
+        ->authors->toBe([['name' => 'acme']]);
 });
 
 it('generates a parsable `shopper-kit.yaml`', function (): void {


### PR DESCRIPTION
## Summary

- Add `shopper:kit:export {path} [--clear]` command that exports project files into a starter kit directory based on the kit's `shopper-kit.yaml` manifest
- Simplify `kit:init` to only generate essential files (no more empty directories)
- Extract `HasConsoleTask` trait to deduplicate the task helper across Installer, Exporter, and KitInitCommand

### Export command features
- Reads `shopper-kit.yaml` from the target kit directory
- Validates export paths exist and are not forbidden (`.env`, `vendor`, `composer.json`, etc.)
- Validates listed dependencies are installed in the project
- Copies project files to the kit directory
- Versions dependencies from the project's `composer.json`
- Writes formatted YAML with section separators
- `--clear` flag clears the export path while preserving `.git`

### kit:init changes
- Remove empty directory scaffolding (`resources/views/`, `routes/`, etc.)
- Remove `type` and `require` from generated `composer.json`
- Add `authors` field to generated `composer.json`
- Fix YAML template to use explicit `[]` instead of null values
- Update next steps hint to reference `kit:export`