### PR TITLE
feat(admin): reviews page polish with stats, breakdown sidebar and split moderation actions

### DIFF
--- a/packages/admin/resources/lang/en/pages/reviews.php
+++ b/packages/admin/resources/lang/en/pages/reviews.php
@@ -6,5 +6,48 @@ return [
 
     'menu' => 'Reviews',
     'single' => 'review',
+    'title' => 'Customer Reviews',
+    'description' => 'See what customers are saying about your products.',
+
+    'stats' => [
+        'average' => 'Average rating',
+        'based_on' => 'Based on :count reviews',
+        'total' => 'Total reviews',
+        'last_30_days' => 'in the last 30 days',
+        'no_recent' => 'No new reviews in the last 30 days',
+        'no_data' => 'No reviews yet',
+        'five_star' => '5-star reviews',
+        'excellent' => 'Excellent ratings',
+        'pending' => 'Pending moderation',
+        'pending_description' => 'Needs your input',
+        'pending_empty' => 'Inbox is clear',
+    ],
+
+    'breakdown' => [
+        'title' => 'Ratings breakdown',
+        'description' => 'How customers rate you',
+    ],
+
+    'recommended' => [
+        'title' => 'Recommended',
+        'description' => ':percent% of customers recommend',
+        'empty' => 'No recommendations yet',
+    ],
+
+    'tabs' => [
+        'all' => 'All',
+        'pending' => 'Pending',
+        'approved' => 'Approved',
+    ],
+
+    'actions' => [
+        'approve' => 'Approve',
+        'reject' => 'Reject',
+        'mark_as_spam' => 'Mark as spam',
+        'approved_message' => 'Review approved.',
+        'rejected_message' => 'Review rejected.',
+        'spam_message' => 'Review flagged as spam.',
+        'spam_confirmation' => 'Flagging this review as spam will hide it from your customers. You can revert this from the moderation queue.',
+    ],
 
 ];

--- a/packages/admin/resources/lang/es/pages/reviews.php
+++ b/packages/admin/resources/lang/es/pages/reviews.php
@@ -3,6 +3,51 @@
 declare(strict_types=1);
 
 return [
+
     'menu' => 'Reseñas',
     'single' => 'reseña',
+    'title' => 'Reseñas de clientes',
+    'description' => 'Descubre lo que tus clientes dicen sobre tus productos.',
+
+    'stats' => [
+        'average' => 'Valoración media',
+        'based_on' => 'Basado en :count reseñas',
+        'total' => 'Reseñas totales',
+        'last_30_days' => 'en los últimos 30 días',
+        'no_recent' => 'No hay reseñas nuevas en los últimos 30 días',
+        'no_data' => 'Aún no hay reseñas',
+        'five_star' => 'Reseñas 5 estrellas',
+        'excellent' => 'Excelentes valoraciones',
+        'pending' => 'Pendientes de moderación',
+        'pending_description' => 'Requiere tu atención',
+        'pending_empty' => 'Bandeja vacía',
+    ],
+
+    'breakdown' => [
+        'title' => 'Distribución de valoraciones',
+        'description' => 'Cómo te valoran tus clientes',
+    ],
+
+    'recommended' => [
+        'title' => 'Recomendación',
+        'description' => ':percent% de clientes te recomiendan',
+        'empty' => 'Aún no hay recomendaciones',
+    ],
+
+    'tabs' => [
+        'all' => 'Todas',
+        'pending' => 'Pendientes',
+        'approved' => 'Aprobadas',
+    ],
+
+    'actions' => [
+        'approve' => 'Aprobar',
+        'reject' => 'Rechazar',
+        'mark_as_spam' => 'Marcar como spam',
+        'approved_message' => 'Reseña aprobada.',
+        'rejected_message' => 'Reseña rechazada.',
+        'spam_message' => 'Reseña marcada como spam.',
+        'spam_confirmation' => 'Marcar esta reseña como spam la ocultará a tus clientes. Puedes revertirlo desde la cola de moderación.',
+    ],
+
 ];

--- a/packages/admin/resources/lang/fr/pages/reviews.php
+++ b/packages/admin/resources/lang/fr/pages/reviews.php
@@ -6,5 +6,48 @@ return [
 
     'menu' => 'Avis',
     'single' => 'avis',
+    'title' => 'Avis clients',
+    'description' => 'Découvrez ce que vos clients pensent de vos produits.',
+
+    'stats' => [
+        'average' => 'Note moyenne',
+        'based_on' => 'Basé sur :count avis',
+        'total' => 'Avis au total',
+        'last_30_days' => 'sur les 30 derniers jours',
+        'no_recent' => 'Aucun nouvel avis sur les 30 derniers jours',
+        'no_data' => 'Aucun avis pour le moment',
+        'five_star' => 'Avis 5 étoiles',
+        'excellent' => 'Avis excellents',
+        'pending' => 'En attente de modération',
+        'pending_description' => 'Action requise',
+        'pending_empty' => 'Tout est traité',
+    ],
+
+    'breakdown' => [
+        'title' => 'Répartition des notes',
+        'description' => 'Comment vos clients vous notent',
+    ],
+
+    'recommended' => [
+        'title' => 'Recommandation',
+        'description' => ':percent% de clients vous recommandent',
+        'empty' => 'Pas encore de recommandation',
+    ],
+
+    'tabs' => [
+        'all' => 'Tous',
+        'pending' => 'En attente',
+        'approved' => 'Approuvés',
+    ],
+
+    'actions' => [
+        'approve' => 'Approuver',
+        'reject' => 'Rejeter',
+        'mark_as_spam' => 'Marquer comme spam',
+        'approved_message' => 'Avis approuvé.',
+        'rejected_message' => 'Avis rejeté.',
+        'spam_message' => 'Avis signalé comme spam.',
+        'spam_confirmation' => 'Signaler cet avis comme spam le masquera à vos clients. Vous pourrez l\'annuler depuis la file de modération.',
+    ],
 
 ];

