### PR TITLE
feat(admin): session expired modal replacing the native 419 prompt

### DIFF
--- a/packages/admin/resources/lang/en/pages/auth.php
+++ b/packages/admin/resources/lang/en/pages/auth.php
@@ -16,6 +16,13 @@ return [
         'return_login' => 'Back to login',
     ],
 
+    'session_expired' => [
+        'title' => 'Resume your session',
+        'description' => 'Your session has expired. Enter your password to pick up where you left off.',
+        'submit' => 'Sign in',
+        'submitting' => 'Signing in…',
+    ],
+
     'reset' => [
         'title' => 'Reset password',
         'message' => 'Enter your email and the new password you\'d like to use to access your account.',

--- a/packages/admin/resources/lang/es/pages/auth.php
+++ b/packages/admin/resources/lang/es/pages/auth.php
@@ -16,6 +16,13 @@ return [
         'return_login' => 'Volver al inicio de sesión',
     ],
 
+    'session_expired' => [
+        'title' => 'Reanudar tu sesión',
+        'description' => 'Tu sesión ha expirado. Ingresa tu contraseña para continuar donde lo dejaste.',
+        'submit' => 'Iniciar sesión',
+        'submitting' => 'Iniciando sesión…',
+    ],
+
     'reset' => [
         'title' => 'Restablecer contraseña',
         'message' => 'Ingresa tu correo electrónico y la nueva contraseña que te gustaría usar para acceder a tu cuenta.',

--- a/packages/admin/resources/lang/fr/pages/auth.php
+++ b/packages/admin/resources/lang/fr/pages/auth.php
@@ -16,6 +16,13 @@ return [
         'return_login' => 'Retour à la connexion',
     ],
 
+    'session_expired' => [
+        'title' => 'Reprendre votre session',
+        'description' => 'Votre session a expiré. Entrez votre mot de passe pour reprendre là où vous en étiez.',
+        'submit' => 'Se connecter',
+        'submitting' => 'Connexion…',
+    ],
+
     'reset' => [
         'title' => 'Réinitialiser le mot de passe',
         'message' => 'Saisissez votre e-mail et le nouveau mot de passe que vous souhaitez utiliser pour accéder à votre compte.',

--- a/packages/admin/resources/views/components/layouts/app.blade.php
+++ b/packages/admin/resources/views/components/layouts/app.blade.php
@@ -37,5 +37,7 @@
                 </main>
             </div>
         </div>
+
+        <livewire:shopper-session-expired />
     </div>
 </x-shopper::layouts.base>

--- a/packages/admin/resources/views/livewire/components/session-expired.blade.php
+++ b/packages/admin/resources/views/livewire/components/session-expired.blade.php
@@ -1,0 +1,44 @@
+<div>
+    <x-filament::modal
+        id="session-expired"
+        :close-by-clicking-away="false"
+        :close-by-escaping="false"
+        width="md"
+    >
+        <x-slot name="heading">
+            {{ __('shopper::pages/auth.session_expired.title') }}
+        </x-slot>
+
+        <x-slot name="description">
+            {{ __('shopper::pages/auth.session_expired.description') }}
+        </x-slot>
+
+        <form wire:submit="attempt" class="flex items-center gap-2">
+            <div class="flex-1">
+                {{ $this->form }}
+            </div>
+
+            <x-filament::button type="submit" wire:loading.attr="disabled" wire:target="attempt">
+                <span wire:loading.remove wire:target="attempt">
+                    {{ __('shopper::pages/auth.session_expired.submit') }}
+                </span>
+                <span wire:loading wire:target="attempt">
+                    {{ __('shopper::pages/auth.session_expired.submitting') }}
+                </span>
+            </x-filament::button>
+        </form>
+    </x-filament::modal>
+</div>
+
+@script
+    <script>
+        Livewire.interceptRequest(({ onError }) => {
+            onError(({ response, preventDefault }) => {
+                if (response.status === 419) {
+                    preventDefault()
+                    Livewire.dispatch('open-modal', { id: 'session-expired' })
+                }
+            })
+        })
+    </script>
+@endscript

--- a/packages/admin/src/Livewire/Components/SessionExpired.php
+++ b/packages/admin/src/Livewire/Components/SessionExpired.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Livewire\Components;
+
+use DanHarrin\LivewireRateLimiting\Exceptions\TooManyRequestsException;
+use DanHarrin\LivewireRateLimiting\WithRateLimiting;
+use Filament\Forms\Components\TextInput;
+use Filament\Schemas\Concerns\InteractsWithSchemas;
+use Filament\Schemas\Contracts\HasSchemas;
+use Filament\Schemas\Schema;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Validation\ValidationException;
+use Livewire\Component;
+
+/**
+ * @property-read Schema $form
+ */
+final class SessionExpired extends Component implements HasSchemas
+{
+    use InteractsWithSchemas;
+    use WithRateLimiting;
+
+    /** @var array<string, mixed>|null */
+    public ?array $data = [];
+
+    public function mount(): void
+    {
+        $this->form->fill();
+    }
+
+    public function form(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                TextInput::make('password')
+                    ->hiddenLabel()
+                    ->password()
+                    ->revealable()
+                    ->inlineSuffix()
+                    ->required()
+                    ->autocomplete('current-password')
+                    ->autofocus(),
+            ])
+            ->statePath('data');
+    }
+
+    public function attempt(): void
+    {
+        try {
+            $this->rateLimit(5);
+        } catch (TooManyRequestsException $exception) {
+            throw ValidationException::withMessages([
+                'data.password' => __('shopper::pages/auth.login.throttled', [
+                    'seconds' => $exception->secondsUntilAvailable,
+                    'minutes' => ceil($exception->secondsUntilAvailable / 60),
+                ]),
+            ]);
+        }
+
+        $data = $this->form->getState();
+
+        $user = shopper()->auth()->user();
+
+        if ($user === null || ! Hash::check($data['password'], $user->password)) {
+            throw ValidationException::withMessages([
+                'data.password' => __('shopper::pages/auth.login.failed'),
+            ]);
+        }
+
+        session()->regenerate();
+
+        $this->form->fill();
+        $this->dispatch('close-modal', id: 'session-expired');
+        $this->redirect(request()->header('Referer') ?? route('shopper.dashboard'), navigate: true);
+    }
+
+    public function render(): View
+    {
+        return view('shopper::livewire.components.session-expired');
+    }
+}

--- a/packages/admin/src/Livewire/Components/SessionExpired.php
+++ b/packages/admin/src/Livewire/Components/SessionExpired.php
@@ -64,7 +64,7 @@ final class SessionExpired extends Component implements HasSchemas
 
         $user = shopper()->auth()->user();
 
-        if ($user === null || ! Hash::check($data['password'], $user->password)) {
+        if ($user === null || ! Hash::check($data['password'], $user->getAuthPassword())) {
             throw ValidationException::withMessages([
                 'data.password' => __('shopper::pages/auth.login.failed'),
             ]);

--- a/packages/admin/src/ShopperServiceProvider.php
+++ b/packages/admin/src/ShopperServiceProvider.php
@@ -196,6 +196,7 @@ final class ShopperServiceProvider extends PackageServiceProvider
             'auth.login' => Pages\Auth\Login::class,
             'auth.password' => Pages\Auth\ForgotPassword::class,
             'auth.password-reset' => Pages\Auth\ResetPassword::class,
+            'session-expired' => Components\SessionExpired::class,
             'setup-guide' => Components\Dashboard\SetupGuide::class,
             'dashboard.stat-cards' => Components\Dashboard\StatCards::class,
             'dashboard.revenue-chart' => Components\Dashboard\RevenueChart::class,

--- a/tests/Admin/Livewire/Components/SessionExpiredTest.php
+++ b/tests/Admin/Livewire/Components/SessionExpiredTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+use Livewire\Livewire;
+use Shopper\Livewire\Components\SessionExpired;
+use Tests\Core\Stubs\User;
+
+uses(Tests\Admin\TestCase::class);
+
+describe(SessionExpired::class, function (): void {
+    it('renders the session expired modal', function (): void {
+        Livewire::test(SessionExpired::class)
+            ->assertSuccessful()
+            ->assertSee('session-expired');
+    });
+
+    it('regenerates the session when the password is correct', function (): void {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        $oldSessionId = session()->getId();
+
+        Livewire::test(SessionExpired::class)
+            ->set('data.password', 'password')
+            ->call('attempt')
+            ->assertHasNoErrors()
+            ->assertDispatched('close-modal', id: 'session-expired');
+
+        expect(session()->getId())->not->toBe($oldSessionId);
+    });
+
+    it('rejects an incorrect password', function (): void {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        Livewire::test(SessionExpired::class)
+            ->set('data.password', 'wrong-password')
+            ->call('attempt')
+            ->assertHasErrors(['data.password']);
+    });
+
+    it('rejects when the user is no longer authenticated', function (): void {
+        Livewire::test(SessionExpired::class)
+            ->set('data.password', 'anything')
+            ->call('attempt')
+            ->assertHasErrors(['data.password']);
+    });
+
+    it('clears the password field after a successful attempt', function (): void {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        Livewire::test(SessionExpired::class)
+            ->set('data.password', 'password')
+            ->call('attempt')
+            ->assertSet('data.password', null);
+    });
+
+    it('rate limits after too many failed attempts', function (): void {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        $component = Livewire::test(SessionExpired::class);
+
+        for ($i = 0; $i < 5; $i++) {
+            $component
+                ->set('data.password', 'wrong')
+                ->call('attempt')
+                ->assertHasErrors(['data.password']);
+        }
+
+        $component
+            ->set('data.password', 'wrong')
+            ->call('attempt')
+            ->assertHasErrors(['data.password']);
+    });
+});


### PR DESCRIPTION
## Summary

Replaces Laravel's default 419 browser prompt with a branded Filament modal asking for the user's password to resume the session. Built around Livewire v4's `Livewire.interceptRequest` API — no extra JS file, the script sits inline in the component view via `@script`.

## Before

The ugly native confirm dialog from Livewire when the CSRF token expires:

> `This page has expired. Would you like to refresh the page?` [Cancel] [OK]

## After

A Filament modal (`<x-filament::modal id="session-expired">`) with a Filament Schema form (password field, reveal toggle, autofocus), opened by the JS interceptor on any 419 response.

## What's in

- `Shopper\Livewire\Components\SessionExpired` — Livewire component, `final`, uses `HasSchemas` + `InteractsWithSchemas` + `WithRateLimiting` (same pattern as `Login.php`)
- `shopper::livewire.components.session-expired` — Blade view with the Filament modal, the Schema-driven form (``{{ $this->form }}``), and the inline JS interceptor
- Registered as Livewire component `shopper-session-expired` in `ShopperServiceProvider`
- Mounted once in `layouts/app.blade.php` — one instance, listens globally
- Translations added in `shopper::pages/auth.session_expired.*` for en / fr / es

## Interceptor

Exact snippet from the Livewire 4 docs, `confirm()` replaced by our modal dispatch:

```js
Livewire.interceptRequest(({ onError }) => {
    onError(({ response, preventDefault }) => {
        if (response.status === 419) {
            preventDefault()
            Livewire.dispatch('open-modal', { id: 'session-expired' })
        }
    })
})
```

## Security

- Rate limit: 5 attempts, same pattern as Login.php
- Session regenerated via ``session()->regenerate()`` on success → new CSRF token
- `close-by-clicking-away="false"` and `close-by-escaping="false"` — the user cannot dismiss the modal without actually re-authenticating
- If the user is no longer authenticated server-side (session fully dead), the attempt fails and Laravel's `auth` middleware will redirect them to `/login` on the next request

## Tests

- 6 Pest tests, 30 assertions — renders, regenerates on correct password, rejects wrong password / logged-out, clears form after success, rate limit after 5 attempts

## Not in scope (deferred)

- Proactive "session will expire in X seconds" warning before expiry — would ship as a separate feature if useful
- Auto-retry of the action that triggered the 419 — complex to thread through Livewire state, reload is good enough for the beta