### PR TITLE
fix(security): close remaining authorization gaps in team settings

### DIFF
--- a/packages/admin/src/Livewire/Pages/Settings/Team/RolePermission.php
+++ b/packages/admin/src/Livewire/Pages/Settings/Team/RolePermission.php
@@ -104,6 +104,7 @@ class RolePermission extends Component implements HasActions, HasSchemas
         return DeleteAction::make('delete')
             ->label(__('shopper::forms.actions.delete'))
             ->icon(Untitledui::Trash03)
+            ->authorize('system.settings')
             ->visible($this->role->can_be_removed)
             ->record($this->role)
             ->successNotificationTitle(__('shopper::notifications.users_roles.role_deleted'))

--- a/packages/admin/src/Livewire/SlideOvers/CreateTeamMember.php
+++ b/packages/admin/src/Livewire/SlideOvers/CreateTeamMember.php
@@ -50,7 +50,7 @@ class CreateTeamMember extends SlideOverComponent implements HasActions, HasSche
 
     public function mount(): void
     {
-        $this->authorize('system.users');
+        $this->authorize('system.settings');
 
         $this->title = __('shopper::pages/settings/staff.add_admin');
 
@@ -121,7 +121,7 @@ class CreateTeamMember extends SlideOverComponent implements HasActions, HasSche
 
     public function store(): void
     {
-        $this->authorize('system.users');
+        $this->authorize('system.settings');
 
         $data = $this->form->getState();
         $userModel = config('auth.providers.users.model');

--- a/tests/Admin/Livewire/Components/Settings/Team/PermissionsTest.php
+++ b/tests/Admin/Livewire/Components/Settings/Team/PermissionsTest.php
@@ -125,4 +125,34 @@ describe(Permissions::class, function (): void {
 
         $component->assertOk();
     });
+
+    it('blocks `togglePermission` for users without `system.settings`', function (): void {
+        $reader = User::factory()->create();
+        $reader->givePermissionTo('system.users');
+        $this->actingAs($reader);
+
+        Livewire::test(Permissions::class, ['role' => $this->role])
+            ->call('togglePermission', $this->permission->id);
+
+        $this->role->refresh();
+
+        expect($this->role->hasPermissionTo('test.permission'))->toBeFalse();
+    });
+
+    it('blocks `removePermission` for users without `system.settings`', function (): void {
+        $reader = User::factory()->create();
+        $reader->givePermissionTo('system.users');
+        $this->actingAs($reader);
+
+        $permissionToDelete = Permission::create([
+            'name' => 'delete.me',
+            'display_name' => 'Delete Me',
+            'group_name' => 'Test',
+        ]);
+
+        Livewire::test(Permissions::class, ['role' => $this->role])
+            ->call('removePermission', $permissionToDelete->id);
+
+        expect(Permission::query()->find($permissionToDelete->id))->not->toBeNull();
+    });
 })->group('livewire', 'components', 'settings');

--- a/tests/Admin/Livewire/Pages/Settings/Team/RolePermissionTest.php
+++ b/tests/Admin/Livewire/Pages/Settings/Team/RolePermissionTest.php
@@ -179,4 +179,21 @@ describe(RolePermission::class, function (): void {
 
         expect(Permission::query()->count())->toBe($initialCount + 1);
     });
+
+    it('hides `delete` action for users without `system.settings`', function (): void {
+        $roleToDelete = Role::create([
+            'name' => 'temporary',
+            'display_name' => 'Temporary',
+            'can_be_removed' => true,
+        ]);
+
+        $reader = User::factory()->create();
+        $reader->givePermissionTo('system.users');
+        $this->actingAs($reader);
+
+        Livewire::test(RolePermission::class, ['role' => $roleToDelete])
+            ->assertActionHidden('delete');
+
+        expect(Role::query()->find($roleToDelete->id))->not->toBeNull();
+    });
 })->group('livewire', 'settings', 'team');

--- a/tests/Admin/Livewire/SlideOvers/CreateTeamMemberTest.php
+++ b/tests/Admin/Livewire/SlideOvers/CreateTeamMemberTest.php
@@ -14,7 +14,7 @@ uses(Tests\Admin\TestCase::class);
 
 beforeEach(function (): void {
     $this->user = User::factory()->create();
-    $this->user->givePermissionTo('system.users');
+    $this->user->givePermissionTo(['system.users', 'system.settings']);
     $this->actingAs($this->user);
 
     $this->role = Role::query()->where('name', 'manager')->first();
@@ -153,5 +153,19 @@ describe(CreateTeamMember::class, function (): void {
         $newUser = User::query()->where('email', 'role@example.com')->first();
 
         expect($newUser->hasRole($secondRole->name))->toBeTrue();
+    });
+
+    it('blocks `store` for users without `system.settings`', function (): void {
+        $reader = User::factory()->create();
+        $reader->givePermissionTo('system.users');
+        $this->actingAs($reader);
+
+        $initialCount = User::query()->count();
+
+        Livewire::test(CreateTeamMember::class)
+            ->call('store');
+
+        expect(User::query()->count())->toBe($initialCount)
+            ->and(User::query()->where('email', 'denied@example.com')->exists())->toBeFalse();
     });
 })->group('livewire', 'team');


### PR DESCRIPTION
## Summary

Ports #514 to `3.x`. Patches two authorization bypasses in the team settings surface that mirror the issues from #514 / [GHSA-f946-9qp6-vgch](https://github.com/shopperlabs/shopper/security/advisories/GHSA-f946-9qp6-vgch).

A staff user holding only `system.users` + `access_dashboard` could:

1. Create a new admin user with a chosen password through `CreateTeamMember::store`, then log in as full admin.
2. Delete arbitrary removable roles through `RolePermission::deleteAction`.

`Permissions::togglePermission` and `Permissions::removePermission` were already gated on `system.settings` by #512 on this branch; regression tests are added here for parity with the 2.x audit.

## Vulnerable surfaces (before)

| Component | Method | Gate before | Gate after |
| --- | --- | --- | --- |
| `Livewire\SlideOvers\CreateTeamMember` | `mount` | `system.users` | `system.settings` |
| `Livewire\SlideOvers\CreateTeamMember` | `store` | `system.users` | `system.settings` |
| `Livewire\Pages\Settings\Team\RolePermission` | `deleteAction` | none (only `->visible(can_be_removed)`) | `->authorize('system.settings')` |

The new gates match the pattern already used by `RolePermission::save`, `generatePermissionsAction`, `createPermissionAction`, and `Permissions::togglePermission` / `removePermission` since #512.

## Notes

- Permission names differ from 2.x (`system.users` / `system.settings` instead of `view_users` / `access_setting`) but the threat model is identical.
- Regression tests added for every blocked path, including the two `Permissions` methods already gated by #512.