### PR TITLE
refactor(admin): drop redundant Shopper wordmark from header

### DIFF
--- a/packages/admin/resources/views/components/layouts/header.blade.php
+++ b/packages/admin/resources/views/components/layouts/header.blade.php
@@ -24,13 +24,10 @@
         class="flex items-center gap-2 font-semibold tracking-tight hover:opacity-80"
     >
         <x-shopper::brand class="size-6" aria-hidden="true" />
-        <span>Shopper</span>
+        @if ($storeName = shopper_setting('name'))
+            <span>{{ $storeName }}</span>
+        @endif
     </x-shopper::link>
-
-    @if ($storeName = shopper_setting('name'))
-        <span class="text-sh-header-fg-muted" aria-hidden="true">/</span>
-        <span class="font-medium">{{ $storeName }}</span>
-    @endif
 
     <span class="text-sh-header-fg-muted/60" aria-hidden="true">/</span>
 


### PR DESCRIPTION
## Summary

Simplifies the admin header branding: the brand icon and the store name from `shopper_setting('name')` now form a single unified block that links to the dashboard. The hardcoded "Shopper" wordmark is removed to avoid duplication next to the store name and to make the admin feel like the merchant's own.

## Before

`[icon] Shopper / {store name} / [breadcrumbs]`

## After

`[icon] {store name} / [breadcrumbs]`

If `shopper_setting('name')` is empty, the icon stays as the dashboard link — safe fallback, no broken layout.