### PR TITLE
fix(core): cache only the resolved value in shopper_setting

### DIFF
--- a/packages/core/src/helpers.php
+++ b/packages/core/src/helpers.php
@@ -43,13 +43,11 @@ if (! function_exists('generate_number')) {
 if (! function_exists('shopper_setting')) {
     function shopper_setting(string $key, bool $withCache = true): mixed
     {
-        $setting = Cache::remember(
+        return Cache::remember(
             "shopper-setting.{$key}",
             $withCache ? 3600 * 24 : 1,
-            fn () => Setting::query()->where('key', $key)->first()
+            fn () => Setting::query()->where('key', $key)->first()?->value,
         );
-
-        return $setting?->value;
     }
 }
 


### PR DESCRIPTION
## Summary

\`shopper_setting()\` cached the entire \`Setting\` Eloquent model. When the cache entry survived a context where the \`Setting\` class could not be autoloaded in time (e.g., dev with path-repository symlinks, container restart, opcache reset, starter kit using the package via composer path repository), the \`unserialize\` step produced a \`__PHP_Incomplete_Class\` and accessing \`->value\` threw:

\`\`\`
ErrorException: shopper_setting(): The script tried to access a property on an incomplete object.
Please ensure that the class definition "Shopper\Core\Models\Setting" of the object you are trying
to operate on was loaded _before_ unserialize() gets called or provide an autoloader to load the
class definition
\`\`\`

## Fix

Cache the resolved \`->value\` (string, array, null per the \`value => array\` cast) directly. The cast runs inside the closure on a cache miss, so the cached payload now contains primitives only and has no class-loading dependency on deserialize.

## Impact

All call sites of \`shopper_setting()\` already use the return as a scalar/array (currency code, locale, etc.). No behavior change for consumers.