### PR TITLE
fix(deps): support symfony/yaml v8 for Laravel 12 compatibility

### DIFF
--- a/packages/admin/composer.json
+++ b/packages/admin/composer.json
@@ -60,7 +60,7 @@
     "spatie/laravel-package-tools": "^1.9",
     "spatie/laravel-permission": "^6.24|^7.0",
     "stevebauman/location": "^7.2",
-    "symfony/yaml": "^7.0"
+    "symfony/yaml": "^7.0|^8.0"
   },
   "autoload": {
     "files": [


### PR DESCRIPTION
## Summary

- Widen `symfony/yaml` constraint from `^7.0` to `^7.0|^8.0` in `packages/admin/composer.json`
- Fixes installation failure on Laravel 12 projects where Symfony 8 packages are locked