### PR TITLE
fix(security): close remaining authorization gaps in team settings

### DIFF
--- a/packages/admin/src/Livewire/Components/Settings/Team/Permissions.php
+++ b/packages/admin/src/Livewire/Components/Settings/Team/Permissions.php
@@ -27,7 +27,7 @@ class Permissions extends Component
 
     public function togglePermission(int $id): void
     {
-        $this->authorize('view_users');
+        $this->authorize('access_setting');
 
         $permission = Permission::query()->find($id);
 
@@ -54,7 +54,7 @@ class Permissions extends Component
 
     public function removePermission(int $id): void
     {
-        $this->authorize('view_users');
+        $this->authorize('access_setting');
 
         $permission = Permission::query()->find($id);
 

--- a/packages/admin/src/Livewire/Pages/Settings/Team/RolePermission.php
+++ b/packages/admin/src/Livewire/Pages/Settings/Team/RolePermission.php
@@ -83,6 +83,7 @@ class RolePermission extends Component implements HasActions, HasSchemas
         return DeleteAction::make('delete')
             ->label(__('shopper::forms.actions.delete'))
             ->icon(Untitledui::Trash03)
+            ->authorize('access_setting')
             ->visible($this->role->can_be_removed)
             ->record($this->role)
             ->successNotificationTitle(__('shopper::notifications.users_roles.role_deleted'))

--- a/packages/admin/src/Livewire/SlideOvers/CreateTeamMember.php
+++ b/packages/admin/src/Livewire/SlideOvers/CreateTeamMember.php
@@ -50,7 +50,7 @@ class CreateTeamMember extends SlideOverComponent implements HasActions, HasSche
 
     public function mount(): void
     {
-        $this->authorize('view_users');
+        $this->authorize('access_setting');
 
         $this->title = __('shopper::pages/settings/staff.add_admin');
 
@@ -119,7 +119,7 @@ class CreateTeamMember extends SlideOverComponent implements HasActions, HasSche
 
     public function store(): void
     {
-        $this->authorize('view_users');
+        $this->authorize('access_setting');
 
         $data = $this->form->getState();
         $userModel = config('auth.providers.users.model');

--- a/tests/Admin/Livewire/Components/Settings/Team/PermissionsTest.php
+++ b/tests/Admin/Livewire/Components/Settings/Team/PermissionsTest.php
@@ -12,7 +12,7 @@ uses(Tests\Admin\TestCase::class);
 
 beforeEach(function (): void {
     $this->user = User::factory()->create();
-    $this->user->givePermissionTo('view_users');
+    $this->user->givePermissionTo('view_users', 'access_setting');
     $this->actingAs($this->user);
 
     $this->role = Role::create([
@@ -124,5 +124,35 @@ describe(Permissions::class, function (): void {
         $component->dispatch('permissionAdded');
 
         $component->assertOk();
+    });
+
+    it('blocks `togglePermission` for users without `access_setting`', function (): void {
+        $reader = User::factory()->create();
+        $reader->givePermissionTo('view_users');
+        $this->actingAs($reader);
+
+        Livewire::test(Permissions::class, ['role' => $this->role])
+            ->call('togglePermission', $this->permission->id);
+
+        $this->role->refresh();
+
+        expect($this->role->hasPermissionTo('test.permission'))->toBeFalse();
+    });
+
+    it('blocks `removePermission` for users without `access_setting`', function (): void {
+        $reader = User::factory()->create();
+        $reader->givePermissionTo('view_users');
+        $this->actingAs($reader);
+
+        $permissionToDelete = Permission::create([
+            'name' => 'delete.me',
+            'display_name' => 'Delete Me',
+            'group_name' => 'Test',
+        ]);
+
+        Livewire::test(Permissions::class, ['role' => $this->role])
+            ->call('removePermission', $permissionToDelete->id);
+
+        expect(Permission::query()->find($permissionToDelete->id))->not->toBeNull();
     });
 })->group('livewire', 'components', 'settings');

--- a/tests/Admin/Livewire/Pages/Settings/Team/RolePermissionTest.php
+++ b/tests/Admin/Livewire/Pages/Settings/Team/RolePermissionTest.php
@@ -179,4 +179,21 @@ describe(RolePermission::class, function (): void {
 
         expect(Permission::query()->count())->toBe($initialCount + 1);
     });
+
+    it('hides `delete` action for users without `access_setting`', function (): void {
+        $roleToDelete = Role::create([
+            'name' => 'temporary',
+            'display_name' => 'Temporary',
+            'can_be_removed' => true,
+        ]);
+
+        $reader = User::factory()->create();
+        $reader->givePermissionTo('view_users');
+        $this->actingAs($reader);
+
+        Livewire::test(RolePermission::class, ['role' => $roleToDelete])
+            ->assertActionHidden('delete');
+
+        expect(Role::query()->find($roleToDelete->id))->not->toBeNull();
+    });
 })->group('livewire', 'settings', 'team');

--- a/tests/Admin/Livewire/SlideOvers/CreateTeamMemberTest.php
+++ b/tests/Admin/Livewire/SlideOvers/CreateTeamMemberTest.php
@@ -14,7 +14,7 @@ uses(Tests\Admin\TestCase::class);
 
 beforeEach(function (): void {
     $this->user = User::factory()->create();
-    $this->user->givePermissionTo('view_users');
+    $this->user->givePermissionTo('view_users', 'access_setting');
     $this->actingAs($this->user);
 
     $this->role = Role::query()->where('name', 'manager')->first();
@@ -153,5 +153,19 @@ describe(CreateTeamMember::class, function (): void {
         $newUser = User::query()->where('email', 'role@example.com')->first();
 
         expect($newUser->hasRole($secondRole->name))->toBeTrue();
+    });
+
+    it('blocks `store` for users without `access_setting`', function (): void {
+        $reader = User::factory()->create();
+        $reader->givePermissionTo('view_users');
+        $this->actingAs($reader);
+
+        $initialCount = User::query()->count();
+
+        Livewire::test(CreateTeamMember::class)
+            ->call('store');
+
+        expect(User::query()->count())->toBe($initialCount)
+            ->and(User::query()->where('email', 'denied@example.com')->exists())->toBeFalse();
     });
 })->group('livewire', 'team');


### PR DESCRIPTION
## Summary

Patches three authorization bypasses in the team settings surface that were missed by #511 / [GHSA-f946-9qp6-vgch](https://github.com/shopperlabs/shopper/security/advisories/GHSA-f946-9qp6-vgch).

A staff user holding only `view_users` + `access_dashboard` could:

1. Self-escalate by granting any permission (including `access_setting`) to their own role via `Permissions::togglePermission`.
2. Create a new admin user with a chosen password through `CreateTeamMember::store`, then log in as full admin.
3. Delete arbitrary permissions or removable roles through `Permissions::removePermission` and `RolePermission::deleteAction`.

## Vulnerable surfaces (before)

| Component | Method | Gate before | Gate after |
| --- | --- | --- | --- |
| `Livewire\Components\Settings\Team\Permissions` | `togglePermission` | `view_users` | `access_setting` |
| `Livewire\Components\Settings\Team\Permissions` | `removePermission` | `view_users` | `access_setting` |
| `Livewire\SlideOvers\CreateTeamMember` | `mount` | `view_users` | `access_setting` |
| `Livewire\SlideOvers\CreateTeamMember` | `store` | `view_users` | `access_setting` |
| `Livewire\Pages\Settings\Team\RolePermission` | `deleteAction` | none (only `->visible(can_be_removed)`) | `->authorize('access_setting')` |

The new gates match the pattern already used by `RolePermission::save`, `generatePermissionsAction`, `createPermissionAction`, and `Team\Index` write actions since #511.

## Notes

- `CreateTeamMember` was introduced by the #511 commit itself but inherited the same `view_users` gate.
- Regression tests added for every blocked path.
- Disclosed responsibly by @therawdev; advisory will be published once they re-submit through PVR (now enabled).