### PR TITLE
fix(pricing): include morph type in SavePricingAction lookup

### DIFF
--- a/packages/admin/src/Actions/Store/Product/SavePricingAction.php
+++ b/packages/admin/src/Actions/Store/Product/SavePricingAction.php
@@ -22,6 +22,7 @@ final class SavePricingAction
                     attributes: [
                         'currency_id' => $key,
                         'priceable_id' => $model->id, // @phpstan-ignore-line
+                        'priceable_type' => $model->getMorphClass(),
                     ],
                     values: array_merge($price, [
                         'priceable_id' => $model->id, // @phpstan-ignore-line

--- a/tests/Admin/Actions/Store/Product/SavePricingActionTest.php
+++ b/tests/Admin/Actions/Store/Product/SavePricingActionTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Shopper\Actions\Store\Product\SavePricingAction;
 use Shopper\Core\Models\Currency;
 use Tests\Core\Stubs\Product;
+use Tests\Core\Stubs\ProductVariant;
 use Tests\Core\Stubs\User;
 
 uses(Tests\Admin\TestCase::class);
@@ -53,5 +54,30 @@ describe(SavePricingAction::class, function (): void {
 
         expect($product->prices()->count())->toBe(1)
             ->and($product->prices()->first()->amount)->toBe(2000);
+    });
+
+    it('keeps `Product` and `ProductVariant` prices isolated when their ids collide', function (): void {
+        $product = Product::factory()->create();
+        $variant = ProductVariant::factory()->create();
+        $currency = Currency::query()->first();
+
+        expect($product->id)->toBe($variant->id);
+
+        $action = new SavePricingAction();
+
+        $action(
+            pricing: [$currency->id => ['amount' => 1000]],
+            model: $product
+        );
+
+        $action(
+            pricing: [$currency->id => ['amount' => 2500]],
+            model: $variant
+        );
+
+        expect($product->prices()->count())->toBe(1)
+            ->and($product->prices()->first()->amount)->toBe(1000)
+            ->and($variant->prices()->count())->toBe(1)
+            ->and($variant->prices()->first()->amount)->toBe(2500);
     });
 })->group('actions', 'product');

--- a/tests/Admin/Actions/Store/Product/SavePricingActionTest.php
+++ b/tests/Admin/Actions/Store/Product/SavePricingActionTest.php
@@ -58,10 +58,8 @@ describe(SavePricingAction::class, function (): void {
 
     it('keeps `Product` and `ProductVariant` prices isolated when their ids collide', function (): void {
         $product = Product::factory()->create();
-        $variant = ProductVariant::factory()->create();
+        $variant = ProductVariant::factory()->create(['id' => $product->id]);
         $currency = Currency::query()->first();
-
-        expect($product->id)->toBe($variant->id);
 
         $action = new SavePricingAction();
 


### PR DESCRIPTION
## Summary

Fix a silent data-loss bug in `SavePricingAction` where saving a price for a `Product` and a `ProductVariant` with the same primary key would overwrite each other.

### Root cause

The `updateOrCreate` call was using only `currency_id` and `priceable_id` as search attributes:

```php
Price::query()->updateOrCreate(
    attributes: [
        'currency_id' => $key,
        'priceable_id' => $model->id,   // no priceable_type filter
    ],
    values: [...],
);
```

Because `priceable_type` was only in the `values` array, Eloquent would match any existing row with the same `priceable_id + currency_id` regardless of its morph type, then flip `priceable_type` on that row. One model's price would silently replace another's.

### Fix

Add `priceable_type` to the `attributes` array so the lookup is scoped to the model type. Regression test added in `SavePricingActionTest` that creates a `Product` and a `ProductVariant` with colliding IDs, saves a price on each, and asserts both prices coexist.

Closes #491.