### PR TITLE
chore(deps): bump stripe/stripe-php to ^19.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
     "spatie/laravel-permission": "^6.24|^7.0",
     "staudenmeir/laravel-adjacency-list": "^1.0",
     "stevebauman/location": "^7.2",
-    "stripe/stripe-php": "^16.0"
+    "stripe/stripe-php": "^19.0"
   },
   "require-dev": {
     "larastan/larastan": "^3.8",


### PR DESCRIPTION
## Summary

Aligns the root `composer.json` constraint with `packages/stripe/composer.json`, which already requires `stripe/stripe-php: ^19.0`. The mismatch caused composer to resolve the shared dependency to `^16.0` in dev installs of the monorepo and would have created drift between the root and the split stripe package on the next release.