### PR TITLE
fix(pricing): include morph type in SavePricingAction lookup

### DIFF
--- a/packages/admin/src/Actions/Store/Product/SavePricingAction.php
+++ b/packages/admin/src/Actions/Store/Product/SavePricingAction.php
@@ -22,6 +22,7 @@ final class SavePricingAction
                     attributes: [
                         'currency_id' => $key,
                         'priceable_id' => $model->id, // @phpstan-ignore-line
+                        'priceable_type' => $model->getMorphClass(),
                     ],
                     values: array_merge($price, [
                         'priceable_id' => $model->id, // @phpstan-ignore-line

--- a/tests/Admin/Actions/Store/Product/SavePricingActionTest.php
+++ b/tests/Admin/Actions/Store/Product/SavePricingActionTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Shopper\Actions\Store\Product\SavePricingAction;
 use Shopper\Core\Models\Currency;
 use Tests\Core\Stubs\Product;
+use Tests\Core\Stubs\ProductVariant;
 use Tests\Core\Stubs\User;
 
 uses(Tests\Admin\TestCase::class);
@@ -53,5 +54,28 @@ describe(SavePricingAction::class, function (): void {
 
         expect($product->prices()->count())->toBe(1)
             ->and($product->prices()->first()->amount)->toBe(2000);
+    });
+
+    it('keeps `Product` and `ProductVariant` prices isolated when their ids collide', function (): void {
+        $product = Product::factory()->create();
+        $variant = ProductVariant::factory()->create(['id' => $product->id]);
+        $currency = Currency::query()->first();
+
+        $action = new SavePricingAction();
+
+        $action(
+            pricing: [$currency->id => ['amount' => 1000]],
+            model: $product
+        );
+
+        $action(
+            pricing: [$currency->id => ['amount' => 2500]],
+            model: $variant
+        );
+
+        expect($product->prices()->count())->toBe(1)
+            ->and($product->prices()->first()->amount)->toBe(1000)
+            ->and($variant->prices()->count())->toBe(1)
+            ->and($variant->prices()->first()->amount)->toBe(2500);
     });
 })->group('actions', 'product');


### PR DESCRIPTION
Cherry-pick of #498 onto \`3.x\`.

Fix a silent data-loss bug in \`SavePricingAction\` where saving a price for a \`Product\` and a \`ProductVariant\` with the same primary key would overwrite each other. The \`updateOrCreate\` lookup now filters on \`priceable_type\` as well as \`priceable_id\`, so each morphed model keeps its own price row.

Already shipped on \`2.x\` as part of v2.7.3.