--- a/packages/admin/resources/views/components/card.blade.php
+++ b/packages/admin/resources/views/components/card.blade.php
@@ -3,10 +3,11 @@
 @props([
     'title' => null,
     'description' => null,
+    'footer' => null
 ])
 
 <div
-    {{ $attributes->twMerge(['class' => 'sh-card bg-sh-card ring-sh-border overflow-hidden rounded-xl p-1 ring-1']) }}
+    {{ $attributes->twMerge(['class' => 'sh-card bg-sh-card ring-sh-border overflow-hidden rounded-xl p-0.5 ring-1']) }}
 >
     @if ($title)
         <header class="sh-card-header px-2 py-3">
@@ -18,7 +19,11 @@
         </header>
     @endif
 
-    <div class="sh-card-content bg-sh-surface ring-sh-border overflow-hidden rounded-lg p-4 ring-1">
+    <div class="sh-card-content bg-sh-surface ring-sh-border overflow-hidden rounded-[10px] p-4 ring-1">
         {{ $slot }}
     </div>
+
+    @if ($footer)
+        {{ $footer }}
+    @endif
 </div>

--- a/packages/admin/resources/views/components/heading.blade.php
+++ b/packages/admin/resources/views/components/heading.blade.php
@@ -1,5 +1,9 @@
 @blaze
 
+@props([
+    'title' => null,
+])
+
 <div
     {{ $attributes->twMerge(['class' => 'space-y-3 sm:flex sm:items-center sm:justify-between sm:space-x-4 sm:space-y-0']) }}
 >

--- a/packages/admin/resources/views/livewire/pages/reviews/index.blade.php
+++ b/packages/admin/resources/views/livewire/pages/reviews/index.blade.php
@@ -1,13 +1,226 @@
-<x-shopper::container class="py-5">
-    <x-shopper::heading :title="__('shopper::pages/reviews.menu')" />
+<div>
+    <x-shopper::container class="space-y-8 py-5">
+        <div class="space-y-2">
+            <x-shopper::heading :title="__('shopper::pages/reviews.title')" />
+            <p class="max-w-2xl text-sm text-gray-500 dark:text-gray-400">
+                {{ __('shopper::pages/reviews.description') }}
+            </p>
+        </div>
 
-    {{ shopper()->getRenderHook(\Shopper\View\CatalogRenderHook::REVIEWS_TABLE_BEFORE) }}
+        @php
+            $stats = $this->stats;
+            $hasReviews = $stats['total'] > 0;
+        @endphp
 
-    <div class="mt-8">
-        {{ $this->table }}
-    </div>
+        <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            <x-shopper::card>
+                <x-slot:title>
+                    <div class="flex items-center justify-between">
+                        <span class="text-sh-fg-secondary text-sm font-medium">
+                            {{ __('shopper::pages/reviews.stats.average') }}
+                        </span>
+                        <x-phosphor-sparkle-duotone class="text-sh-fg-secondary size-5" aria-hidden="true" />
+                    </div>
+                </x-slot:title>
 
-    {{ shopper()->getRenderHook(\Shopper\View\CatalogRenderHook::REVIEWS_TABLE_AFTER) }}
+                <p class="font-heading text-sh-fg text-3xl font-bold">
+                    {{ $hasReviews ? number_format($stats['average'], 1) : '—' }}
+                </p>
 
