### PR TITLE
fix(core): cache only the resolved code in shopper_currency

### DIFF
--- a/packages/core/src/helpers.php
+++ b/packages/core/src/helpers.php
@@ -67,17 +67,17 @@ if (! function_exists('shopper_currency')) {
     {
         $currencyId = shopper_setting('default_currency_id');
 
-        if ($currencyId) {
-            $currency = Cache::remember(
-                'shopper-setting.default_currency',
-                now()->addHour(),
-                fn () => Currency::query()->find($currencyId)
-            );
-
-            return $currency ? $currency->code : 'USD';
+        if (! $currencyId) {
+            return 'USD';
         }
 
-        return 'USD';
+        return Cache::remember(
+            'shopper-setting.default_currency',
+            now()->addHour(),
+            fn (): string => Currency::query()
+                ->where('id', $currencyId)
+                ->value('code') ?? 'USD',
+        );
     }
 }
 


### PR DESCRIPTION
## Summary

\`shopper_currency()\` cached the entire \`Currency\` Eloquent model, producing the same \`__PHP_Incomplete_Class\` exception on deserialize as the \`shopper_setting()\` issue fixed in #520 when the \`Currency\` class was not autoloaded in time.

\`\`\`
ErrorException: shopper_currency(): The script tried to access a property on an incomplete object.
Please ensure that the class definition "Shopper\Core\Models\Currency" of the object you are trying
to operate on was loaded _before_ unserialize() gets called.
\`\`\`

## Fix

Cache the resolved \`code\` string directly via \`value('code')\`. Falls back to \`'USD'\` both when no default currency is configured and when the cached id no longer resolves to a row.