### PR TITLE
fix: address post-merge audit findings on onboarding and settings

### DIFF
--- a/packages/admin/src/Livewire/Components/Dashboard/SetupGuide.php
+++ b/packages/admin/src/Livewire/Components/Dashboard/SetupGuide.php
@@ -26,8 +26,8 @@ final class SetupGuide extends Component
 
     public function mount(): void
     {
-        if ($this->isComplete) {
-            $this->complete();
+        if ($this->isComplete && auth()->user()?->can('access_setting')) {
+            $this->markComplete();
         }
     }
 
@@ -96,13 +96,20 @@ final class SetupGuide extends Component
 
     public function complete(): void
     {
-        $this->saveSettings(['setup_guide_done' => true]);
+        $this->authorize('access_setting');
 
-        $this->dispatch('setup-guide-completed');
+        $this->markComplete();
     }
 
     public function render(): View
     {
         return view('shopper::livewire.components.dashboard.setup-guide');
+    }
+
+    private function markComplete(): void
+    {
+        $this->saveSettings(['setup_guide_done' => true]);
+
+        $this->dispatch('setup-guide-completed');
     }
 }

--- a/packages/admin/src/Livewire/Components/Initialization/InitializationWizard.php
+++ b/packages/admin/src/Livewire/Components/Initialization/InitializationWizard.php
@@ -25,6 +25,7 @@ use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\Str;
+use Livewire\Attributes\Locked;
 use Livewire\Component;
 use Mckenziearts\Icons\Untitledui\Enums\Untitledui;
 use Shopper\Components\OnboardingWizard;
@@ -46,8 +47,17 @@ final class InitializationWizard extends Component implements HasActions, HasSch
     /** @var array<string, mixed>|null */
     public ?array $data = [];
 