-    <x-shopper::learn-more :name="__('shopper::pages/reviews.menu')" link="reviews" />
-</x-shopper::container>
+                <div class="mt-3 flex items-center gap-4">
+                    <div class="flex items-center gap-1">
+                        @foreach ([1, 2, 3, 4, 5] as $star)
+                            <x-heroicon-s-star
+                                @class([
+                                    'size-4 shrink-0',
+                                    'text-yellow-400' => $stats['average'] >= $star,
+                                    'text-gray-300 dark:text-gray-600' => $stats['average'] < $star,
+                                ])
+                                aria-hidden="true"
+                            />
+                        @endforeach
+                    </div>
+
+                    <p class="text-sh-fg-muted text-xs">
+                        {{ $hasReviews
+                            ? __('shopper::pages/reviews.stats.based_on', ['count' => \Illuminate\Support\Number::abbreviate($stats['total'])])
+                            : __('shopper::pages/reviews.stats.no_data') }}
+                    </p>
+                </div>
+            </x-shopper::card>
+
+            <x-shopper::card>
+                <x-slot:title>
+                    <div class="flex items-center justify-between">
+                        <span class="text-sh-fg-secondary text-sm font-medium">
+                            {{ __('shopper::pages/reviews.stats.total') }}
+                        </span>
+                        <x-phosphor-list-star-duotone class="text-sh-fg-secondary size-5" aria-hidden="true" />
+                    </div>
+                </x-slot:title>
+
+                <p class="font-heading text-sh-fg text-3xl font-bold">
+                    {{ \Illuminate\Support\Number::abbreviate($stats['total']) }}
+                </p>
+
+                <p class="text-sh-fg-muted mt-3 text-xs">
+                    @if ($stats['this_month'] > 0)
+                        <span class="font-medium text-emerald-600 dark:text-emerald-400">
+                            +{{ \Illuminate\Support\Number::abbreviate($stats['this_month']) }}
+                        </span>
+                        {{ __('shopper::pages/reviews.stats.last_30_days') }}
+                    @else
+                        {{ __('shopper::pages/reviews.stats.no_recent') }}
+                    @endif
+                </p>
+            </x-shopper::card>
+
+            <x-shopper::card>
+                <x-slot:title>
+                    <div class="flex items-center justify-between">
+                        <span class="text-sh-fg-secondary text-sm font-medium">
+                            {{ __('shopper::pages/reviews.stats.five_star') }}
+                        </span>
+                        <x-phosphor-shooting-star-duotone class="text-sh-fg-secondary size-5" aria-hidden="true" />
+                    </div>
+                </x-slot:title>
+
+                <p class="font-heading text-sh-fg text-3xl font-bold">
+                    {{ $stats['five_star_percent'] }}%
+                </p>
+
+                <p class="text-sh-fg-muted mt-3 text-xs">
+                    {{ __('shopper::pages/reviews.stats.excellent') }}
+                </p>
+            </x-shopper::card>
+
+            <x-shopper::card>
+                <x-slot:title>
+                    <div class="flex items-center justify-between">
+                        <span class="text-sh-fg-secondary text-sm font-medium">
+                            {{ __('shopper::pages/reviews.stats.pending') }}
+                        </span>
+                        <x-phosphor-warning-circle-duotone
+                            @class([
+                                'size-5',
+                                'text-amber-500' => $stats['pending'] > 0,
+                                'text-sh-fg-secondary' => $stats['pending'] === 0,
+                            ])
+                            aria-hidden="true"
+                        />
+                    </div>
+                </x-slot:title>
+
+                <p
+                    @class([
+                        'font-heading text-3xl font-bold',
+                        'text-amber-600 dark:text-amber-400' => $stats['pending'] > 0,
+                        'text-sh-fg' => $stats['pending'] === 0,
+                    ])
+                >
+                    {{ \Illuminate\Support\Number::abbreviate($stats['pending']) }}
+                </p>
+
+                <p class="text-sh-fg-muted mt-3 text-xs">
+                    {{ $stats['pending'] > 0
+                        ? __('shopper::pages/reviews.stats.pending_description')
+                        : __('shopper::pages/reviews.stats.pending_empty') }}
+                </p>
+            </x-shopper::card>
+        </div>
+
+        {{ shopper()->getRenderHook(\Shopper\View\CatalogRenderHook::REVIEWS_TABLE_BEFORE) }}
+
+        <div class="lg:grid lg:grid-cols-4 lg:gap-6">
+            <aside class="space-y-4 lg:sticky lg:top-4 lg:col-span-1 lg:self-start">
+                <x-shopper::card>
+                    <x-slot:title>
+                        <span class="text-sh-fg text-sm font-semibold">
+                            {{ __('shopper::pages/reviews.breakdown.title') }}
+                        </span>
+                    </x-slot:title>
+
+                    <div class="space-y-3">
+                        @foreach ($this->ratingBreakdown as $row)
+                            <div class="flex items-center gap-3 text-sm">
+                                <span class="text-sh-fg-secondary flex w-7 shrink-0 items-center gap-1 text-xs font-semibold">
+                                    {{ $row['rating'] }}
+                                    <x-heroicon-s-star class="size-3 text-yellow-400" aria-hidden="true" />
+                                </span>
+                                <div class="bg-sh-muted h-1.5 flex-1 overflow-hidden rounded-full">
+                                    <div
+                                        class="h-full rounded-full bg-yellow-400 transition-all"
+                                        style="width: {{ $row['percent'] }}%"
+                                    ></div>
+                                </div>
+                                <span class="text-sh-fg-muted w-8 shrink-0 text-right text-xs tabular-nums">
+                                    {{ number_format($row['count']) }}
+                                </span>
+                            </div>
+                        @endforeach
+                    </div>
+                </x-shopper::card>
+
+                <x-shopper::card>
+                    <x-slot:title>
+                        <span class="text-sh-fg text-sm font-semibold">
+                            {{ __('shopper::pages/reviews.recommended.title') }}
+                        </span>
+                    </x-slot:title>
+
+                    <div class="flex items-baseline gap-2">
+                        <p class="font-heading text-sh-fg text-2xl font-bold">
+                            @if ($hasReviews)
+                                {{ $this->recommendedPercent }}%
+                            @else
+                                —
+                            @endif
+                        </p>
+                        <x-untitledui-thumbs-up class="size-4 text-emerald-500" aria-hidden="true" />
+                    </div>
+
+                    <p class="text-sh-fg-muted mt-1 text-xs">
+                        {{ $hasReviews
+                            ? __('shopper::pages/reviews.recommended.description', ['percent' => $this->recommendedPercent])
+                            : __('shopper::pages/reviews.recommended.empty') }}
+                    </p>
+                </x-shopper::card>
+            </aside>
+
+            <div class="mt-6 space-y-4 lg:col-span-3 lg:mt-0">
+                <x-filament::tabs class="sh-tabs-underline">
+                    <x-filament::tabs.item
+                        :active="$activeTab === 'all'"
+                        wire:click="$set('activeTab', 'all')"
+                    >
+                        {{ __('shopper::pages/reviews.tabs.all') }}
+                    </x-filament::tabs.item>
+
+                    <x-filament::tabs.item
+                        :active="$activeTab === 'pending'"
+                        wire:click="$set('activeTab', 'pending')"
+                        :badge="$stats['pending'] > 0 ? $stats['pending'] : null"
+                        badge-color="warning"
+                    >
+                        {{ __('shopper::pages/reviews.tabs.pending') }}
+                    </x-filament::tabs.item>
+
+                    <x-filament::tabs.item
+                        :active="$activeTab === 'approved'"
+                        wire:click="$set('activeTab', 'approved')"
+                    >
+                        {{ __('shopper::pages/reviews.tabs.approved') }}
+                    </x-filament::tabs.item>
+                </x-filament::tabs>
+
+                <div>
+                    {{ $this->table }}
+                </div>
+            </div>
+        </div>
+
+        {{ shopper()->getRenderHook(\Shopper\View\CatalogRenderHook::REVIEWS_TABLE_AFTER) }}
+
+        <x-shopper::learn-more :name="__('shopper::pages/reviews.menu')" link="reviews" />
+    </x-shopper::container>
+</div>

