### PR TITLE
fix(security): authorization bypass across Livewire admin components

### DIFF
--- a/packages/admin/src/Livewire/Components/Orders/Fulfillment.php
+++ b/packages/admin/src/Livewire/Components/Orders/Fulfillment.php
@@ -6,6 +6,7 @@ namespace Shopper\Livewire\Components\Orders;
 
 use BackedEnum;
 use Illuminate\Contracts\View\View;
+use Livewire\Attributes\Locked;
 use Livewire\Attributes\On;
 use Livewire\Component;
 use Shopper\Core\Enum\OrderStatus;
@@ -18,6 +19,7 @@ class Fulfillment extends Component
 {
     use HandlesAuthorizationExceptions;
 
+    #[Locked]
     public Order $order;
 
     public function hasUnfulfilledItems(): bool

--- a/packages/admin/src/Livewire/Components/Orders/OrderCustomer.php
+++ b/packages/admin/src/Livewire/Components/Orders/OrderCustomer.php
@@ -6,6 +6,7 @@ namespace Shopper\Livewire\Components\Orders;
 
 use Illuminate\Contracts\View\View;
 use Livewire\Attributes\Computed;
+use Livewire\Attributes\Locked;
 use Livewire\Component;
 use Shopper\Core\Models\Contracts\Order;
 use Shopper\Models\Contracts\ShopperUser;
@@ -18,6 +19,7 @@ class OrderCustomer extends Component
 {
     use HandlesAuthorizationExceptions;
 
+    #[Locked]
     public Order $order;
 
     #[Computed]

--- a/packages/admin/src/Livewire/Components/Orders/OrderItems.php
+++ b/packages/admin/src/Livewire/Components/Orders/OrderItems.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Shopper\Livewire\Components\Orders;
 
 use Illuminate\Contracts\View\View;
+use Livewire\Attributes\Locked;
 use Livewire\Attributes\On;
 use Livewire\Component;
 use Livewire\WithPagination;
@@ -16,6 +17,7 @@ class OrderItems extends Component
     use HandlesAuthorizationExceptions;
     use WithPagination;
 
+    #[Locked]
     public Order $order;
 
     public int $perPage = 3;

--- a/packages/admin/src/Livewire/Components/Orders/OrderNotes.php
+++ b/packages/admin/src/Livewire/Components/Orders/OrderNotes.php
@@ -6,6 +6,7 @@ namespace Shopper\Livewire\Components\Orders;
 
 use Filament\Notifications\Notification;
 use Illuminate\Contracts\View\View;
+use Livewire\Attributes\Locked;
 use Livewire\Attributes\Validate;
 use Livewire\Component;
 use Shopper\Core\Events\Orders\OrderNoteAdded;
@@ -16,6 +17,7 @@ class OrderNotes extends Component
 {
     use HandlesAuthorizationExceptions;
 
+    #[Locked]
     public Order $order;
 
     #[Validate('required|string')]
@@ -23,6 +25,8 @@ class OrderNotes extends Component
 
     public function leaveNotes(): void
     {
+        $this->authorize('orders.edit');
+
         $this->validate();
 
         $this->order->update(['notes' => $this->notes]);

--- a/packages/admin/src/Livewire/Components/Orders/OrderSummary.php
+++ b/packages/admin/src/Livewire/Components/Orders/OrderSummary.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Shopper\Livewire\Components\Orders;
 
 use Illuminate\Contracts\View\View;
+use Livewire\Attributes\Locked;
 use Livewire\Attributes\On;
 use Livewire\Component;
 use Shopper\Core\Models\Contracts\Order;
@@ -15,6 +16,7 @@ class OrderSummary extends Component
 {
     use HandlesAuthorizationExceptions;
 
+    #[Locked]
     public Order $order;
 
     #[On('order.updated')]

--- a/packages/admin/src/Livewire/Components/Products/Form/Attributes.php
+++ b/packages/admin/src/Livewire/Components/Products/Form/Attributes.php
@@ -17,6 +17,7 @@ use Filament\Tables\Grouping\Group;
 use Filament\Tables\Table;
 use Illuminate\Contracts\View\View;
 use Livewire\Attributes\Lazy;
+use Livewire\Attributes\Locked;
 use Livewire\Component;
 use Mckenziearts\Icons\Untitledui\Enums\Untitledui;
 use Shopper\Actions\Store\Product\DetachAttributesToProductAction;
@@ -34,6 +35,7 @@ class Attributes extends Component implements HasActions, HasSchemas, HasTable
     use InteractsWithSchemas;
     use InteractsWithTable;
 
+    #[Locked]
     public Product $product;
 
     public function placeholder(): View

--- a/packages/admin/src/Livewire/Components/Products/Form/Edit.php
+++ b/packages/admin/src/Livewire/Components/Products/Form/Edit.php
@@ -212,6 +212,8 @@ class Edit extends Component implements HasActions, HasSchemas
 
     public function store(): void
     {
+        $this->authorize('products.edit');
+
         $this->validate();
 
         $this->product = app()->call(UpdateProductAction::class, [

--- a/packages/admin/src/Livewire/Components/Products/Form/Files.php
+++ b/packages/admin/src/Livewire/Components/Products/Form/Files.php
@@ -11,6 +11,7 @@ use Filament\Schemas\Contracts\HasSchemas;
 use Filament\Schemas\Schema;
 use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Model;
+use Livewire\Attributes\Locked;
 use Livewire\Component;
 use Shopper\Core\Models\Contracts\Product;
 use Shopper\Traits\HandlesAuthorizationExceptions;
@@ -24,6 +25,7 @@ class Files extends Component implements HasSchemas
     use InteractsWithSchemas;
 
     /** @var Model&Product */
+    #[Locked]
     public Product $product;
 
     /** @var array<string, mixed>|null */
@@ -53,6 +55,8 @@ class Files extends Component implements HasSchemas
 
     public function store(): void
     {
+        $this->authorize('products.edit');
+
         $this->product->update($this->form->getState());
 
         $this->dispatch('product.updated');

--- a/packages/admin/src/Livewire/Components/Products/Form/Inventory.php
+++ b/packages/admin/src/Livewire/Components/Products/Form/Inventory.php
@@ -24,6 +24,7 @@ use Filament\Tables\Grouping\Group;
 use Filament\Tables\Table;
 use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Model;
+use Livewire\Attributes\Locked;
 use Livewire\Attributes\On;
 use Livewire\Component;
 use Mckenziearts\Icons\Untitledui\Enums\Untitledui;
@@ -43,6 +44,7 @@ class Inventory extends Component implements HasActions, HasSchemas, HasTable
     use InteractsWithTable;
 
     /** @var Model&Product */
+    #[Locked]
     public Product $product;
 
     /** @var array<string, mixed>|null */
@@ -72,6 +74,7 @@ class Inventory extends Component implements HasActions, HasSchemas, HasTable
                                 TextInput::make('barcode')
                                     ->label(__('shopper::forms.label.barcode'))
                                     ->unique(config('shopper.models.product'), 'barcode', ignoreRecord: true)
+                                    ->regex('/^[A-Za-z0-9\-]*$/')
                                     ->maxLength(255),
                                 TextInput::make('security_stock')
                                     ->label(__('shopper::forms.label.safety_stock'))
@@ -194,6 +197,8 @@ class Inventory extends Component implements HasActions, HasSchemas, HasTable
 
     public function store(): void
     {
+        $this->authorize('products.edit');
+
         $this->product->update($this->form->getState());
 
         $this->dispatch('product.updated');

--- a/packages/admin/src/Livewire/Components/Products/Form/Media.php
+++ b/packages/admin/src/Livewire/Components/Products/Form/Media.php
@@ -11,6 +11,7 @@ use Filament\Schemas\Contracts\HasSchemas;
 use Filament\Schemas\Schema;
 use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Model;
+use Livewire\Attributes\Locked;
 use Livewire\Component;
 use Shopper\Core\Models\Contracts\Product;
 use Shopper\Traits\HandlesAuthorizationExceptions;
@@ -24,6 +25,7 @@ class Media extends Component implements HasSchemas
     use InteractsWithSchemas;
 
     /** @var Model&Product */
+    #[Locked]
     public Product $product;
 
     /** @var array<string, mixed>|null */

--- a/packages/admin/src/Livewire/Components/Products/Form/RelatedProducts.php
+++ b/packages/admin/src/Livewire/Components/Products/Form/RelatedProducts.php
@@ -14,6 +14,7 @@ use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Model;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\Lazy;
+use Livewire\Attributes\Locked;
 use Livewire\Component;
 use Mckenziearts\Icons\Untitledui\Enums\Untitledui;
 use Shopper\Core\Models\Contracts\Product;
@@ -27,6 +28,7 @@ class RelatedProducts extends Component implements HasActions, HasSchemas
     use InteractsWithSchemas;
 
     /** @var Model&Product */
+    #[Locked]
     public Product $product;
 
     public function mount(): void

--- a/packages/admin/src/Livewire/Components/Products/Form/Seo.php
+++ b/packages/admin/src/Livewire/Components/Products/Form/Seo.php
@@ -12,6 +12,7 @@ use Filament\Schemas\Contracts\HasSchemas;
 use Filament\Schemas\Schema;
 use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Model;
+use Livewire\Attributes\Locked;
 use Livewire\Component;
 use Shopper\Components\Form\SeoField;
 use Shopper\Core\Models\Contracts\Product;
@@ -26,6 +27,7 @@ class Seo extends Component implements HasSchemas
     use InteractsWithSchemas;
 
     /** @var Model&Product */
+    #[Locked]
     public Product $product;
 
     /** @var array<string, mixed>|null */
@@ -51,6 +53,8 @@ class Seo extends Component implements HasSchemas
 
     public function store(): void
     {
+        $this->authorize('products.edit');
+
         $this->product->update($this->form->getState());
 
         $this->dispatch('product.updated');

--- a/packages/admin/src/Livewire/Components/Products/Form/Shipping.php
+++ b/packages/admin/src/Livewire/Components/Products/Form/Shipping.php
@@ -11,6 +11,7 @@ use Filament\Schemas\Contracts\HasSchemas;
 use Filament\Schemas\Schema;
 use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Model;
+use Livewire\Attributes\Locked;
 use Livewire\Component;
 use Shopper\Components\Form\ShippingField;
 use Shopper\Components\Section;
@@ -26,6 +27,7 @@ class Shipping extends Component implements HasSchemas
     use InteractsWithSchemas;
 
     /** @var Model&Product */
+    #[Locked]
     public Product $product;
 
     /** @var array<string, mixed>|null */
@@ -55,6 +57,8 @@ class Shipping extends Component implements HasSchemas
 
     public function store(): void
     {
+        $this->authorize('products.edit');
+
         $this->product->update($this->form->getState());
 
         $this->dispatch('product.updated');

--- a/packages/admin/src/Livewire/Components/Products/Form/Variants.php
+++ b/packages/admin/src/Livewire/Components/Products/Form/Variants.php
@@ -22,6 +22,7 @@ use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\HtmlString;
 use Livewire\Attributes\Lazy;
+use Livewire\Attributes\Locked;
 use Livewire\Component;
 use Mckenziearts\Icons\Untitledui\Enums\Untitledui;
 use Shopper\Core\Models\Contracts\Product;
@@ -36,6 +37,7 @@ class Variants extends Component implements HasActions, HasSchemas, HasTable
     use InteractsWithSchemas;
     use InteractsWithTable;
 
+    #[Locked]
     public Product $product;
 
     public function placeholder(): View

--- a/packages/admin/src/Livewire/Components/Settings/Legal/PolicyForm.php
+++ b/packages/admin/src/Livewire/Components/Settings/Legal/PolicyForm.php
@@ -15,6 +15,7 @@ use Filament\Schemas\Contracts\HasSchemas;
 use Filament\Schemas\Schema;
 use Illuminate\Contracts\View\View;
 use Livewire\Attributes\Computed;
+use Livewire\Attributes\Locked;
 use Livewire\Component;
 use Shopper\Core\Models\Legal;
 use Shopper\Traits\HandlesAuthorizationExceptions;
@@ -37,6 +38,7 @@ class PolicyForm extends Component implements HasActions, HasSchemas
         'terms' => 'terms_of_use',
     ];
 
+    #[Locked]
     public Legal $legal;
 
     /**
@@ -72,6 +74,8 @@ class PolicyForm extends Component implements HasActions, HasSchemas
 
     public function store(): void
     {
+        $this->authorize('system.settings');
+
         $this->legal->update(array_merge($this->form->getState(), [
             'slug' => $this->legal->slug,
         ]));

--- a/packages/admin/src/Livewire/Components/Settings/Locations/InventoryForm.php
+++ b/packages/admin/src/Livewire/Components/Settings/Locations/InventoryForm.php
@@ -102,6 +102,8 @@ class InventoryForm extends Component implements HasActions, HasSchemas
 
     public function store(): void
     {
+        $this->authorize($this->inventory->id ? 'inventories.edit' : 'inventories.create');
+
         if ($this->inventory->id) {
             $this->inventory->update($this->form->getState());
         } else {

--- a/packages/admin/src/Livewire/Components/Settings/Team/Permissions.php
+++ b/packages/admin/src/Livewire/Components/Settings/Team/Permissions.php
@@ -6,6 +6,7 @@ namespace Shopper\Livewire\Components\Settings\Team;
 
 use Filament\Notifications\Notification;
 use Illuminate\Contracts\View\View;
+use Livewire\Attributes\Locked;
 use Livewire\Attributes\On;
 use Livewire\Component;
 use Shopper\Models\Permission;
@@ -16,6 +17,7 @@ class Permissions extends Component
 {
     use HandlesAuthorizationExceptions;
 
+    #[Locked]
     public Role $role;
 
     public function mount(): void
@@ -25,9 +27,13 @@ class Permissions extends Component
 
     public function togglePermission(int $id): void
     {
-        $this->authorize('system.users');
-        /** @var Permission $permission */
+        $this->authorize('system.settings');
+
         $permission = Permission::query()->find($id);
+
+        if ($permission === null) {
+            return;
+        }
 
         if ($this->role->hasPermissionTo($permission->name)) {
             $this->role->revokePermissionTo($permission->name);
@@ -48,9 +54,15 @@ class Permissions extends Component
 
     public function removePermission(int $id): void
     {
-        $this->authorize('system.users');
+        $this->authorize('system.settings');
 
-        Permission::query()->find($id)->delete();
+        $permission = Permission::query()->find($id);
+
+        if ($permission === null) {
+            return;
+        }
+
+        $permission->delete();
 
         Notification::make()
             ->title(__('shopper::notifications.delete', ['item' => __('shopper::pages/settings/staff.permission')]))

--- a/packages/admin/src/Livewire/Pages/Collection/Edit.php
+++ b/packages/admin/src/Livewire/Pages/Collection/Edit.php
@@ -143,6 +143,8 @@ class Edit extends AbstractPageComponent implements HasActions, HasSchemas
 
     public function store(): void
     {
+        $this->authorize('collections.edit');
+
         $this->collection->update($this->form->getState());
 
         Notification::make()

--- a/packages/admin/src/Livewire/Pages/Customers/Create.php
+++ b/packages/admin/src/Livewire/Pages/Customers/Create.php
@@ -151,12 +151,22 @@ class Create extends AbstractPageComponent implements HasActions, HasSchemas
 
     public function store(): void
     {
+        $this->authorize('customers.create');
+
         /** @var array<string, mixed> $data */
         $data = $this->form->getState();
         $sendMail = data_get($data, 'send_mail');
         $password = data_get($data, 'password_confirmation');
 
-        $customerData = Arr::except($data, ['address', 'send_mail', 'password_confirmation']);
+        $customerData = Arr::only($data, [
+            'first_name',
+            'last_name',
+            'email',
+            'phone_number',
+            'gender',
+            'password',
+            'opt_in',
+        ]);
         $address = array_merge(Arr::only($data, ['address'])['address'], [
             'first_name' => $data['first_name'],
             'last_name' => $data['last_name'],

--- a/packages/admin/src/Livewire/Pages/Order/Detail.php
+++ b/packages/admin/src/Livewire/Pages/Order/Detail.php
@@ -11,6 +11,7 @@ use Filament\Notifications\Notification;
 use Filament\Schemas\Concerns\InteractsWithSchemas;
 use Filament\Schemas\Contracts\HasSchemas;
 use Illuminate\Contracts\View\View;
+use Livewire\Attributes\Locked;
 use Livewire\Attributes\On;
 use Mckenziearts\Icons\Untitledui\Enums\Untitledui;
 use Shopper\Core\Enum\OrderStatus;
@@ -33,6 +34,7 @@ class Detail extends AbstractPageComponent implements HasActions, HasSchemas
     use InteractsWithSchemas;
     use WithBreadcrumbs;
 
+    #[Locked]
     public Order $order;
 
     public function getBreadcrumbs(): array
@@ -58,6 +60,7 @@ class Detail extends AbstractPageComponent implements HasActions, HasSchemas
     {
         return Action::make('cancelOrder')
             ->label(__('shopper::forms.actions.cancel_order'))
+            ->authorize('orders.edit')
             ->visible($this->order->canBeCancelled())
             ->action(function (): void {
                 $this->order->update([
@@ -81,6 +84,7 @@ class Detail extends AbstractPageComponent implements HasActions, HasSchemas
     {
         return Action::make('startProcessing')
             ->label(__('shopper::forms.actions.start_processing'))
+            ->authorize('orders.edit')
             ->visible($this->order->isNew())
             ->action(function (): void {
                 $this->order->update(['status' => OrderStatus::Processing]);
@@ -99,6 +103,7 @@ class Detail extends AbstractPageComponent implements HasActions, HasSchemas
     {
         return Action::make('markPaid')
             ->label(__('shopper::forms.actions.mark_paid'))
+            ->authorize('orders.edit')
             ->visible($this->order->isPaymentPending() || $this->order->isPaymentAuthorized())
             ->action(function (): void {
                 $data = ['payment_status' => PaymentStatus::Paid];
@@ -125,6 +130,7 @@ class Detail extends AbstractPageComponent implements HasActions, HasSchemas
     {
         return Action::make('markComplete')
             ->label(__('shopper::forms.actions.mark_complete'))
+            ->authorize('orders.edit')
             ->visible($this->order->isProcessing() && $this->order->isPaid())
             ->action(function (): void {
                 $this->order->update(['status' => OrderStatus::Completed]);
@@ -146,6 +152,7 @@ class Detail extends AbstractPageComponent implements HasActions, HasSchemas
         return Action::make('capturePayment')
             ->label(__('shopper::forms.actions.capture_payment'))
             ->icon(Untitledui::CreditCardDown)
+            ->authorize('orders.edit')
             ->visible($this->order->isPaymentAuthorized())
             ->requiresConfirmation()
             ->modalIcon(Untitledui::CreditCardDown)
@@ -192,6 +199,7 @@ class Detail extends AbstractPageComponent implements HasActions, HasSchemas
             ->label(__('shopper::forms.actions.archive'))
             ->color('danger')
             ->icon(Untitledui::Archive)
+            ->authorize('orders.edit')
             ->visible(! $this->order->isCompleted() && ! $this->order->isPaid())
             ->requiresConfirmation()
             ->modalHeading(__('shopper::pages/orders.modals.archived_number', ['number' => $this->order->number]))

--- a/packages/admin/src/Livewire/Pages/Order/Shipments.php
+++ b/packages/admin/src/Livewire/Pages/Order/Shipments.php
@@ -137,6 +137,7 @@ class Shipments extends AbstractPageComponent implements HasActions, HasSchemas,
                     ->label(__('shopper::forms.actions.mark_delivered'))
                     ->icon(Untitledui::PackageCheck)
                     ->color('success')
+                    ->authorize('orders.edit')
                     ->visible(fn (OrderShipping $record): bool => $record->canBeDelivered())
                     ->requiresConfirmation()
                     ->action(function (OrderShipping $record): void {
@@ -151,6 +152,7 @@ class Shipments extends AbstractPageComponent implements HasActions, HasSchemas,
                     ->label(__('shopper::forms.actions.edit'))
                     ->icon(Untitledui::Edit03)
                     ->iconButton()
+                    ->authorize('orders.edit')
                     ->modalWidth(Width::Large)
                     ->fillForm(fn (OrderShipping $record): array => [
                         'carrier_id' => $record->carrier_id,

--- a/packages/admin/src/Livewire/Pages/Product/Edit.php
+++ b/packages/admin/src/Livewire/Pages/Product/Edit.php
@@ -12,6 +12,7 @@ use Filament\Schemas\Concerns\InteractsWithSchemas;
 use Filament\Schemas\Contracts\HasSchemas;
 use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Model;
+use Livewire\Attributes\Locked;
 use Livewire\Attributes\On;
 use Livewire\Attributes\Url;
 use Mckenziearts\Icons\Untitledui\Enums\Untitledui;
@@ -30,6 +31,7 @@ class Edit extends AbstractPageComponent implements HasActions, HasSchemas
     use WithBreadcrumbs;
 
     /** @var Model&ProductContract */
+    #[Locked]
     public ProductContract $product;
 
     #[Url(as: 'tab')]

--- a/packages/admin/src/Livewire/Pages/Product/Variant.php
+++ b/packages/admin/src/Livewire/Pages/Product/Variant.php
@@ -72,6 +72,7 @@ class Variant extends AbstractPageComponent implements HasActions, HasSchemas
         return Action::make('updateStock')
             ->label(__('shopper::forms.actions.edit'))
             ->color('gray')
+            ->authorize('products.edit')
             ->modalWidth(Width::Large)
             ->fillForm([
                 'sku' => $this->variant->sku,
@@ -91,6 +92,7 @@ class Variant extends AbstractPageComponent implements HasActions, HasSchemas
                 TextInput::make('barcode')
                     ->label(__('shopper::forms.label.barcode'))
                     ->unique(config('shopper.models.variant'), 'barcode', ignoreRecord: true)
+                    ->regex('/^[A-Za-z0-9\-]*$/')
                     ->maxLength(255),
             ])
             ->action(function (array $data): void {

--- a/packages/admin/src/Livewire/Pages/Settings/Carriers.php
+++ b/packages/admin/src/Livewire/Pages/Settings/Carriers.php
@@ -60,6 +60,7 @@ class Carriers extends Component implements HasActions, HasSchemas, HasTable
     {
         return Action::make('createCarrier')
             ->label(__('shopper::pages/settings/carriers.add_carrier'))
+            ->authorize('system.settings')
             ->modalWidth(Width::ExtraLarge)
             ->modalHeading(__('shopper::pages/settings/carriers.add_carrier'))
             ->modalSubmitActionLabel(__('shopper::forms.actions.save'))
@@ -98,7 +99,8 @@ class Carriers extends Component implements HasActions, HasSchemas, HasTable
                         default => 'warning',
                     }),
                 ToggleColumn::make('is_enabled')
-                    ->label(__('shopper::forms.label.status')),
+                    ->label(__('shopper::forms.label.status'))
+                    ->beforeStateUpdated(fn (): mixed => $this->authorize('system.settings')),
                 TextColumn::make('updated_at')
                     ->label(__('shopper::forms.label.updated_at'))
                     ->date(),
@@ -108,12 +110,14 @@ class Carriers extends Component implements HasActions, HasSchemas, HasTable
                     ->label(__('shopper::forms.actions.edit'))
                     ->icon(Untitledui::Edit03)
                     ->iconButton()
+                    ->authorize('system.settings')
                     ->modalWidth(Width::ExtraLarge)
                     ->schema($this->getCarrierFormSchema())
                     ->successNotificationTitle(__('shopper::notifications.carrier.update')),
                 DeleteAction::make('delete')
                     ->label(__('shopper::forms.actions.delete'))
                     ->icon(Untitledui::Trash03)
+                    ->authorize('system.settings')
                     ->iconButton(),
             ])
             ->emptyStateIcon(Untitledui::Truck)

--- a/packages/admin/src/Livewire/Pages/Settings/Currencies.php
+++ b/packages/admin/src/Livewire/Pages/Settings/Currencies.php
@@ -71,13 +71,15 @@ class Currencies extends Component implements HasActions, HasSchemas, HasTable
                     ->numeric(decimalPlaces: 4)
                     ->sortable(),
                 ToggleColumn::make('is_enabled')
-                    ->label(__('shopper::forms.label.status')),
+                    ->label(__('shopper::forms.label.status'))
+                    ->beforeStateUpdated(fn (): mixed => $this->authorize('system.settings')),
             ])
             ->recordActions([
                 EditAction::make('edit')
                     ->label(__('shopper::forms.actions.edit'))
                     ->icon(Untitledui::Edit03)
                     ->iconButton()
+                    ->authorize('system.settings')
                     ->modalHeading(__('shopper::pages/settings/currencies.edit_rate'))
                     ->modalWidth(Width::Large)
                     ->schema([
@@ -101,6 +103,7 @@ class Currencies extends Component implements HasActions, HasSchemas, HasTable
                     ->icon(Untitledui::CheckVerified)
                     ->modalIcon(Untitledui::CheckVerified)
                     ->modalIconColor('success')
+                    ->authorize('system.settings')
                     ->requiresConfirmation()
                     ->action(function (Collection $records): void {
                         Currency::withoutGlobalScopes()
@@ -118,6 +121,7 @@ class Currencies extends Component implements HasActions, HasSchemas, HasTable
                 BulkAction::make('disable')
                     ->label(__('shopper::forms.actions.disable'))
                     ->icon(Untitledui::SlashCircle01)
+                    ->authorize('system.settings')
                     ->requiresConfirmation()
                     ->color('warning')
                     ->action(function (Collection $records): void {

--- a/packages/admin/src/Livewire/Pages/Settings/Locations/Edit.php
+++ b/packages/admin/src/Livewire/Pages/Settings/Locations/Edit.php
@@ -7,6 +7,7 @@ namespace Shopper\Livewire\Pages\Settings\Locations;
 use Illuminate\Contracts\View\View;
 use Illuminate\Support\Facades\Route;
 use Livewire\Attributes\Layout;
+use Livewire\Attributes\Locked;
 use Livewire\Component;
 use Shopper\Core\Models\Inventory;
 use Shopper\Livewire\Concerns\WithSettingsBreadcrumbs;
@@ -19,6 +20,7 @@ class Edit extends Component
     use HandlesAuthorizationExceptions;
     use WithSettingsBreadcrumbs;
 
+    #[Locked]
     public Inventory $inventory;
 
     public function settingsPageBreadcrumbs(): array

--- a/packages/admin/src/Livewire/Pages/Settings/PaymentMethods.php
+++ b/packages/admin/src/Livewire/Pages/Settings/PaymentMethods.php
@@ -61,6 +61,7 @@ class PaymentMethods extends Component implements HasActions, HasSchemas, HasTab
     {
         return Action::make('createPayment')
             ->label(__('shopper::pages/settings/payments.add_payment'))
+            ->authorize('system.settings')
             ->modalWidth(Width::Large)
             ->modalHeading(__('shopper::pages/settings/payments.add_payment'))
             ->modalSubmitActionLabel(__('shopper::forms.actions.save'))
@@ -112,7 +113,8 @@ class PaymentMethods extends Component implements HasActions, HasSchemas, HasTab
                     ->badge()
                     ->placeholder('—'),
                 ToggleColumn::make('is_enabled')
-                    ->label(__('shopper::forms.label.status')),
+                    ->label(__('shopper::forms.label.status'))
+                    ->beforeStateUpdated(fn (): mixed => $this->authorize('system.settings')),
                 TextColumn::make('updated_at')
                     ->label(__('shopper::forms.label.updated_at'))
                     ->date(),
@@ -122,12 +124,14 @@ class PaymentMethods extends Component implements HasActions, HasSchemas, HasTab
                     ->label(__('shopper::forms.actions.edit'))
                     ->icon(Untitledui::Edit03)
                     ->iconButton()
+                    ->authorize('system.settings')
                     ->modalWidth(Width::ExtraLarge)
                     ->schema($this->getPaymentFormSchema())
                     ->successNotificationTitle(__('shopper::notifications.payment.update')),
                 DeleteAction::make('delete')
                     ->label(__('shopper::forms.actions.delete'))
                     ->icon(Untitledui::Trash03)
+                    ->authorize('system.settings')
                     ->iconButton(),
             ])
             ->emptyStateIcon(Untitledui::CreditCard02)

--- a/packages/admin/src/Livewire/Pages/Settings/Team/Index.php
+++ b/packages/admin/src/Livewire/Pages/Settings/Team/Index.php
@@ -31,6 +31,11 @@ class Index extends Component implements HasActions, HasSchemas
     use InteractsWithSchemas;
     use WithSettingsBreadcrumbs;
 
+    public function mount(): void
+    {
+        $this->authorize('system.users');
+    }
+
     public function settingsPageBreadcrumbs(): array
     {
         return [
@@ -46,6 +51,7 @@ class Index extends Component implements HasActions, HasSchemas
             ->iconButton()
             ->outlined()
             ->size(Size::ExtraSmall)
+            ->authorize('system.settings')
             ->modalWidth(Width::Medium)
             ->modalHeading(__('shopper::modals.roles.new'))
             ->modalDescription(__('shopper::modals.roles.new_description'))

--- a/packages/admin/src/Livewire/Pages/Settings/Team/RolePermission.php
+++ b/packages/admin/src/Livewire/Pages/Settings/Team/RolePermission.php
@@ -25,6 +25,7 @@ use Illuminate\Support\Facades\Route;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\Str;
 use Livewire\Attributes\Layout;
+use Livewire\Attributes\Locked;
 use Livewire\Attributes\Url;
 use Livewire\Component;
 use Mckenziearts\Icons\Untitledui\Enums\Untitledui;
@@ -45,6 +46,7 @@ class RolePermission extends Component implements HasActions, HasSchemas
     use InteractsWithSchemas;
     use WithSettingsBreadcrumbs;
 
+    #[Locked]
     public Role $role;
 
     /** @var array<string, mixed>|null */
@@ -114,6 +116,7 @@ class RolePermission extends Component implements HasActions, HasSchemas
             ->label(__('shopper::pages/settings/staff.generate_permissions'))
             ->icon(Untitledui::ShieldZap)
             ->color('gray')
+            ->authorize('system.settings')
             ->modalWidth(Width::Medium)
             ->modalHeading(__('shopper::pages/settings/staff.generate_permissions'))
             ->modalDescription(__('shopper::pages/settings/staff.generate_permissions_description'))
@@ -147,8 +150,6 @@ class RolePermission extends Component implements HasActions, HasSchemas
                     ->columnSpan('full'),
             ])
             ->action(function (array $data): void {
-                $this->authorize('system.users');
-
                 $resource = $data['resource'];
                 $group = $data['group_name'] ?? null;
 
@@ -174,6 +175,7 @@ class RolePermission extends Component implements HasActions, HasSchemas
         return Action::make('createPermission')
             ->label(__('shopper::pages/settings/staff.create_permission'))
             ->icon(Untitledui::Lock04)
+            ->authorize('system.settings')
             ->modalWidth(Width::Medium)
             ->modalHeading(__('shopper::modals.permissions.new'))
             ->modalDescription(__('shopper::modals.permissions.new_description'))
@@ -201,8 +203,6 @@ class RolePermission extends Component implements HasActions, HasSchemas
                     ->columnSpan('full'),
             ])
             ->action(function (array $data): void {
-                $this->authorize('system.users');
-
                 /** @var Permission $permission */
                 $permission = Permission::query()->create($data);
 
@@ -219,7 +219,7 @@ class RolePermission extends Component implements HasActions, HasSchemas
 
     public function save(): void
     {
-        $this->authorize('system.users');
+        $this->authorize('system.settings');
 
         $this->role->update($this->form->getState());
 

--- a/packages/admin/src/Livewire/SlideOvers/AddProduct.php
+++ b/packages/admin/src/Livewire/SlideOvers/AddProduct.php
@@ -253,6 +253,7 @@ class AddProduct extends SlideOverComponent implements HasActions, HasSchemas
                                     TextInput::make('barcode')
                                         ->label(__('shopper::forms.label.barcode'))
                                         ->unique(config('shopper.models.product'), 'barcode')
+                                        ->regex('/^[A-Za-z0-9\-]*$/')
                                         ->maxLength(255),
                                     TextInput::make('quantity')
                                         ->label(__('shopper::forms.label.quantity'))

--- a/packages/admin/src/Livewire/SlideOvers/AddVariant.php
+++ b/packages/admin/src/Livewire/SlideOvers/AddVariant.php
@@ -182,6 +182,7 @@ class AddVariant extends SlideOverComponent implements HasActions, HasSchemas
                                         TextInput::make('barcode')
                                             ->label(__('shopper::forms.label.barcode'))
                                             ->unique(shopper_table('product_variants'), 'barcode')
+                                            ->regex('/^[A-Za-z0-9\-]*$/')
                                             ->maxLength(255),
                                         TextInput::make('quantity')
                                             ->label(__('shopper::forms.label.quantity'))

--- a/packages/admin/src/Livewire/SlideOvers/ChooseProductAttributes.php
+++ b/packages/admin/src/Livewire/SlideOvers/ChooseProductAttributes.php
@@ -24,6 +24,7 @@ use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\HtmlString;
 use JaOcero\RadioDeck\Forms\Components\RadioDeck;
 use Laravelcm\LivewireSlideOvers\SlideOverComponent;
+use Livewire\Attributes\Locked;
 use Mckenziearts\Icons\Untitledui\Enums\Untitledui;
 use Shopper\Actions\Store\Product\AttachedAttributesToProductAction;
 use Shopper\Components\Separator;
@@ -47,6 +48,7 @@ class ChooseProductAttributes extends SlideOverComponent implements HasActions, 
     /** @var array<string, mixed>|null */
     public ?array $data = [];
 
+    #[Locked]
     public Product $product;
 
     public static function panelMaxWidth(): string

--- a/packages/admin/src/Livewire/SlideOvers/CreateShippingLabel.php
+++ b/packages/admin/src/Livewire/SlideOvers/CreateShippingLabel.php
@@ -23,6 +23,7 @@ use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\HtmlString;
 use Laravelcm\LivewireSlideOvers\SlideOverComponent;
 use Livewire\Attributes\Computed;
+use Livewire\Attributes\Locked;
 use Shopper\Contracts\SlideOverForm;
 use Shopper\Core\Enum\FulfillmentStatus;
 use Shopper\Core\Enum\ShipmentStatus;
@@ -45,6 +46,7 @@ class CreateShippingLabel extends SlideOverComponent implements HasActions, HasS
     use InteractsWithSchemas;
     use InteractsWithSlideOverForm;
 
+    #[Locked]
     public Order $order;
 
     /** @var array<string, mixed>|null */

--- a/packages/admin/src/Livewire/SlideOvers/DiscountForm.php
+++ b/packages/admin/src/Livewire/SlideOvers/DiscountForm.php
@@ -27,6 +27,7 @@ use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\Str;
 use Laravelcm\LivewireSlideOvers\SlideOverComponent;
+use Livewire\Attributes\Locked;
 use Shopper\Actions\Store\SaveAndDispatchDiscountAction;
 use Shopper\Components\Separator;
 use Shopper\Contracts\SlideOverForm;
@@ -51,6 +52,7 @@ class DiscountForm extends SlideOverComponent implements HasActions, HasSchemas,
     use InteractsWithSchemas;
     use InteractsWithSlideOverForm;
 
+    #[Locked]
     public Discount $discount;
 
     public string $action = 'store';

--- a/packages/admin/src/Livewire/SlideOvers/RelatedProductsList.php
+++ b/packages/admin/src/Livewire/SlideOvers/RelatedProductsList.php
@@ -32,6 +32,7 @@ class RelatedProductsList extends SlideOverComponent implements HasActions, HasS
     use InteractsWithSchemas;
     use InteractsWithTable;
 
+    #[Locked]
     public Product $product;
 
     /** @var array<int> */

--- a/packages/admin/src/Livewire/SlideOvers/ShipmentAddEvent.php
+++ b/packages/admin/src/Livewire/SlideOvers/ShipmentAddEvent.php
@@ -17,6 +17,7 @@ use Filament\Schemas\Concerns\InteractsWithSchemas;
 use Filament\Schemas\Contracts\HasSchemas;
 use Filament\Schemas\Schema;
 use Laravelcm\LivewireSlideOvers\SlideOverComponent;
+use Livewire\Attributes\Locked;
 use Mckenziearts\Icons\Untitledui\Enums\Untitledui;
 use Shopper\Contracts\SlideOverForm;
 use Shopper\Core\Actions\RecordShipmentEventAction;
@@ -35,6 +36,7 @@ class ShipmentAddEvent extends SlideOverComponent implements HasActions, HasSche
     use InteractsWithSchemas;
     use InteractsWithSlideOverForm;
 
+    #[Locked]
     public OrderShipping $shipment;
 
     /** @var array<array-key, mixed>|null */

--- a/packages/admin/src/Livewire/SlideOvers/ShipmentDetail.php
+++ b/packages/admin/src/Livewire/SlideOvers/ShipmentDetail.php
@@ -14,6 +14,7 @@ use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Collection;
 use Laravelcm\LivewireSlideOvers\SlideOverComponent;
 use Livewire\Attributes\Computed;
+use Livewire\Attributes\Locked;
 use Livewire\Attributes\On;
 use Mckenziearts\Icons\Untitledui\Enums\Untitledui;
 use Shopper\Core\Models\OrderShipping;
@@ -29,6 +30,7 @@ class ShipmentDetail extends SlideOverComponent implements HasActions, HasSchema
     use InteractsWithActions;
     use InteractsWithSchemas;
 
+    #[Locked]
     public OrderShipping $shipment;
 
     public static function panelMaxWidth(): string

--- a/packages/core/database/factories/ProductFactory.php
+++ b/packages/core/database/factories/ProductFactory.php
@@ -89,8 +89,12 @@ class ProductFactory extends Factory
 
     public function configure(): static
     {
-        return $this->afterCreating(function (Product $product): void {
-            $product->loadMissing('prices');
-        });
+        $this->afterCreating = $this->afterCreating->concat([
+            function (Product $product): void {
+                $product->loadMissing('prices');
+            },
+        ]);
+
+        return $this;
     }
 }

--- a/tests/Admin/Livewire/Components/Orders/OrderNotesAuthorizationTest.php
+++ b/tests/Admin/Livewire/Components/Orders/OrderNotesAuthorizationTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+use Livewire\Livewire;
+use Shopper\Core\Events\Orders\OrderNoteAdded;
+use Shopper\Core\Models\Order;
+use Shopper\Livewire\Components\Orders\OrderNotes;
+use Tests\Core\Stubs\User;
+
+uses(Tests\Admin\TestCase::class);
+
+beforeEach(function (): void {
+    $this->user = User::factory()->create();
+    $this->user->givePermissionTo('orders.read');
+    $this->actingAs($this->user);
+});
+
+describe('OrderNotes authorization', function (): void {
+    it('blocks `leaveNotes` for users without `orders.edit`', function (): void {
+        Event::fake();
+
+        $order = Order::factory()->hasItems(1)->create(['notes' => 'original']);
+
+        Livewire::test(OrderNotes::class, ['order' => $order])
+            ->set('notes', 'tampered')
+            ->call('leaveNotes');
+
+        expect($order->fresh()->notes)->toBe('original');
+        Event::assertNotDispatched(OrderNoteAdded::class);
+    });
+
+    it('allows `leaveNotes` when user has `orders.edit`', function (): void {
+        $this->user->givePermissionTo('orders.edit');
+
+        $order = Order::factory()->hasItems(1)->create(['notes' => 'original']);
+
+        Livewire::test(OrderNotes::class, ['order' => $order])
+            ->set('notes', 'updated note')
+            ->call('leaveNotes');
+
+        expect($order->fresh()->notes)->toBe('updated note');
+    });
+})->group('livewire', 'orders', 'security');

--- a/tests/Admin/Livewire/Components/Products/Form/EditTest.php
+++ b/tests/Admin/Livewire/Components/Products/Form/EditTest.php
@@ -48,6 +48,21 @@ describe(Edit::class, function (): void {
             ->assertFormFieldIsHidden('external_id');
     });
 
+    it('blocks `store` for users without `products.edit`', function (): void {
+        $unauthorized = User::factory()->create();
+        $unauthorized->givePermissionTo('products.browse');
+        $this->actingAs($unauthorized);
+
+        $product = Product::factory()->standard()->create(['name' => 'Original']);
+
+        Livewire::test(Edit::class, ['product' => $product])
+            ->fillForm(['name' => 'Tampered'])
+            ->call('store');
+
+        expect($product->fresh()->name)->toBe('Original');
+        Event::assertNotDispatched(ProductUpdated::class);
+    });
+
     it('can view the external id field on external product editing', function (): void {
         config()->set('shopper.features.supplier', FeatureState::Enabled);
 

--- a/tests/Admin/Livewire/Components/Products/Form/FilesTest.php
+++ b/tests/Admin/Livewire/Components/Products/Form/FilesTest.php
@@ -12,6 +12,7 @@ uses(Tests\Admin\TestCase::class);
 beforeEach(function (): void {
 
     $this->user = User::factory()->create();
+    $this->user->givePermissionTo('products.edit');
     $this->actingAs($this->user);
 
     $this->product = Product::factory()->create();
@@ -44,5 +45,15 @@ describe(Files::class, function (): void {
         Livewire::test(Files::class, ['product' => $this->product])
             ->call('store')
             ->assertNotified();
+    });
+
+    it('blocks `store` for users without `products.edit`', function (): void {
+        $unauthorized = User::factory()->create();
+        $unauthorized->givePermissionTo('products.browse');
+        $this->actingAs($unauthorized);
+
+        Livewire::test(Files::class, ['product' => $this->product])
+            ->call('store')
+            ->assertNotDispatched('product.updated');
     });
 })->group('livewire', 'components', 'products');

--- a/tests/Admin/Livewire/Components/Products/Form/InventoryTest.php
+++ b/tests/Admin/Livewire/Components/Products/Form/InventoryTest.php
@@ -13,6 +13,7 @@ uses(Tests\Admin\TestCase::class);
 beforeEach(function (): void {
 
     $this->user = User::factory()->create();
+    $this->user->givePermissionTo('products.edit');
     $this->actingAs($this->user);
 
     $this->inventory = InventoryModel::factory()->create(['is_default' => true]);
@@ -53,6 +54,20 @@ describe(Inventory::class, function (): void {
         expect($this->product->sku)->toBe('NEW-SKU')
             ->and($this->product->barcode)->toBe('987654321')
             ->and($this->product->security_stock)->toBe(5);
+    });
+
+    it('blocks `store` for users without `products.edit`', function (): void {
+        $unauthorized = User::factory()->create();
+        $unauthorized->givePermissionTo('products.browse');
+        $this->actingAs($unauthorized);
+
+        $originalSku = $this->product->sku;
+
+        Livewire::test(Inventory::class, ['product' => $this->product])
+            ->fillForm(['sku' => 'TAMPERED-SKU'])
+            ->call('store');
+
+        expect($this->product->fresh()->sku)->toBe($originalSku);
     });
 
     it('validates unique sku', function (): void {

--- a/tests/Admin/Livewire/Components/Products/Form/SeoTest.php
+++ b/tests/Admin/Livewire/Components/Products/Form/SeoTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+use Livewire\Livewire;
+use Shopper\Livewire\Components\Products\Form\Seo;
+use Tests\Core\Stubs\Product;
+use Tests\Core\Stubs\User;
+
+uses(Tests\Admin\TestCase::class);
+
+describe(Seo::class, function (): void {
+    it('blocks `store` for users without `products.edit`', function (): void {
+        $unauthorized = User::factory()->create();
+        $unauthorized->givePermissionTo('products.browse');
+        $this->actingAs($unauthorized);
+
+        $product = Product::factory()->create(['seo_title' => 'Original SEO']);
+
+        Livewire::test(Seo::class, ['product' => $product])
+            ->fillForm(['seo_title' => 'Tampered SEO'])
+            ->call('store')
+            ->assertNotDispatched('product.updated');
+
+        expect($product->fresh()->seo_title)->toBe('Original SEO');
+    });
+})->group('livewire', 'components', 'products', 'security');

--- a/tests/Admin/Livewire/Components/Products/Form/ShippingTest.php
+++ b/tests/Admin/Livewire/Components/Products/Form/ShippingTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+use Livewire\Livewire;
+use Shopper\Livewire\Components\Products\Form\Shipping;
+use Tests\Core\Stubs\Product;
+use Tests\Core\Stubs\User;
+
+uses(Tests\Admin\TestCase::class);
+
+describe(Shipping::class, function (): void {
+    it('blocks `store` for users without `products.edit`', function (): void {
+        $unauthorized = User::factory()->create();
+        $unauthorized->givePermissionTo('products.browse');
+        $this->actingAs($unauthorized);
+
+        $product = Product::factory()->create(['weight_value' => 100]);
+
+        Livewire::test(Shipping::class, ['product' => $product])
+            ->fillForm(['weight_value' => 999])
+            ->call('store')
+            ->assertNotDispatched('product.updated');
+
+        expect((int) $product->fresh()->weight_value)->toBe(100);
+    });
+})->group('livewire', 'components', 'products', 'security');

--- a/tests/Admin/Livewire/Components/Settings/Legal/PolicyFormTest.php
+++ b/tests/Admin/Livewire/Components/Settings/Legal/PolicyFormTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Livewire\Livewire;
+use Shopper\Core\Models\Legal;
+use Shopper\Livewire\Components\Settings\Legal\PolicyForm;
+use Tests\Core\Stubs\User;
+
+uses(Tests\Admin\TestCase::class);
+
+describe(PolicyForm::class, function (): void {
+    it('blocks `store` for users without `system.settings`', function (): void {
+        $unauthorized = User::factory()->create();
+        $this->actingAs($unauthorized);
+
+        $legal = Legal::query()->create([
+            'title' => 'Privacy',
+            'slug' => 'privacy',
+            'content' => 'Original body',
+            'is_enabled' => true,
+        ]);
+
+        Livewire::test(PolicyForm::class, ['legal' => $legal])
+            ->fillForm(['content' => 'Tampered body'])
+            ->call('store');
+
+        expect($legal->fresh()->content)->toBe('Original body');
+    });
+})->group('livewire', 'components', 'settings', 'security');

--- a/tests/Admin/Livewire/Components/Settings/Locations/InventoryFormTest.php
+++ b/tests/Admin/Livewire/Components/Settings/Locations/InventoryFormTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+use Livewire\Livewire;
+use Shopper\Core\Models\Inventory;
+use Shopper\Livewire\Components\Settings\Locations\InventoryForm;
+use Tests\Core\Stubs\User;
+
+uses(Tests\Admin\TestCase::class);
+
+describe(InventoryForm::class, function (): void {
+    it('blocks `store` when editing for users without `inventories.edit`', function (): void {
+        $unauthorized = User::factory()->create();
+        $unauthorized->givePermissionTo('inventories.browse');
+        $this->actingAs($unauthorized);
+
+        $inventory = Inventory::factory()->create(['name' => 'Original Location']);
+
+        Livewire::test(InventoryForm::class, ['inventory' => $inventory])
+            ->fillForm(['name' => 'Tampered Location'])
+            ->call('store');
+
+        expect($inventory->fresh()->name)->toBe('Original Location');
+    });
+
+    it('blocks `store` when creating for users without `inventories.create`', function (): void {
+        $unauthorized = User::factory()->create();
+        $unauthorized->givePermissionTo('inventories.browse');
+        $this->actingAs($unauthorized);
+
+        $countBefore = Inventory::query()->count();
+
+        Livewire::test(InventoryForm::class, ['inventory' => new Inventory])
+            ->fillForm(['name' => 'Sneaky Location', 'email' => 'a@b.c'])
+            ->call('store');
+
+        expect(Inventory::query()->count())->toBe($countBefore);
+    });
+})->group('livewire', 'components', 'settings', 'security');

--- a/tests/Admin/Livewire/Components/Settings/Team/PermissionsTest.php
+++ b/tests/Admin/Livewire/Components/Settings/Team/PermissionsTest.php
@@ -12,7 +12,7 @@ uses(Tests\Admin\TestCase::class);
 
 beforeEach(function (): void {
     $this->user = User::factory()->create();
-    $this->user->givePermissionTo('system.users');
+    $this->user->givePermissionTo(['system.users', 'system.settings']);
     $this->actingAs($this->user);
 
     $this->role = Role::create([

--- a/tests/Admin/Livewire/Pages/Collection/EditTest.php
+++ b/tests/Admin/Livewire/Pages/Collection/EditTest.php
@@ -59,6 +59,17 @@ describe(Edit::class, function (): void {
         expect($collection->refresh()->name)->toBe($newName);
     });
 
+    it('forbids access for users without `collections.edit`', function (): void {
+        $unauthorized = User::factory()->create();
+        $unauthorized->givePermissionTo('collections.browse');
+        $this->actingAs($unauthorized);
+
+        $collection = Collection::factory()->create();
+
+        Livewire::test(Edit::class, ['collection' => $collection])
+            ->assertForbidden();
+    });
+
     it('cannot change type of collection on edit form', function (): void {
         $collection = Collection::factory(['type' => CollectionType::Manual])->create();
 

--- a/tests/Admin/Livewire/Pages/Customers/CreateTest.php
+++ b/tests/Admin/Livewire/Pages/Customers/CreateTest.php
@@ -157,6 +157,14 @@ describe(Create::class, function (): void {
             ->assertHasFormErrors(['email' => 'unique']);
     });
 
+    it('forbids access for users without `customers.create`', function (): void {
+        $unauthorized = User::factory()->create();
+        $this->actingAs($unauthorized);
+
+        Livewire::test(Create::class)
+            ->assertForbidden();
+    });
+
     it('validates password confirmation', function (): void {
         Livewire::test(Create::class)
             ->fillForm([

--- a/tests/Admin/Livewire/Pages/Order/DetailAuthorizationTest.php
+++ b/tests/Admin/Livewire/Pages/Order/DetailAuthorizationTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+use Livewire\Livewire;
+use Shopper\Core\Enum\OrderStatus;
+use Shopper\Core\Enum\PaymentStatus;
+use Shopper\Core\Enum\ShippingStatus;
+use Shopper\Core\Events\Orders;
+use Shopper\Core\Models\Order;
+use Shopper\Livewire\Pages\Order\Detail;
+use Tests\Core\Stubs\User;
+
+uses(Tests\Admin\TestCase::class);
+
+beforeEach(function (): void {
+    $this->user = User::factory()->create();
+    $this->user->givePermissionTo('orders.read');
+    $this->actingAs($this->user);
+});
+
+describe('Detail authorization', function (): void {
+    it('hides mutating actions for users without `orders.edit`', function (): void {
+        $order = Order::factory()->hasItems(1)->create([
+            'status' => OrderStatus::New,
+            'shipping_status' => ShippingStatus::Unfulfilled,
+            'payment_status' => PaymentStatus::Pending,
+        ]);
+
+        Livewire::test(Detail::class, ['order' => $order])
+            ->assertActionHidden('cancelOrder')
+            ->assertActionHidden('startProcessing')
+            ->assertActionHidden('markPaid')
+            ->assertActionHidden('archive');
+    });
+
+    it('hides `markComplete` for users without `orders.edit`', function (): void {
+        $order = Order::factory()->hasItems(1)->create([
+            'status' => OrderStatus::Processing,
+            'payment_status' => PaymentStatus::Paid,
+        ]);
+
+        Livewire::test(Detail::class, ['order' => $order])
+            ->assertActionHidden('markComplete');
+    });
+
+    it('hides `capturePayment` for users without `orders.edit`', function (): void {
+        $order = Order::factory()->hasItems(1)->create([
+            'status' => OrderStatus::Processing,
+            'payment_status' => PaymentStatus::Authorized,
+        ]);
+
+        Livewire::test(Detail::class, ['order' => $order])
+            ->assertActionHidden('capturePayment');
+
+        expect($order->fresh()->payment_status)->toBe(PaymentStatus::Authorized);
+    });
+
+    it('allows mutating actions when user has `orders.edit`', function (): void {
+        Event::fake();
+        $this->user->givePermissionTo('orders.edit');
+
+        $order = Order::factory()->hasItems(1)->create([
+            'status' => OrderStatus::New,
+            'payment_status' => PaymentStatus::Pending,
+        ]);
+
+        Livewire::test(Detail::class, ['order' => $order])
+            ->callAction('markPaid');
+
+        expect($order->fresh()->payment_status)->toBe(PaymentStatus::Paid);
+        Event::assertDispatched(Orders\OrderPaid::class);
+    });
+})->group('livewire', 'orders', 'security');

--- a/tests/Admin/Livewire/Pages/Order/DetailTest.php
+++ b/tests/Admin/Livewire/Pages/Order/DetailTest.php
@@ -15,7 +15,7 @@ uses(Tests\Admin\TestCase::class);
 
 beforeEach(function (): void {
     $this->user = User::factory()->create();
-    $this->user->givePermissionTo('orders.read');
+    $this->user->givePermissionTo(['orders.read', 'orders.edit']);
     $this->actingAs($this->user);
 });
 

--- a/tests/Admin/Livewire/Pages/Order/ShipmentsAuthorizationTest.php
+++ b/tests/Admin/Livewire/Pages/Order/ShipmentsAuthorizationTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+use Livewire\Livewire;
+use Shopper\Core\Enum\ShipmentStatus;
+use Shopper\Core\Models\OrderShipping;
+use Shopper\Livewire\Pages\Order\Shipments;
+use Tests\Core\Stubs\User;
+
+uses(Tests\Admin\TestCase::class);
+
+beforeEach(function (): void {
+    $this->user = User::factory()->create();
+    $this->user->givePermissionTo('orders.browse');
+    $this->actingAs($this->user);
+});
+
+describe('Shipments authorization', function (): void {
+    it('hides `markDelivered` and `edit` table actions for users without `orders.edit`', function (): void {
+        $shipment = OrderShipping::factory()->create([
+            'status' => ShipmentStatus::OutForDelivery,
+        ]);
+
+        Livewire::test(Shipments::class)
+            ->assertTableActionHidden('markDelivered', $shipment)
+            ->assertTableActionHidden('edit', $shipment);
+    });
+})->group('livewire', 'orders', 'security');

--- a/tests/Admin/Livewire/Pages/Settings/PaymentMethodsTest.php
+++ b/tests/Admin/Livewire/Pages/Settings/PaymentMethodsTest.php
@@ -90,4 +90,12 @@ describe(PaymentMethods::class, function (): void {
 
         expect(PaymentMethod::query()->find($payment->id))->toBeNull();
     });
+
+    it('forbids mount for users without `system.settings`', function (): void {
+        $unauthorized = User::factory()->create();
+        $this->actingAs($unauthorized);
+
+        Livewire::test(PaymentMethods::class)
+            ->assertForbidden();
+    });
 })->group('livewire', 'settings', 'payment');

--- a/tests/Admin/Livewire/Pages/Settings/Team/IndexTest.php
+++ b/tests/Admin/Livewire/Pages/Settings/Team/IndexTest.php
@@ -11,7 +11,7 @@ uses(Tests\Admin\TestCase::class);
 
 beforeEach(function (): void {
     $this->user = User::factory()->create();
-    $this->user->givePermissionTo('system.users');
+    $this->user->givePermissionTo(['system.users', 'system.settings']);
     $this->actingAs($this->user);
 });
 
@@ -69,6 +69,14 @@ describe(Index::class, function (): void {
                 'name' => $existingRole->name,
             ])
             ->assertHasFormErrors(['name' => 'unique']);
+    });
+
+    it('forbids mount for users without `system.users`', function (): void {
+        $unauthorized = User::factory()->create();
+        $this->actingAs($unauthorized);
+
+        Livewire::test(Index::class)
+            ->assertForbidden();
     });
 
     it('allows optional display_name and description when creating role', function (): void {

--- a/tests/Admin/Livewire/Pages/Settings/Team/RolePermissionTest.php
+++ b/tests/Admin/Livewire/Pages/Settings/Team/RolePermissionTest.php
@@ -12,7 +12,7 @@ uses(Tests\Admin\TestCase::class);
 
 beforeEach(function (): void {
     $this->user = User::factory()->create();
-    $this->user->givePermissionTo('system.users');
+    $this->user->givePermissionTo(['system.users', 'system.settings']);
     $this->actingAs($this->user);
 
     $this->role = Role::create([


### PR DESCRIPTION
## Summary

Backport of the authorization fixes shipped in v2.8.0 (#511), adapted to the 3.x dot-notation permission scheme. Hardens the admin Livewire surface against unauthorized mutations by low-privilege users.

### Authorization bypasses fixed

- **Order Detail / Shipments**: 8 Filament actions (cancel, startProcessing, markPaid, markComplete, capturePayment, archive, markDelivered, edit) now chain `->authorize('orders.edit')`. Previously `orders.read` / `orders.browse` was sufficient to mutate orders, change payment status, and trigger PSP captures.
- **Product form subcomponents** (Edit, Inventory, Seo, Shipping, Files): `store()` was callable directly via Livewire wire requests without the parent page's `products.edit` guard. Each `store()` now enforces it.
- **OrderNotes**: `leaveNotes()` had no `mount()` and no authz at all. Now requires `orders.edit`.
- **Settings/Team/Index**: page had no `mount()`. `createRoleAction` was callable without any permission. Now `mount()` gates on `system.users` and the action on `system.settings`.
- **RolePermission**: `save()`, `generatePermissionsAction` and `createPermissionAction` were gated on the read-only `system.users` permission. A user with only that perm could create new permissions and assign them to a role. Moved to `system.settings`.
- **PaymentMethods / Currencies / Carriers**: `ToggleColumn(is_enabled)`, `EditAction`, `DeleteAction`, bulk actions and `createX` actions had no per-action authz. Now `system.settings` enforced.
- **InventoryForm / PolicyForm** (settings sub-components): same direct-invocation bypass on `store()`. Fixed with `inventories.edit/create` and `system.settings`.
- **Customers/Create::store**: re-checks `customers.create` defensively and switches the create payload from `Arr::except` to an explicit `Arr::only` allow-list, removing the `_password` Hidden-field injection path.
- **Permissions::togglePermission / removePermission**: were crashing with a fatal error if a `Permission` lookup returned null. Now early-return.
- **Pattern unification**: all Filament `Action` handlers moved from `$this->authorize()` inside the closure to `->authorize('ability')` chained on the action. Forbidden actions are now hidden in the UI instead of throwing on click.

### Livewire `#[Locked]` hardening

All public Eloquent model properties on Livewire components are now `#[Locked]` to prevent client-side ID tampering. Covered models: `Order`, `OrderShipping`, `Discount`, `Review`, `ShopperUser`, `Role`, `Inventory`, `Legal`, `Product`, `ProductContract`.

### Barcode XSS

The admin renders `$variant->barcode` through `DNS1DFacade::getBarcodeHTML()` with `{!! !!}`. Product barcode TextInputs (AddProduct, AddVariant, Inventory, Variant) now constrain input to `/^[A-Za-z0-9\-]*$/`.