### PR TITLE
fix(discounts): enforce positive discount values across all layers

### DIFF
--- a/packages/admin/src/Livewire/SlideOvers/DiscountForm.php
+++ b/packages/admin/src/Livewire/SlideOvers/DiscountForm.php
@@ -182,6 +182,10 @@ class DiscountForm extends SlideOverComponent implements HasActions, HasSchemas,
                                         return is_no_division_currency($currency) ? (int) $state : (int) round((float) $state * 100);
                                     })
                                     ->numeric()
+                                    ->minValue(fn (Get $get): float => $get('type') === DiscountType::Percentage->value ? 1 : 0.01)
+                                    ->maxValue(
+                                        fn (Get $get): ?int => $get('type') === DiscountType::Percentage->value ? 100 : null
+                                    )
                                     ->required(),
                             ]),
                         Toggle::make('is_active')
@@ -322,6 +326,7 @@ class DiscountForm extends SlideOverComponent implements HasActions, HasSchemas,
                         TextInput::make('min_required_value')
                             ->hiddenLabel()
                             ->numeric()
+                            ->minValue(0)
                             ->suffix(
                                 fn (Get $get): ?string => match ($get('min_required')) {
                                     DiscountRequirement::Price->value => $get('zone_id')

--- a/packages/cart/resources/lang/en/messages.php
+++ b/packages/cart/resources/lang/en/messages.php
@@ -22,6 +22,8 @@ return [
         'not_available_in_zone' => 'Discount is not available in this zone.',
         'min_amount_not_reached' => 'Minimum purchase amount not reached.',
         'min_quantity_not_reached' => 'Minimum quantity not reached.',
+        'invalid_value' => 'Discount value must be greater than zero.',
+        'invalid_percentage' => 'Percentage discount cannot exceed 100%.',
     ],
 
 ];

--- a/packages/cart/resources/lang/es/messages.php
+++ b/packages/cart/resources/lang/es/messages.php
@@ -22,6 +22,8 @@ return [
         'not_available_in_zone' => 'El descuento no está disponible en esta zona.',
         'min_amount_not_reached' => 'No se ha alcanzado el monto mínimo de compra.',
         'min_quantity_not_reached' => 'No se ha alcanzado la cantidad mínima.',
+        'invalid_value' => 'El valor del descuento debe ser mayor que cero.',
+        'invalid_percentage' => 'El descuento porcentual no puede superar el 100 %.',
     ],
 
 ];

--- a/packages/cart/resources/lang/fr/messages.php
+++ b/packages/cart/resources/lang/fr/messages.php
@@ -22,6 +22,8 @@ return [
         'not_available_in_zone' => 'La réduction n\'est pas disponible dans cette zone.',
         'min_amount_not_reached' => 'Le montant minimum d\'achat n\'est pas atteint.',
         'min_quantity_not_reached' => 'La quantité minimum n\'est pas atteinte.',
+        'invalid_value' => 'La valeur de la réduction doit être supérieure à zéro.',
+        'invalid_percentage' => 'Une réduction en pourcentage ne peut pas dépasser 100 %.',
     ],
 
 ];

--- a/packages/cart/src/Discounts/DiscountValidator.php
+++ b/packages/cart/src/Discounts/DiscountValidator.php
@@ -8,6 +8,7 @@ use Shopper\Cart\Pipelines\CartPipelineContext;
 use Shopper\Core\Enum\DiscountCondition;
 use Shopper\Core\Enum\DiscountEligibility;
 use Shopper\Core\Enum\DiscountRequirement;
+use Shopper\Core\Enum\DiscountType;
 use Shopper\Core\Models\Contracts\Order as OrderContract;
 use Shopper\Core\Models\Discount;
 