--- a/packages/admin/resources/views/livewire/slide-overs/review-detail.blade.php
+++ b/packages/admin/resources/views/livewire/slide-overs/review-detail.blade.php
@@ -111,19 +111,25 @@
                             <dt class="text-sm font-medium text-gray-500 dark:text-gray-400">
                                 {{ __('shopper::pages/products.reviews.approved_status') }}
                             </dt>
-                            <dd
-                                class="flex items-center justify-between space-x-4 text-sm text-gray-900 sm:col-span-2 sm:mt-0 dark:text-white"
-                            >
+                            <dd class="flex items-center text-sm text-gray-900 sm:col-span-2 sm:mt-0 dark:text-white">
                                 <x-filament::badge :color="$review->approved ? 'success': 'warning'">
                                     {{ $review->approved ? __('shopper::pages/products.reviews.published') : __('shopper::pages/products.reviews.pending') }}
                                 </x-filament::badge>
-
-                                {{ $this->approvedAction }}
                             </dd>
                         </div>
                     </dl>
                 </div>
             </div>
         </div>
+    </div>
+
+    <div class="flex shrink-0 flex-wrap items-center justify-end gap-2 border-t border-gray-200 px-4 py-4 dark:border-white/10">
+        {{ $this->markAsSpamAction }}
+
+        @if ($review->approved)
+            {{ $this->rejectAction }}
+        @else
+            {{ $this->approveAction }}
+        @endif
     </div>
 </x-shopper::slideover-card>

--- a/packages/admin/src/Livewire/Pages/Reviews/Index.php
+++ b/packages/admin/src/Livewire/Pages/Reviews/Index.php
@@ -19,13 +19,22 @@ use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Filters\TernaryFilter;
 use Filament\Tables\Table;
 use Illuminate\Contracts\View\View;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\DB;
+use Livewire\Attributes\Computed;
+use Livewire\Attributes\Url;
 use Mckenziearts\Icons\Untitledui\Enums\Untitledui;
 use Shopper\Core\Models\Contracts\Product;
 use Shopper\Core\Models\Review;
 use Shopper\Livewire\Pages\AbstractPageComponent;
 use Shopper\Traits\HandlesAuthorizationExceptions;
 