+    #[Locked]
+    public array $countryOptions = [];
+
+    #[Locked]
+    public array $currencyOptions = [];
+
     public function mount(): void
     {
+        $this->countryOptions = self::countryOptions();
+        $this->currencyOptions = self::currencyOptions();
+
         /** @var Collection<int, Setting> $settings */
         $settings = Setting::query()
             ->whereIn('key', [
@@ -106,13 +116,13 @@ final class InitializationWizard extends Component implements HasActions, HasSch
                                 ]),
                             Select::make('country_id')
                                 ->label(__('shopper::forms.label.country'))
-                                ->options(fn (): array => self::countryOptions())
+                                ->options($this->countryOptions)
                                 ->searchable()
                                 ->native(false),
                             Select::make('currencies')
                                 ->label(__('shopper::forms.label.currencies'))
                                 ->helperText(__('shopper::pages/onboarding.currencies_description'))
-                                ->options(fn (): array => self::currencyOptions())
+                                ->options($this->currencyOptions)
                                 ->searchable()
                                 ->multiple()
                                 ->minItems(1)
@@ -124,7 +134,7 @@ final class InitializationWizard extends Component implements HasActions, HasSch
                                 ->helperText(__('shopper::pages/onboarding.currency_description'))
                                 ->placeholder(__('shopper::forms.placeholder.select_currencies'))
                                 ->options(
-                                    fn (Get $get): array => collect(self::currencyOptions())
+                                    fn (Get $get): array => collect($this->currencyOptions)
                                         ->only($get('currencies') ?? [])
                                         ->all()
                                 )
@@ -277,7 +287,7 @@ final class InitializationWizard extends Component implements HasActions, HasSch
     private static function countryOptions(): array
     {
         return Cache::remember(
-            'shopper.onboarding.country_options',
+            'shopper.onboarding.country_options.'.app()->getLocale(),
             now()->addDay(),
             fn (): array => Country::query()
                 ->select('name', 'id', 'region', 'cca2')
@@ -296,7 +306,7 @@ final class InitializationWizard extends Component implements HasActions, HasSch
     private static function currencyOptions(): array
     {
         return Cache::remember(
-            'shopper.onboarding.currency_options',
+            'shopper.onboarding.currency_options.'.app()->getLocale(),
             now()->addDay(),
             fn (): array => Currency::query()
                 ->orderBy('name')
@@ -333,19 +343,17 @@ final class InitializationWizard extends Component implements HasActions, HasSch
      */
     private function createDefaultInventory(array $state): void
     {
-        $name = $state['name'] ?? shopper_setting('name');
-
-        Inventory::query()->firstOrCreate(
+        Inventory::query()->updateOrCreate(
             ['is_default' => true],
             [
-                'name' => $name,
-                'code' => Str::slug((string) $name),
-                'email' => $state['email'] ?? shopper_setting('email'),
-                'street_address' => $state['street_address'] ?? shopper_setting('street_address'),
-                'postal_code' => $state['postal_code'] ?? shopper_setting('postal_code'),
-                'city' => $state['city'] ?? shopper_setting('city'),
-                'phone_number' => $state['phone_number'] ?? shopper_setting('phone_number'),
-                'country_id' => $state['country_id'] ?? shopper_setting('country_id'),
+                'name' => $state['name'],
+                'code' => Str::slug((string) $state['name']),
+                'email' => $state['email'],
+                'street_address' => $state['street_address'],
+                'postal_code' => $state['postal_code'],
+                'city' => $state['city'],
+                'phone_number' => $state['phone_number'] ?? null,
+                'country_id' => $state['country_id'] ?? null,
             ]
         );
     }

--- a/packages/admin/src/Traits/SaveSettings.php
+++ b/packages/admin/src/Traits/SaveSettings.php
@@ -17,6 +17,14 @@ trait SaveSettings
     {
         DB::transaction(function () use ($keys, $locked): void {
             foreach ($keys as $key => $value) {
+                $existingLocked = Setting::query()
+                    ->where('key', $key)
+                    ->value('locked');
+
+                if ($existingLocked && ! $locked) {
+                    continue;
+                }
+
                 Cache::forget('shopper-setting.'.$key);
 
                 Setting::query()->updateOrCreate(['key' => $key], [

--- a/packages/core/src/Models/Setting.php
+++ b/packages/core/src/Models/Setting.php
@@ -24,13 +24,6 @@ class Setting extends Model implements SettingContract
     /** @use HasFactory<SettingFactory> */
     use HasFactory;
 
-    protected $fillable = [
-        'value',
-        'display_name',
-        'locked',
-        'key',
-    ];
-
     protected $guarded = [];
 
     protected $hidden = [
@@ -57,8 +50,8 @@ class Setting extends Model implements SettingContract
             'longitude' => __('shopper::forms.label.longitude'),
             'latitude' => __('shopper::forms.label.latitude'),
             'facebook_link' => __('shopper::words.socials.facebook'),
-            'instagram_link' => __('shopper::words.socials.twitter'),
-            'twitter_link' => __('shopper::words.socials.instagram'),
+            'instagram_link' => __('shopper::words.socials.instagram'),
+            'twitter_link' => __('shopper::words.socials.twitter'),
             default => Str::title($key),
         };
     }

--- a/packages/core/src/Observers/InventoryObserver.php
+++ b/packages/core/src/Observers/InventoryObserver.php
@@ -23,16 +23,13 @@ class InventoryObserver
      */
     private function ensureOnlyOneIsDefault(Inventory $inventory): void
     {
-        if ($inventory->is_default) {
-            /** @var Inventory|null $defaultInventory */
-            $defaultInventory = resolve(Inventory::class)::query()
-                ->where('id', '!=', $inventory->id)
-                ->where('is_default', false)
-                ->first();
-
-            if ($defaultInventory instanceof Inventory) {
-                $defaultInventory->updateQuietly(['is_default' => false]);
-            }
+        if (! $inventory->is_default) {
+            return;
         }
+
+        resolve(Inventory::class)::query()
+            ->where('id', '!=', $inventory->id)
+            ->where('is_default', true)
+            ->update(['is_default' => false]);
     }
 }


### PR DESCRIPTION
## Summary

Post-audit fixes on onboarding (#517) and Laravel 13 upgrade (#518).

## Fixes

- **InventoryObserver**: query was `is_default = false` (no-op). Now `true` + updates all matching rows. Stops multiple default inventories.
- **SetupGuide::complete()**: add `authorize('access_setting')`. `mount()` uses a capability check before auto-completing.
- **SaveSettings**: refuse to overwrite a locked setting with `locked: false`.
- **Setting model**: drop `\$fillable` (kept `\$guarded = []` per convention). Fix swapped translation keys (`instagram_link` <-> `twitter_link`).
- **InitializationWizard**: capture country/currency options once at `mount()` into `#[Locked]` properties. Scope cache keys by locale. Switch to `updateOrCreate` so re-runs propagate updates. Drop redundant `shopper_setting()` fallbacks.