### PR TITLE
fix(core): add missing morph map entries for Country, Carrier, CarrierOption, and PaymentMethod

### DIFF
--- a/packages/core/src/CoreServiceProvider.php
+++ b/packages/core/src/CoreServiceProvider.php
@@ -142,6 +142,10 @@ final class CoreServiceProvider extends PackageServiceProvider
             'tax_zone' => config('shopper.models.tax_zone'),
             'tax_rate' => config('shopper.models.tax_rate'),
             'product_tag' => Models\ProductTag::class,
+            'country' => Models\Country::class,
+            'carrier' => Models\Carrier::class,
+            'carrier_option' => Models\CarrierOption::class,
+            'payment_method' => Models\PaymentMethod::class,
         ]);
     }
 }


### PR DESCRIPTION
## Summary

- Adds `country`, `carrier`, `carrier_option`, and `payment_method` to the morph map in `CoreServiceProvider::bootModelRelationName()`

## Problem

These four models use the `HasZones` trait, which defines a `morphToMany` relationship via the `zone_has_relations` table. When an application enables `Relation::enforceMorphMap()`, Laravel requires every model involved in polymorphic relationships to be registered in the morph map. Without these entries, navigating to the Zone settings page throws:

```
ClassMorphViolationException: No morph map defined for model [Shopper\Core\Models\Country]
```

## Fix

Register the missing models alongside the existing entries in `bootModelRelationName()`.

## Test plan

- Enable `Relation::enforceMorphMap()` in an application using Shopper
- Navigate to Settings > Zones and create/edit a zone
- Verify no `ClassMorphViolationException` is thrown