+/**
+ * @property-read array{total: int, pending: int, average: float, five_star_percent: int, this_month: int, recommended_percent: int} $stats
+ * @property-read array<int, array{rating: int, count: int, percent: int}> $ratingBreakdown
+ * @property-read int $recommendedPercent
+ */
 class Index extends AbstractPageComponent implements HasActions, HasSchemas, HasTable
 {
     use HandlesAuthorizationExceptions;
@@ -33,16 +42,100 @@ class Index extends AbstractPageComponent implements HasActions, HasSchemas, Has
     use InteractsWithSchemas;
     use InteractsWithTable;
 
+    #[Url(as: 'tab', except: 'all')]
+    public string $activeTab = 'all';
+
     public function mount(): void
     {
         $this->authorize('reviews.browse');
+    }
+
+    public function updatedActiveTab(): void
+    {
+        $this->resetTable();
+    }
+
+    /**
+     * @return array{total: int, pending: int, average: float, five_star_percent: int, this_month: int, recommended_percent: int}
+     */
+    #[Computed]
+    public function stats(): array
+    {
+        /** @var object{total: int, pending: int, average: float|string|null, five_star_count: int, recommended_count: int, this_month: int}|null $row */
+        $row = DB::table(shopper_table('reviews'))
+            ->selectRaw(
+                'COUNT(*) as total,
+                 COUNT(CASE WHEN NOT approved THEN 1 END) as pending,
+                 COALESCE(AVG(rating), 0) as average,
+                 COUNT(CASE WHEN rating = ? THEN 1 END) as five_star_count,
+                 COUNT(CASE WHEN is_recommended THEN 1 END) as recommended_count,
+                 COUNT(CASE WHEN created_at >= ? THEN 1 END) as this_month',
+                [5, now()->subDays(30)]
+            )
+            ->first();
+
+        $total = (int) ($row->total ?? 0);
+
+        return [
+            'total' => $total,
+            'pending' => (int) ($row->pending ?? 0),
+            'average' => $total > 0 ? round((float) ($row->average ?? 0), 1) : 0.0,
+            'five_star_percent' => $total > 0
+                ? (int) round(((int) ($row->five_star_count ?? 0) / $total) * 100)
+                : 0,
+            'recommended_percent' => $total > 0
+                ? (int) round(((int) ($row->recommended_count ?? 0) / $total) * 100)
+                : 0,
+            'this_month' => (int) ($row->this_month ?? 0),
+        ];
+    }
+
+    /**
+     * @return array<int, array{rating: int, count: int, percent: int}>
+     */
+    #[Computed]
+    public function ratingBreakdown(): array
+    {
+        $total = $this->stats['total'];
+        $counts = $total > 0
+            ? Review::query()
+                ->selectRaw('rating, COUNT(*) as aggregate')
+                ->groupBy('rating')
+                ->pluck('aggregate', 'rating')
+                ->all()
+            : [];
+
+        return collect([5, 4, 3, 2, 1])
+            ->map(fn (int $rating): array => [
+                'rating' => $rating,
+                'count' => (int) ($counts[$rating] ?? 0),
+                'percent' => $total > 0
+                    ? (int) round((((int) ($counts[$rating] ?? 0)) / $total) * 100)
+                    : 0,
+            ])
+            ->all();
+    }
+
+    #[Computed]
+    public function recommendedPercent(): int
+    {
+        return $this->stats['recommended_percent'];
     }
 
     public function table(Table $table): Table
     {
         return $table
             ->query(
-                Review::query()->with(['author', 'reviewrateable'])
+                Review::query()
+                    ->with(['author', 'reviewrateable'])
+                    ->when(
+                        $this->activeTab === 'pending',
+                        fn (Builder $query): Builder => $query->where('approved', false)
+                    )
+                    ->when(
+                        $this->activeTab === 'approved',
+                        fn (Builder $query): Builder => $query->where('approved', true)
+                    )
             )
             ->columns([
                 TextColumn::make('author.full_name')
@@ -56,14 +149,19 @@ class Index extends AbstractPageComponent implements HasActions, HasSchemas, Has
                 TextColumn::make('reviewrateable.name')
                     ->label(__('shopper::words.product'))
                     ->searchable()
-                    ->sortable(),
+                    ->sortable()
+                    ->url(fn (Review $record): string => route(
+                        name: 'shopper.products.edit',
+                        parameters: ['product' => $record->reviewrateable]
+                    )),
                 ViewColumn::make('rating')
                     ->label(__('shopper::pages/products.reviews.rating'))
                     ->view('shopper::livewire.tables.cells.reviews.rating'),
                 TextColumn::make('content')
                     ->label(__('shopper::pages/products.reviews.review'))
-                    ->limit(50)
+                    ->limit(30)
                     ->tooltip(fn (Review $record): string => $record->content)
+                    ->toggledHiddenByDefault()
                     ->toggleable(),
                 TextColumn::make('approved')
                     ->label(__('shopper::forms.label.status'))
@@ -152,8 +250,6 @@ class Index extends AbstractPageComponent implements HasActions, HasSchemas, Has
                     )
                     ->searchable()
                     ->preload(),
-                TernaryFilter::make('approved')
-                    ->label(__('shopper::pages/products.reviews.approved_status')),
                 TernaryFilter::make('is_recommended')
                     ->label(__('shopper::pages/products.reviews.is_recommended')),
             ])
@@ -163,6 +259,6 @@ class Index extends AbstractPageComponent implements HasActions, HasSchemas, Has
     public function render(): View
     {
         return view('shopper::livewire.pages.reviews.index')
-            ->title(__('shopper::pages/reviews.menu'));
+            ->title(__('shopper::pages/reviews.title'));
     }
 }

--- a/packages/admin/src/Livewire/SlideOvers/ReviewDetail.php
+++ b/packages/admin/src/Livewire/SlideOvers/ReviewDetail.php
@@ -13,6 +13,8 @@ use Filament\Schemas\Contracts\HasSchemas;
 use Filament\Support\Enums\Size;
 use Illuminate\Contracts\View\View;
 use Laravelcm\LivewireSlideOvers\SlideOverComponent;
+use Livewire\Attributes\Locked;
+use Mckenziearts\Icons\Untitledui\Enums\Untitledui;
 use Shopper\Core\Models\Review;
 use Shopper\Traits\HandlesAuthorizationExceptions;
 
@@ -22,6 +24,7 @@ class ReviewDetail extends SlideOverComponent implements HasActions, HasSchemas
     use InteractsWithActions;
     use InteractsWithSchemas;
 
+    #[Locked]
     public Review $review;
 
     public function mount(): void
@@ -31,19 +34,68 @@ class ReviewDetail extends SlideOverComponent implements HasActions, HasSchemas
         $this->review->load('author', 'reviewrateable');
     }
 