@@ -17,6 +18,14 @@ final readonly class DiscountValidator
     {
         if (! $discount->is_active) {
             return new DiscountValidationResult(false, __('shopper-cart::messages.discount.not_active'));
+        }
+
+        if ($discount->value <= 0) {
+            return new DiscountValidationResult(false, __('shopper-cart::messages.discount.invalid_value'));
+        }
+
+        if ($discount->type === DiscountType::Percentage && $discount->value > 100) {
+            return new DiscountValidationResult(false, __('shopper-cart::messages.discount.invalid_percentage'));
         }
 
         if ($discount->start_at->isFuture()) {

--- a/packages/core/database/factories/DiscountFactory.php
+++ b/packages/core/database/factories/DiscountFactory.php
@@ -25,11 +25,15 @@ class DiscountFactory extends Factory
      */
     public function definition(): array
     {
+        $type = $this->faker->randomElement(DiscountType::values());
+
         return [
             'code' => $this->faker->unique()->regexify('[A-Z0-9]{8}'),
             'is_active' => $this->faker->boolean(),
-            'type' => $this->faker->randomElement(DiscountType::values()),
-            'value' => $this->faker->numberBetween(10, 1000),
+            'type' => $type,
+            'value' => $type === DiscountType::Percentage->value
+                ? $this->faker->numberBetween(1, 100)
+                : $this->faker->numberBetween(100, 100000),
             'apply_to' => $this->faker->randomElement(DiscountApplyTo::values()),
             'min_required' => $this->faker->randomElement(DiscountRequirement::values()),
             'eligibility' => $this->faker->randomElement(DiscountEligibility::values()),

--- a/packages/core/src/CoreServiceProvider.php
+++ b/packages/core/src/CoreServiceProvider.php
@@ -14,6 +14,7 @@ use Shopper\Core\Models\Address;
 use Shopper\Core\Models\Attribute;
 use Shopper\Core\Models\Category;
 use Shopper\Core\Models\Channel;
+use Shopper\Core\Models\Discount;
 use Shopper\Core\Models\Inventory;
 use Shopper\Core\Models\Order;
 use Shopper\Core\Models\OrderItem;
@@ -23,6 +24,7 @@ use Shopper\Core\Observers\AddressObserver;
 use Shopper\Core\Observers\AttributeObserver;
 use Shopper\Core\Observers\CategoryObserver;
 use Shopper\Core\Observers\ChannelObserver;
+use Shopper\Core\Observers\DiscountObserver;
 use Shopper\Core\Observers\InventoryObserver;
 use Shopper\Core\Observers\OrderItemObserver;
 use Shopper\Core\Observers\OrderObserver;
@@ -89,6 +91,7 @@ final class CoreServiceProvider extends PackageServiceProvider
         ProductVariant::observeUsingConfiguredClass(ProductVariantObserver::class);
 
         Attribute::observe(AttributeObserver::class);
+        Discount::observe(DiscountObserver::class);
         OrderItem::observe(OrderItemObserver::class);
     }
 

--- a/packages/core/src/Exceptions/InvalidDiscountValueException.php
+++ b/packages/core/src/Exceptions/InvalidDiscountValueException.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Core\Exceptions;
+
+use Exception;
+
+final class InvalidDiscountValueException extends Exception
+{
+    public static function notPositive(int $value): self
+    {
+        return new self("Discount value must be greater than zero, [{$value}] given.");
+    }
+
+    public static function percentageOutOfRange(int $value): self
+    {
+        return new self("Percentage discount value cannot exceed 100, [{$value}] given.");
+    }
+}

--- a/packages/core/src/Observers/DiscountObserver.php
+++ b/packages/core/src/Observers/DiscountObserver.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Core\Observers;
+
+use Shopper\Core\Enum\DiscountType;
+use Shopper\Core\Exceptions\InvalidDiscountValueException;
+use Shopper\Core\Models\Discount;
+
+class DiscountObserver
+{
+    public function saving(Discount $discount): void
+    {
+        if ($discount->value <= 0) {
+            throw InvalidDiscountValueException::notPositive($discount->value);
+        }
+
+        if ($discount->type === DiscountType::Percentage && $discount->value > 100) {
+            throw InvalidDiscountValueException::percentageOutOfRange($discount->value);
+        }
+    }
+}

--- a/tests/Admin/Livewire/SlideOvers/DiscountFormTest.php
+++ b/tests/Admin/Livewire/SlideOvers/DiscountFormTest.php
@@ -56,6 +56,42 @@ describe(DiscountForm::class, function (): void {
         Queue::assertCount(2);
     });
 
+    it('should not create a discount with a negative value', function (): void {
+        Livewire::test(DiscountForm::class)
+            ->fillForm([
+                'code' => 'NEGATIVE',
+                'is_active' => true,
+                'type' => DiscountType::FixedAmount,
+                'value' => -99999999,
+                'apply_to' => DiscountApplyTo::Order,
+                'min_required' => DiscountRequirement::None,
+                'eligibility' => DiscountEligibility::Everyone,
+                'start_at' => now(),
+            ])
+            ->call('store')
+            ->assertHasFormErrors(['value']);
+
+        expect(Discount::query()->count())->toBe(0);
+    });
+
+    it('should not create a percentage discount above 100', function (): void {
+        Livewire::test(DiscountForm::class)
+            ->fillForm([
+                'code' => 'OVER100',
+                'is_active' => true,
+                'type' => DiscountType::Percentage,
+                'value' => 150,
+                'apply_to' => DiscountApplyTo::Order,
+                'min_required' => DiscountRequirement::None,
+                'eligibility' => DiscountEligibility::Everyone,
+                'start_at' => now(),
+            ])
+            ->call('store')
+            ->assertHasFormErrors(['value']);
+
+        expect(Discount::query()->count())->toBe(0);
+    });
+
     it('should not create a discount with a date in the past', function (): void {
         Livewire::test(DiscountForm::class)
             ->fillForm([

--- a/tests/Cart/Feature/DiscountValidatorTest.php
+++ b/tests/Cart/Feature/DiscountValidatorTest.php
@@ -76,6 +76,38 @@ describe(DiscountValidator::class, function (): void {
             ->and($result->failureReason)->toBeNull();
     });
 
+    it('rejects a discount with a negative value', function (): void {
+        $discount = Discount::factory()->make(array_merge(validDiscountAttributes(), [
+            'type' => DiscountType::FixedAmount,
+            'value' => -5000,
+        ]));
+
+        $result = $this->validator->validate($discount, $this->context);
+
+        expect($result->valid)->toBeFalse();
+    });
+
+    it('rejects a discount with a zero value', function (): void {
+        $discount = Discount::factory()->make(array_merge(validDiscountAttributes(), [
+            'value' => 0,
+        ]));
+
+        $result = $this->validator->validate($discount, $this->context);
+
+        expect($result->valid)->toBeFalse();
+    });
+
+    it('rejects a percentage discount above 100', function (): void {
+        $discount = Discount::factory()->make(array_merge(validDiscountAttributes(), [
+            'type' => DiscountType::Percentage,
+            'value' => 150,
+        ]));
+
+        $result = $this->validator->validate($discount, $this->context);
+
+        expect($result->valid)->toBeFalse();
+    });
+
     it('rejects an inactive discount', function (): void {
         $discount = Discount::factory()->create(array_merge(validDiscountAttributes(), [
             'is_active' => false,

--- a/tests/Core/Observers/DiscountObserverTest.php
+++ b/tests/Core/Observers/DiscountObserverTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+use Shopper\Core\Enum\DiscountType;
+use Shopper\Core\Exceptions\InvalidDiscountValueException;
+use Shopper\Core\Models\Discount;
+
+uses(Tests\Core\TestCase::class);
+
+describe('DiscountObserver', function (): void {
+    it('persists a valid discount', function (): void {
+        $discount = Discount::factory()->create([
+            'type' => DiscountType::FixedAmount,
+            'value' => 5000,
+        ]);
+
+        expect($discount->exists)->toBeTrue()
+            ->and($discount->value)->toBe(5000);
+    });
+
+    it('blocks creating a discount with a negative value', function (): void {
+        expect(fn () => Discount::factory()->create([
+            'type' => DiscountType::FixedAmount,
+            'value' => -5000,
+        ]))->toThrow(InvalidDiscountValueException::class);
+
+        expect(Discount::query()->count())->toBe(0);
+    });
+
+    it('blocks creating a discount with a zero value', function (): void {
+        expect(fn () => Discount::factory()->create([
+            'type' => DiscountType::Percentage,
+            'value' => 0,
+        ]))->toThrow(InvalidDiscountValueException::class);
+
+        expect(Discount::query()->count())->toBe(0);
+    });
+
+    it('blocks creating a percentage discount above 100', function (): void {
+        expect(fn () => Discount::factory()->create([
+            'type' => DiscountType::Percentage,
+            'value' => 150,
+        ]))->toThrow(InvalidDiscountValueException::class);
+
+        expect(Discount::query()->count())->toBe(0);
+    });
+
+    it('allows a percentage discount of exactly 100', function (): void {
+        $discount = Discount::factory()->create([
+            'type' => DiscountType::Percentage,
+            'value' => 100,
+        ]);
+
+        expect($discount->value)->toBe(100);
+    });
+
+    it('blocks updating a valid discount to a negative value', function (): void {
+        $discount = Discount::factory()->create([
+            'type' => DiscountType::FixedAmount,
+            'value' => 5000,
+        ]);
+
+        expect(fn () => $discount->update(['value' => -1]))
+            ->toThrow(InvalidDiscountValueException::class);
+
+        expect($discount->fresh()->value)->toBe(5000);
+    });
+})->group('core', 'observers', 'discounts');


### PR DESCRIPTION
Zero or negative discount values, and percentages above 100, were accepted by the admin form, persisted to the database, and propagated through the cart calculation pipeline where they inflated order totals. A negative fixed amount discount of -5000 on a 10000 subtotal produced a 15000 total instead of a capped one.

Reported privately in advisory GHSA-5vf4-452p-jjhf (CWE-20, Improper Input Validation).

## What changed

Validation is enforced at three layers so no write path can introduce an invalid value and no calculation can act on one.

**Admin form.** The `value` field now carries `minValue` and `maxValue` constraints. Fixed amounts must be positive, percentages are bound between 1 and 100. The `min_required_value` field gained a `minValue` of 0.

**Domain write boundary.** A new `DiscountObserver` guards every Eloquent write through the `saving` event. It throws `InvalidDiscountValueException` when the value is zero or negative, or when a percentage exceeds 100. This covers the admin action, the API, commands, seeders and any future caller, regardless of how the discount is saved. `Discount` is not a swappable model, so the observer is registered with a plain `Discount::observe()` call alongside `Attribute` and `OrderItem`.

**Calculation net.** `DiscountValidator` rejects malformed records at calculation time. Eloquent observers do not fire on raw inserts or rows that predate this fix, so the validator keeps the cart pipeline safe from data created outside Eloquent.

The discount factory now generates coherent values per type so test fixtures respect the same invariant.

## Coverage

New `DiscountObserverTest` covers blocked creation and updates for negative, zero and over 100 percent values, plus the valid boundary at exactly 100. `DiscountValidatorTest` and `DiscountFormTest` cover the runtime net and the form constraints.