-    public function approvedAction(): Action
+    public function approveAction(): Action
     {
-        return Action::make('approved')
-            ->label(__('shopper::forms.actions.update'))
+        return Action::make('approve')
+            ->label(__('shopper::pages/reviews.actions.approve'))
+            ->icon(Untitledui::CheckCircle)
             ->size(Size::Small)
             ->authorize('reviews.edit')
             ->action(function (): void {
-                $this->review->updatedApproved(! $this->review->approved);
+                $this->review->updatedApproved(true);
 
                 Notification::make()
-                    ->title(__('shopper::pages/products.reviews.approved_message'))
+                    ->title(__('shopper::pages/reviews.actions.approved_message'))
                     ->success()
                     ->send();
+
+                $this->dispatch('review-approved', reviewId: $this->review->id);
+
+                $this->redirectRoute(name: 'shopper.reviews.index', navigate: true);
+            });
+    }
+
+    public function rejectAction(): Action
+    {
+        return Action::make('reject')
+            ->label(__('shopper::pages/reviews.actions.reject'))
+            ->icon(Untitledui::XClose)
+            ->size(Size::Small)
+            ->color('gray')
+            ->authorize('reviews.edit')
+            ->action(function (): void {
+                $this->review->updatedApproved(false);
+
+                Notification::make()
+                    ->title(__('shopper::pages/reviews.actions.rejected_message'))
+                    ->success()
+                    ->send();
+
+                $this->dispatch('review-rejected', reviewId: $this->review->id);
+
+                $this->redirectRoute(name: 'shopper.reviews.index', navigate: true);
+            });
+    }
+
+    public function markAsSpamAction(): Action
+    {
+        return Action::make('markAsSpam')
+            ->label(__('shopper::pages/reviews.actions.mark_as_spam'))
+            ->icon(Untitledui::SlashOctagon)
+            ->size(Size::Small)
+            ->color('danger')
+            ->requiresConfirmation()
+            ->modalDescription(__('shopper::pages/reviews.actions.spam_confirmation'))
+            ->authorize('reviews.delete')
+            ->action(function (): void {
+                $this->review->updatedApproved(false);
+
+                Notification::make()
+                    ->title(__('shopper::pages/reviews.actions.spam_message'))
+                    ->success()
+                    ->send();
+
+                $this->dispatch('review-flagged-as-spam', reviewId: $this->review->id);
 
                 $this->redirectRoute(name: 'shopper.reviews.index', navigate: true);
             });

--- a/packages/admin/src/ShopperServiceProvider.php
+++ b/packages/admin/src/ShopperServiceProvider.php
@@ -12,6 +12,7 @@ use Filament\Forms\Components\TextInput;
 use Filament\Infolists\Components\ImageEntry;
 use Filament\Support\Colors\Color;
 use Filament\Support\Facades\FilamentColor;
+use Filament\Support\Facades\FilamentView;
 use Filament\Tables\Columns\Column;
 use Filament\Tables\Columns\ImageColumn;
 use Filament\Tables\Columns\TextColumn;
@@ -212,6 +213,8 @@ final class ShopperServiceProvider extends PackageServiceProvider
 
     protected function registerCustomFilamentItems(): void
     {
+        FilamentView::spa();
+
         FilamentColor::register([
             'primary' => config('shopper.admin.primary_color'),
             'teal' => Color::Teal,

--- a/packages/core/database/migrations/2026_04_27_000001_add_indexes_to_reviews_table.php
+++ b/packages/core/database/migrations/2026_04_27_000001_add_indexes_to_reviews_table.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Shopper\Core\Helpers\Migration;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table($this->getTableName('reviews'), static function (Blueprint $table): void {
+            $table->index('approved');
+            $table->index('rating');
+            $table->index('is_recommended');
+            $table->index('created_at');
+            $table->index(['approved', 'created_at']);
+        });
+    }
+};

--- a/tests/Admin/Livewire/Pages/Reviews/IndexTest.php
+++ b/tests/Admin/Livewire/Pages/Reviews/IndexTest.php
@@ -40,11 +40,11 @@ describe(Index::class, function (): void {
             ->assertCanSeeTableRecords(Review::limit(3)->get());
     });
 
-    it('can filter reviews by approved status', function (): void {
+    it('filters reviews by pending tab', function (): void {
         $product = Product::factory()->create();
         $author = User::factory()->create();
 
-        Review::factory()->create([
+        $approved = Review::factory()->create([
             'reviewrateable_id' => $product->id,
             'reviewrateable_type' => $product->getMorphClass(),
             'author_id' => $author->id,
@@ -52,7 +52,7 @@ describe(Index::class, function (): void {
             'approved' => true,
         ]);
 
-        Review::factory()->create([
+        $pending = Review::factory()->create([
             'reviewrateable_id' => $product->id,
             'reviewrateable_type' => $product->getMorphClass(),
             'author_id' => $author->id,
@@ -61,7 +61,145 @@ describe(Index::class, function (): void {
         ]);
 
         Livewire::test(Index::class)
-            ->filterTable('approved', true)
-            ->assertCountTableRecords(1);
+            ->set('activeTab', 'pending')
+            ->loadTable()
+            ->assertCanSeeTableRecords([$pending])
+            ->assertCanNotSeeTableRecords([$approved]);
+    });
+
+    it('filters reviews by approved tab', function (): void {
+        $product = Product::factory()->create();
+        $author = User::factory()->create();
+
+        $approved = Review::factory()->create([
+            'reviewrateable_id' => $product->id,
+            'reviewrateable_type' => $product->getMorphClass(),
+            'author_id' => $author->id,
+            'author_type' => $author->getMorphClass(),
+            'approved' => true,
+        ]);
+
+        $pending = Review::factory()->create([
+            'reviewrateable_id' => $product->id,
+            'reviewrateable_type' => $product->getMorphClass(),
+            'author_id' => $author->id,
+            'author_type' => $author->getMorphClass(),
+            'approved' => false,
+        ]);
+
+        Livewire::test(Index::class)
+            ->set('activeTab', 'approved')
+            ->loadTable()
+            ->assertCanSeeTableRecords([$approved])
+            ->assertCanNotSeeTableRecords([$pending]);
+    });
+
+    it('computes stats with empty reviews table', function (): void {
+        $component = Livewire::test(Index::class);
+        $stats = $component->instance()->stats;
+
+        expect($stats)
+            ->toMatchArray([
+                'total' => 0,
+                'pending' => 0,
+                'average' => 0.0,
+                'five_star_percent' => 0,
+            ]);
+    });
+
+    it('computes stats with mixed reviews', function (): void {
+        $product = Product::factory()->create();
+        $author = User::factory()->create();
+
+        Review::factory()->count(2)->create([
+            'reviewrateable_id' => $product->id,
+            'reviewrateable_type' => $product->getMorphClass(),
+            'author_id' => $author->id,
+            'author_type' => $author->getMorphClass(),
+            'rating' => 5,
+            'approved' => true,
+        ]);
+
+        Review::factory()->create([
+            'reviewrateable_id' => $product->id,
+            'reviewrateable_type' => $product->getMorphClass(),
+            'author_id' => $author->id,
+            'author_type' => $author->getMorphClass(),
+            'rating' => 3,
+            'approved' => false,
+        ]);
+
+        Review::factory()->create([
+            'reviewrateable_id' => $product->id,
+            'reviewrateable_type' => $product->getMorphClass(),
+            'author_id' => $author->id,
+            'author_type' => $author->getMorphClass(),
+            'rating' => 1,
+            'approved' => false,
+        ]);
+
+        $component = Livewire::test(Index::class);
+        $stats = $component->instance()->stats;
+
+        expect($stats['total'])->toBe(4)
+            ->and($stats['pending'])->toBe(2)
+            ->and($stats['average'])->toBe(3.5)
+            ->and($stats['five_star_percent'])->toBe(50);
+    });
+
+    it('computes a rating breakdown across all stars', function (): void {
+        $product = Product::factory()->create();
+        $author = User::factory()->create();
+
+        Review::factory()->count(3)->create([
+            'reviewrateable_id' => $product->id,
+            'reviewrateable_type' => $product->getMorphClass(),
+            'author_id' => $author->id,
+            'author_type' => $author->getMorphClass(),
+            'rating' => 5,
+        ]);
+
+        Review::factory()->create([
+            'reviewrateable_id' => $product->id,
+            'reviewrateable_type' => $product->getMorphClass(),
+            'author_id' => $author->id,
+            'author_type' => $author->getMorphClass(),
+            'rating' => 1,
+        ]);
+
+        $breakdown = Livewire::test(Index::class)->instance()->ratingBreakdown;
+
+        expect($breakdown)->toHaveCount(5)
+            ->and($breakdown[0])->toMatchArray(['rating' => 5, 'count' => 3, 'percent' => 75])
+            ->and($breakdown[4])->toMatchArray(['rating' => 1, 'count' => 1, 'percent' => 25]);
+    });
+
+    it('computes the recommended percentage', function (): void {
+        $product = Product::factory()->create();
+        $author = User::factory()->create();
+
+        Review::factory()->count(3)->create([
+            'reviewrateable_id' => $product->id,
+            'reviewrateable_type' => $product->getMorphClass(),
+            'author_id' => $author->id,
+            'author_type' => $author->getMorphClass(),
+            'is_recommended' => true,
+        ]);
+
+        Review::factory()->create([
+            'reviewrateable_id' => $product->id,
+            'reviewrateable_type' => $product->getMorphClass(),
+            'author_id' => $author->id,
+            'author_type' => $author->getMorphClass(),
+            'is_recommended' => false,
+        ]);
+
+        expect(Livewire::test(Index::class)->instance()->recommendedPercent)
+            ->toBe(75);
+    });
+
+    it('returns zero recommended when no reviews exist', function (): void {
+        expect(Livewire::test(Index::class)->instance()->recommendedPercent)
+            ->toBe(0);
     });
 })->group('livewire', 'reviews');

--- a/tests/Admin/Livewire/SlideOvers/ReviewDetailTest.php
+++ b/tests/Admin/Livewire/SlideOvers/ReviewDetailTest.php
@@ -13,7 +13,7 @@ uses(Tests\Admin\TestCase::class);
 beforeEach(function (): void {
 
     $this->user = User::factory()->create();
-    $this->user->givePermissionTo(['reviews.browse', 'reviews.edit']);
+    $this->user->givePermissionTo(['reviews.browse', 'reviews.edit', 'reviews.delete']);
     $this->actingAs($this->user);
 
     $this->customer = User::factory()->create();
@@ -43,11 +43,11 @@ describe(ReviewDetail::class, function (): void {
             ->and($component->get('review')->reviewrateable)->not->toBeNull();
     });
 
-    it('can approve review via action', function (): void {
+    it('can approve a pending review', function (): void {
         expect($this->review->approved)->toBeFalse();
 
         Livewire::test(ReviewDetail::class, ['review' => $this->review])
-            ->callAction('approved')
+            ->callAction('approve')
             ->assertRedirect(route('shopper.reviews.index'));
 
         $this->review->refresh();
@@ -55,13 +55,13 @@ describe(ReviewDetail::class, function (): void {
         expect($this->review->approved)->toBeTrue();
     });
 
-    it('can disapprove review via action', function (): void {
+    it('can reject an approved review', function (): void {
         $this->review->update(['approved' => true]);
 
         expect($this->review->approved)->toBeTrue();
 
         Livewire::test(ReviewDetail::class, ['review' => $this->review])
-            ->callAction('approved')
+            ->callAction('reject')
             ->assertRedirect(route('shopper.reviews.index'));
 
         $this->review->refresh();
@@ -69,15 +69,45 @@ describe(ReviewDetail::class, function (): void {
         expect($this->review->approved)->toBeFalse();
     });
 
-    it('sends notification after toggling approved status', function (): void {
+    it('can flag a review as spam', function (): void {
         Livewire::test(ReviewDetail::class, ['review' => $this->review])
-            ->callAction('approved')
+            ->callAction('markAsSpam')
+            ->assertRedirect(route('shopper.reviews.index'))
+            ->assertDispatched('review-flagged-as-spam');
+
+        $this->review->refresh();
+
+        expect($this->review->approved)->toBeFalse();
+    });
+
+    it('sends notification when approving a review', function (): void {
+        Livewire::test(ReviewDetail::class, ['review' => $this->review])
+            ->callAction('approve')
             ->assertNotified();
     });
 
-    it('redirects to reviews index after action', function (): void {
+    it('dispatches review-approved event after approval', function (): void {
         Livewire::test(ReviewDetail::class, ['review' => $this->review])
-            ->callAction('approved')
-            ->assertRedirect(route('shopper.reviews.index'));
+            ->callAction('approve')
+            ->assertDispatched('review-approved');
+    });
+
+    it('hides the approve action when the user lacks `reviews.edit`', function (): void {
+        $browseOnly = User::factory()->create();
+        $browseOnly->givePermissionTo('reviews.browse');
+        $this->actingAs($browseOnly);
+
+        Livewire::test(ReviewDetail::class, ['review' => $this->review])
+            ->assertActionHidden('approve')
+            ->assertActionHidden('reject');
+    });
+
+    it('hides the markAsSpam action when the user lacks `reviews.delete`', function (): void {
+        $editor = User::factory()->create();
+        $editor->givePermissionTo(['reviews.browse', 'reviews.edit']);
+        $this->actingAs($editor);
+
+        Livewire::test(ReviewDetail::class, ['review' => $this->review])
+            ->assertActionHidden('markAsSpam');
     });
 })->group('livewire', 'slideovers', 'products');


### PR DESCRIPTION
## Summary

Reviews moderation page lifted to the V3 admin shell: page header, 4 KPI cards, ratings breakdown sidebar, deep-linkable status tabs, and a moderation slide-over with three distinct actions.

## Page

- Header with title and description, 4-card KPI strip:
  - Average rating with stars
  - Total reviews with a `+N in the last 30 days` delta
  - 5-star reviews percentage
  - Pending moderation counter (turns amber when actionable)
- Sticky sidebar:
  - Rating breakdown bars (5★ to 1★) with counts
  - Customer recommendation rate (surfaces the existing `is_recommended` flag that was never displayed)
- Status tabs above the table: **All / Pending `{badge}` / Approved**, deep-linkable via `?tab=`. Replaces the redundant `TernaryFilter('approved')`.
- Product column in the table is now a clickable link to the product edit page.

## Slide-over

The previous single approve toggle is replaced with three distinct moderation actions:

| Action | Permission | Behavior |
|---|---|---|
| Approve | `reviews.edit` | Sets `approved=true`, dispatches `review-approved` |
| Reject | `reviews.edit` | Sets `approved=false`, dispatches `review-rejected` |
| Mark as spam | `reviews.delete` | Confirmation modal, sets `approved=false`, dispatches `review-flagged-as-spam` |

The `public Review` property is now `#[Locked]` to prevent snapshot tampering.

## Performance

- Stats, breakdown and recommended rate consolidated into a single aggregated query via `selectRaw(COUNT(CASE WHEN ...))`. Down from 8 queries per render to 2.
- New migration `2026_04_27_000001_add_indexes_to_reviews_table` adds indexes on `approved`, `rating`, `is_recommended`, `created_at`, plus a composite `(approved, created_at)`.
- Boolean expressions in `selectRaw` use bare `NOT approved` and `is_recommended` instead of bound parameters, avoiding the `boolean = integer` mismatch on PostgreSQL when Laravel's `prepareBindings` casts `false` to `0`.

## Global

- `FilamentView::spa()` enabled in `ShopperServiceProvider` so every Filament `->url()` column and action in the admin emits `wire:navigate`.
- `heading.blade.php` declares `title` as a prop so it stops leaking into the wrapper `<div>` as an HTML attribute.

## Cross-DB compatibility

Tests pass on SQLite, MySQL and PostgreSQL: 18/18 (72 assertions) on each driver.

## Breaking changes

- `ReviewDetail::approvedAction()` removed in favor of `approveAction()`, `rejectAction()`, `markAsSpamAction()`. Tests calling `callAction('approved')` must migrate to the new names.
- `TernaryFilter('approved')` removed from the table. `?approved=1` URLs become `?tab=approved`.
- `FilamentView::spa()` is now active globally in the admin. Third-party Filament panels mounted in the same app are also switched to SPA mode. Any `->url()` pointing to non-Livewire targets (downloads, externals) must use `->openUrlInNewTab()`.