### PR TITLE
fix(3.x): backport security, cache and type fixes

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1382,16 +1382,16 @@
         },
         {
             "name": "filament/actions",
-            "version": "v5.5.2",
+            "version": "v5.6.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/actions.git",
-                "reference": "e03839f74432ddacf24cbbb4e91115d8078fdeea"
+                "reference": "eb0f973dd88864c3ea7be5e999bf420ccbd62e14"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/actions/zipball/e03839f74432ddacf24cbbb4e91115d8078fdeea",
-                "reference": "e03839f74432ddacf24cbbb4e91115d8078fdeea",
+                "url": "https://api.github.com/repos/filamentphp/actions/zipball/eb0f973dd88864c3ea7be5e999bf420ccbd62e14",
+                "reference": "eb0f973dd88864c3ea7be5e999bf420ccbd62e14",
                 "shasum": ""
             },
             "require": {
@@ -1426,20 +1426,20 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2026-04-17T10:22:30+00:00"
+            "time": "2026-05-27T16:17:39+00:00"
         },
         {
             "name": "filament/filament",
-            "version": "v5.5.2",
+            "version": "v5.6.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/panels.git",
-                "reference": "e9d0b85ae915946699c146998cf19c34eb2233a2"
+                "reference": "fdb789aaa29ff418e0609927a683b099df2d5f55"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/panels/zipball/e9d0b85ae915946699c146998cf19c34eb2233a2",
-                "reference": "e9d0b85ae915946699c146998cf19c34eb2233a2",
+                "url": "https://api.github.com/repos/filamentphp/panels/zipball/fdb789aaa29ff418e0609927a683b099df2d5f55",
+                "reference": "fdb789aaa29ff418e0609927a683b099df2d5f55",
                 "shasum": ""
             },
             "require": {
@@ -1454,7 +1454,7 @@
                 "filament/widgets": "self.version",
                 "php": "^8.2",
                 "pragmarx/google2fa": "^8.0|^9.0",
-                "pragmarx/google2fa-qrcode": "^3.0"
+                "pragmarx/google2fa-qrcode": "^3.0|^4.0"
             },
             "type": "library",
             "extra": {
@@ -1483,20 +1483,20 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2026-04-17T09:58:49+00:00"
+            "time": "2026-05-27T16:17:24+00:00"
         },
         {
             "name": "filament/forms",
-            "version": "v5.5.2",
+            "version": "v5.6.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/forms.git",
-                "reference": "d1fc844e750f7b17f371ee4f0196f57ce3aa2841"
+                "reference": "e4dc9e2add4b563822d1014e35c8e16bf812aa8d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/forms/zipball/d1fc844e750f7b17f371ee4f0196f57ce3aa2841",
-                "reference": "d1fc844e750f7b17f371ee4f0196f57ce3aa2841",
+                "url": "https://api.github.com/repos/filamentphp/forms/zipball/e4dc9e2add4b563822d1014e35c8e16bf812aa8d",
+                "reference": "e4dc9e2add4b563822d1014e35c8e16bf812aa8d",
                 "shasum": ""
             },
             "require": {
@@ -1533,20 +1533,20 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2026-04-17T09:58:26+00:00"
+            "time": "2026-05-27T16:11:48+00:00"
         },
         {
             "name": "filament/infolists",
-            "version": "v5.5.2",
+            "version": "v5.6.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/infolists.git",
-                "reference": "151188b87a621b07a167db676d7a1d30b3f2e808"
+                "reference": "37a2484d6c65b5908e6549302001161530a88c2c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/infolists/zipball/151188b87a621b07a167db676d7a1d30b3f2e808",
-                "reference": "151188b87a621b07a167db676d7a1d30b3f2e808",
+                "url": "https://api.github.com/repos/filamentphp/infolists/zipball/37a2484d6c65b5908e6549302001161530a88c2c",
+                "reference": "37a2484d6c65b5908e6549302001161530a88c2c",
                 "shasum": ""
             },
             "require": {
@@ -1578,20 +1578,20 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2026-04-14T11:07:46+00:00"
+            "time": "2026-05-22T07:42:24+00:00"
         },
         {
             "name": "filament/notifications",
-            "version": "v5.5.2",
+            "version": "v5.6.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/notifications.git",
-                "reference": "edd19fa1a74052ee7036b2a72d4d211738eaa627"
+                "reference": "d4d1bef688dd85086229fcad6f1a157d47f6c336"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/notifications/zipball/edd19fa1a74052ee7036b2a72d4d211738eaa627",
-                "reference": "edd19fa1a74052ee7036b2a72d4d211738eaa627",
+                "url": "https://api.github.com/repos/filamentphp/notifications/zipball/d4d1bef688dd85086229fcad6f1a157d47f6c336",
+                "reference": "d4d1bef688dd85086229fcad6f1a157d47f6c336",
                 "shasum": ""
             },
             "require": {
@@ -1625,20 +1625,20 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2026-04-17T10:06:30+00:00"
+            "time": "2026-05-20T17:23:54+00:00"
         },
         {
             "name": "filament/query-builder",
-            "version": "v5.5.2",
+            "version": "v5.6.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/query-builder.git",
-                "reference": "6da87cd76791bb31232e68d01680794204c27c6d"
+                "reference": "fb4b6cdebe6ab2c233cc78d3688a64f022263c56"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/query-builder/zipball/6da87cd76791bb31232e68d01680794204c27c6d",
-                "reference": "6da87cd76791bb31232e68d01680794204c27c6d",
+                "url": "https://api.github.com/repos/filamentphp/query-builder/zipball/fb4b6cdebe6ab2c233cc78d3688a64f022263c56",
+                "reference": "fb4b6cdebe6ab2c233cc78d3688a64f022263c56",
                 "shasum": ""
             },
             "require": {
@@ -1671,20 +1671,20 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2026-04-14T11:13:17+00:00"
+            "time": "2026-05-27T16:17:11+00:00"
         },
         {
             "name": "filament/schemas",
-            "version": "v5.5.2",
+            "version": "v5.6.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/schemas.git",
-                "reference": "7fd7037dae90c4c45725858e5ffee5cd93761d9f"
+                "reference": "1b23f15af79252591fd72f17ad4bc536cc32d47b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/schemas/zipball/7fd7037dae90c4c45725858e5ffee5cd93761d9f",
-                "reference": "7fd7037dae90c4c45725858e5ffee5cd93761d9f",
+                "url": "https://api.github.com/repos/filamentphp/schemas/zipball/1b23f15af79252591fd72f17ad4bc536cc32d47b",
+                "reference": "1b23f15af79252591fd72f17ad4bc536cc32d47b",
                 "shasum": ""
             },
             "require": {
@@ -1716,20 +1716,20 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2026-04-14T11:10:06+00:00"
+            "time": "2026-05-27T16:16:01+00:00"
         },
         {
             "name": "filament/spatie-laravel-media-library-plugin",
-            "version": "v5.5.2",
+            "version": "v5.6.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/spatie-laravel-media-library-plugin.git",
-                "reference": "ea479e55d85bab9cebc94e818fc16c09cf649086"
+                "reference": "085dda340dd99dd350d9f8fd77015cd420d8b2d2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/spatie-laravel-media-library-plugin/zipball/ea479e55d85bab9cebc94e818fc16c09cf649086",
-                "reference": "ea479e55d85bab9cebc94e818fc16c09cf649086",
+                "url": "https://api.github.com/repos/filamentphp/spatie-laravel-media-library-plugin/zipball/085dda340dd99dd350d9f8fd77015cd420d8b2d2",
+                "reference": "085dda340dd99dd350d9f8fd77015cd420d8b2d2",
                 "shasum": ""
             },
             "require": {
@@ -1753,20 +1753,20 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2026-02-25T15:34:28+00:00"
+            "time": "2026-05-22T07:42:50+00:00"
         },
         {
             "name": "filament/support",
-            "version": "v5.5.2",
+            "version": "v5.6.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/support.git",
-                "reference": "4cc3322db5c7cc84257cec60086a68761987549c"
+                "reference": "2d79214157790e89b35a00911a5d7fc5da647b87"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/support/zipball/4cc3322db5c7cc84257cec60086a68761987549c",
-                "reference": "4cc3322db5c7cc84257cec60086a68761987549c",
+                "url": "https://api.github.com/repos/filamentphp/support/zipball/2d79214157790e89b35a00911a5d7fc5da647b87",
+                "reference": "2d79214157790e89b35a00911a5d7fc5da647b87",
                 "shasum": ""
             },
             "require": {
@@ -1811,20 +1811,20 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2026-04-17T10:23:10+00:00"
+            "time": "2026-05-27T16:12:42+00:00"
         },
         {
             "name": "filament/tables",
-            "version": "v5.5.2",
+            "version": "v5.6.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/tables.git",
-                "reference": "44d87a87122e7aa40c9447aa73c133b52025a96c"
+                "reference": "b67ef735bb000cf9e11bf9f71450e9faef2c5052"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/tables/zipball/44d87a87122e7aa40c9447aa73c133b52025a96c",
-                "reference": "44d87a87122e7aa40c9447aa73c133b52025a96c",
+                "url": "https://api.github.com/repos/filamentphp/tables/zipball/b67ef735bb000cf9e11bf9f71450e9faef2c5052",
+                "reference": "b67ef735bb000cf9e11bf9f71450e9faef2c5052",
                 "shasum": ""
             },
             "require": {
@@ -1857,20 +1857,20 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2026-04-14T11:09:54+00:00"
+            "time": "2026-05-27T16:17:31+00:00"
         },
         {
             "name": "filament/widgets",
-            "version": "v5.5.2",
+            "version": "v5.6.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/widgets.git",
-                "reference": "9d015855538378f536156feb9d2af494fb236579"
+                "reference": "fdec7f94e32b1c43199221363382e47b8a6a9816"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/widgets/zipball/9d015855538378f536156feb9d2af494fb236579",
-                "reference": "9d015855538378f536156feb9d2af494fb236579",
+                "url": "https://api.github.com/repos/filamentphp/widgets/zipball/fdec7f94e32b1c43199221363382e47b8a6a9816",
+                "reference": "fdec7f94e32b1c43199221363382e47b8a6a9816",
                 "shasum": ""
             },
             "require": {
@@ -1901,7 +1901,7 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2026-04-03T15:40:06+00:00"
+            "time": "2026-05-27T16:16:29+00:00"
         },
         {
             "name": "fruitcake/php-cors",

--- a/packages/admin/src/Components/Form/TextInputSelect.php
+++ b/packages/admin/src/Components/Form/TextInputSelect.php
@@ -71,12 +71,12 @@ class TextInputSelect extends TextInput
         }
     }
 
-    public function hydrateState(?array &$hydratedDefaultState, bool $andCallHydrationHooks = true): void
+    public function hydrateState(?array &$hydratedDefaultState, bool $shouldCallHydrationHooks = true, bool $shouldApplyStateCasts = true, array &$appliedStateCastPaths = []): void
     {
-        parent::hydrateState($hydratedDefaultState, $andCallHydrationHooks);
+        parent::hydrateState($hydratedDefaultState, $shouldCallHydrationHooks, $shouldApplyStateCasts, $appliedStateCastPaths);
 
         if ($this->hasSelect()) {
-            $this->getSelectComponent()->hydrateState($hydratedDefaultState, $andCallHydrationHooks);
+            $this->getSelectComponent()->hydrateState($hydratedDefaultState, $shouldCallHydrationHooks, $shouldApplyStateCasts, $appliedStateCastPaths);
         }
     }
 

--- a/packages/admin/src/Livewire/Components/Dashboard/RecentOrders.php
+++ b/packages/admin/src/Livewire/Components/Dashboard/RecentOrders.php
@@ -20,16 +20,27 @@ final class RecentOrders extends Component
     #[Computed]
     public function orders(): Collection
     {
-        return Cache::flexible(
-            'dashboard:recent-orders',
+        /** @var array<int, int> $ids */
+        $ids = Cache::flexible(
+            'dashboard.orders:recent-ids',
             [60, 300],
-            fn (): Collection => resolve(Order::class)::query()
+            fn (): array => resolve(Order::class)::query()
                 ->whereNotIn('status', [OrderStatus::Cancelled, OrderStatus::Archived])
-                ->with(['customer', 'items', 'items.product', 'items.product.media'])
                 ->latest()
                 ->take(7)
-                ->get()
+                ->pluck('id')
+                ->all()
         );
+
+        if ($ids === []) {
+            return new Collection;
+        }
+
+        return resolve(Order::class)::query()
+            ->whereIn('id', $ids)
+            ->with(['customer', 'items', 'items.product', 'items.product.media'])
+            ->latest()
+            ->get();
     }
 
     public function render(): View

--- a/packages/admin/src/Livewire/Components/Dashboard/SetupGuide.php
+++ b/packages/admin/src/Livewire/Components/Dashboard/SetupGuide.php
@@ -6,12 +6,15 @@ namespace Shopper\Livewire\Components\Dashboard;
 
 use Illuminate\Contracts\View\View;
 use Livewire\Attributes\Computed;
+use Livewire\Attributes\Locked;
 use Livewire\Component;
 use Shopper\Core\Models\Contracts\Collection as CollectionContract;
 use Shopper\Core\Models\Contracts\Product as ProductContract;
 use Shopper\Core\Models\Contracts\TaxZone as TaxZoneContract;
 use Shopper\Core\Models\PaymentMethod;
 use Shopper\Core\Models\Zone;
+use Shopper\Models\Contracts\ShopperUser;
+use Shopper\Traits\AuthorizesSettingsAccess;
 use Shopper\Traits\SaveSettings;
 
 /**
@@ -22,12 +25,24 @@ use Shopper\Traits\SaveSettings;
  */
 final class SetupGuide extends Component
 {
+    use AuthorizesSettingsAccess;
     use SaveSettings;
+
+    #[Locked]
+    public bool $dismissed = false;
 
     public function mount(): void
     {
-        if ($this->isComplete) {
-            $this->complete();
+        $this->dismissed = (bool) shopper_setting('setup_guide_done');
+
+        if ($this->dismissed) {
+            return;
+        }
+
+        $user = shopper()->auth()->user();
+
+        if ($this->isComplete && $user instanceof ShopperUser && ($user->isAdmin() || $user->can('system.settings'))) {
+            $this->markComplete();
         }
     }
 
@@ -37,6 +52,10 @@ final class SetupGuide extends Component
     #[Computed]
     public function steps(): array
     {
+        if ($this->dismissed) {
+            return [];
+        }
+
         return [
             [
                 'key' => 'product.create',
@@ -96,13 +115,22 @@ final class SetupGuide extends Component
 
     public function complete(): void
     {
-        $this->saveSettings(['setup_guide_done' => true]);
+        $this->authorizeSettingsAccess();
 
-        $this->dispatch('setup-guide-completed');
+        $this->markComplete();
     }
 
     public function render(): View
     {
         return view('shopper::livewire.components.dashboard.setup-guide');
+    }
+
+    private function markComplete(): void
+    {
+        $this->saveSettings(['setup_guide_done' => true]);
+
+        $this->dismissed = true;
+
+        $this->dispatch('setup-guide-completed');
     }
 }

--- a/packages/admin/src/Livewire/Components/Initialization/Steps/StoreAddress.php
+++ b/packages/admin/src/Livewire/Components/Initialization/Steps/StoreAddress.php
@@ -14,6 +14,7 @@ use Filament\Schemas\Schema;
 use Illuminate\Contracts\View\View;
 use Illuminate\Support\Collection;
 use Shopper\Core\Models\Setting;
+use Shopper\Traits\AuthorizesSettingsAccess;
 use Shopper\Traits\SaveSettings;
 use Spatie\LivewireWizard\Components\StepComponent;
 
@@ -22,6 +23,7 @@ use Spatie\LivewireWizard\Components\StepComponent;
  */
 final class StoreAddress extends StepComponent implements HasActions, HasSchemas
 {
+    use AuthorizesSettingsAccess;
     use InteractsWithActions;
     use InteractsWithSchemas;
     use SaveSettings;
@@ -31,6 +33,8 @@ final class StoreAddress extends StepComponent implements HasActions, HasSchemas
 
     public function mount(): void
     {
+        $this->authorizeSettingsAccess();
+
         /** @var Collection<int, Setting> $settings */
         $settings = Setting::query()->whereIn('key', [
             'street_address',
@@ -79,6 +83,8 @@ final class StoreAddress extends StepComponent implements HasActions, HasSchemas
 
     public function save(): void
     {
+        $this->authorizeSettingsAccess();
+
         $this->saveSettings($this->form->getState());
 
         Notification::make()

--- a/packages/admin/src/Livewire/Components/Initialization/Steps/StoreInformation.php
+++ b/packages/admin/src/Livewire/Components/Initialization/Steps/StoreInformation.php
@@ -20,6 +20,7 @@ use Mckenziearts\Icons\Untitledui\Enums\Untitledui;
 use Shopper\Core\Models\Country;
 use Shopper\Core\Models\Currency;
 use Shopper\Core\Models\Setting;
+use Shopper\Traits\AuthorizesSettingsAccess;
 use Shopper\Traits\SaveSettings;
 use Spatie\LivewireWizard\Components\StepComponent;
 
@@ -28,6 +29,7 @@ use Spatie\LivewireWizard\Components\StepComponent;
  */
 final class StoreInformation extends StepComponent implements HasActions, HasSchemas
 {
+    use AuthorizesSettingsAccess;
     use InteractsWithActions;
     use InteractsWithSchemas;
     use SaveSettings;
@@ -37,6 +39,8 @@ final class StoreInformation extends StepComponent implements HasActions, HasSch
 
     public function mount(): void
     {
+        $this->authorizeSettingsAccess();
+
         /** @var Collection<int, Setting> $settings */
         $settings = Setting::query()->whereIn('key', [
             'name',
@@ -117,6 +121,8 @@ final class StoreInformation extends StepComponent implements HasActions, HasSch
 
     public function save(): void
     {
+        $this->authorizeSettingsAccess();
+
         $this->saveSettings($this->form->getState());
 
         $this->nextStep();

--- a/packages/admin/src/Livewire/Components/Initialization/Steps/StoreSocialLink.php
+++ b/packages/admin/src/Livewire/Components/Initialization/Steps/StoreSocialLink.php
@@ -16,6 +16,7 @@ use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\Str;
 use Shopper\Core\Models\Inventory;
+use Shopper\Traits\AuthorizesSettingsAccess;
 use Shopper\Traits\SaveSettings;
 use Spatie\LivewireWizard\Components\StepComponent;
 
@@ -24,6 +25,7 @@ use Spatie\LivewireWizard\Components\StepComponent;
  */
 final class StoreSocialLink extends StepComponent implements HasActions, HasSchemas
 {
+    use AuthorizesSettingsAccess;
     use InteractsWithActions;
     use InteractsWithSchemas;
     use SaveSettings;
@@ -33,6 +35,8 @@ final class StoreSocialLink extends StepComponent implements HasActions, HasSche
 
     public function mount(): void
     {
+        $this->authorizeSettingsAccess();
+
         $this->form->fill();
     }
 
@@ -82,6 +86,8 @@ final class StoreSocialLink extends StepComponent implements HasActions, HasSche
 
     public function save(): void
     {
+        $this->authorizeSettingsAccess();
+
         $this->saveSettings($this->form->getState());
 
         $this->createDefaultInventory();
@@ -96,6 +102,8 @@ final class StoreSocialLink extends StepComponent implements HasActions, HasSche
 
     public function createDefaultInventory(): void
     {
+        $this->authorizeSettingsAccess();
+
         Inventory::query()->create([
             'name' => $name = shopper_setting('name'),
             'code' => Str::slug($name),

--- a/packages/admin/src/Livewire/Pages/Initialization.php
+++ b/packages/admin/src/Livewire/Pages/Initialization.php
@@ -7,10 +7,18 @@ namespace Shopper\Livewire\Pages;
 use Illuminate\Contracts\View\View;
 use Livewire\Attributes\Layout;
 use Livewire\Component;
+use Shopper\Traits\AuthorizesSettingsAccess;
 
 #[Layout('shopper::components.layouts.base')]
 final class Initialization extends Component
 {
+    use AuthorizesSettingsAccess;
+
+    public function mount(): void
+    {
+        $this->authorizeSettingsAccess();
+    }
+
     public function render(): View
     {
         return view('shopper::livewire.pages.initialization')

--- a/packages/admin/src/Livewire/SlideOvers/DiscountForm.php
+++ b/packages/admin/src/Livewire/SlideOvers/DiscountForm.php
@@ -182,6 +182,10 @@ class DiscountForm extends SlideOverComponent implements HasActions, HasSchemas,
                                         return is_no_division_currency($currency) ? (int) $state : (int) round((float) $state * 100);
                                     })
                                     ->numeric()
+                                    ->minValue(fn (Get $get): float => $get('type') === DiscountType::Percentage->value ? 1 : 0.01)
+                                    ->maxValue(
+                                        fn (Get $get): ?int => $get('type') === DiscountType::Percentage->value ? 100 : null
+                                    )
                                     ->required(),
                             ]),
                         Toggle::make('is_active')
@@ -322,6 +326,7 @@ class DiscountForm extends SlideOverComponent implements HasActions, HasSchemas,
                         TextInput::make('min_required_value')
                             ->hiddenLabel()
                             ->numeric()
+                            ->minValue(0)
                             ->suffix(
                                 fn (Get $get): ?string => match ($get('min_required')) {
                                     DiscountRequirement::Price->value => $get('zone_id')

--- a/packages/admin/src/Traits/AuthorizesSettingsAccess.php
+++ b/packages/admin/src/Traits/AuthorizesSettingsAccess.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Traits;
+
+use Shopper\Models\Contracts\ShopperUser;
+
+trait AuthorizesSettingsAccess
+{
+    protected function authorizeSettingsAccess(): void
+    {
+        $user = shopper()->auth()->user();
+
+        abort_unless(
+            $user instanceof ShopperUser && ($user->isAdmin() || $user->can('system.settings')),
+            403,
+        );
+    }
+}

--- a/packages/admin/src/Traits/SaveSettings.php
+++ b/packages/admin/src/Traits/SaveSettings.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Shopper\Traits;
 
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
 use Shopper\Core\Models\Setting;
 
 trait SaveSettings
@@ -12,16 +13,39 @@ trait SaveSettings
     /**
      * @param  array<string, mixed>  $keys
      */
-    public function saveSettings(array $keys): void
+    protected function saveSettings(array $keys, bool $locked = true): void
     {
-        foreach ($keys as $key => $value) {
-            Cache::forget('shopper-setting.'.$key);
+        if ($keys === []) {
+            return;
+        }
 
-            Setting::query()->updateOrCreate(['key' => $key], [
-                'value' => $value,
-                'display_name' => Setting::lockedAttributesDisplayName($key),
-                'locked' => true,
-            ]);
+        DB::transaction(function () use ($keys, $locked): void {
+            $existing = Setting::query()
+                ->whereIn('key', array_keys($keys))
+                ->pluck('locked', 'key');
+
+            foreach ($keys as $key => $value) {
+                if (($existing[$key] ?? false) && ! $locked) {
+                    continue;
+                }
+
+                Setting::query()->updateOrCreate(['key' => $key], [
+                    'value' => $value,
+                    'display_name' => Setting::lockedAttributesDisplayName($key),
+                    'locked' => $locked,
+                ]);
+
+                $this->forgetSettingCache($key);
+            }
+        });
+    }
+
+    private function forgetSettingCache(string $key): void
+    {
+        Cache::forget('shopper-setting.'.$key);
+
+        if ($key === 'default_currency_id') {
+            Cache::forget('shopper-setting.default_currency');
         }
     }
 }

--- a/packages/cart/resources/lang/en/messages.php
+++ b/packages/cart/resources/lang/en/messages.php
@@ -22,6 +22,8 @@ return [
         'not_available_in_zone' => 'Discount is not available in this zone.',
         'min_amount_not_reached' => 'Minimum purchase amount not reached.',
         'min_quantity_not_reached' => 'Minimum quantity not reached.',
+        'invalid_value' => 'Discount value must be greater than zero.',
+        'invalid_percentage' => 'Percentage discount cannot exceed 100%.',
     ],
 
 ];

--- a/packages/cart/resources/lang/es/messages.php
+++ b/packages/cart/resources/lang/es/messages.php
@@ -22,6 +22,8 @@ return [
         'not_available_in_zone' => 'El descuento no está disponible en esta zona.',
         'min_amount_not_reached' => 'No se ha alcanzado el monto mínimo de compra.',
         'min_quantity_not_reached' => 'No se ha alcanzado la cantidad mínima.',
+        'invalid_value' => 'El valor del descuento debe ser mayor que cero.',
+        'invalid_percentage' => 'El descuento porcentual no puede superar el 100 %.',
     ],
 
 ];

--- a/packages/cart/resources/lang/fr/messages.php
+++ b/packages/cart/resources/lang/fr/messages.php
@@ -22,6 +22,8 @@ return [
         'not_available_in_zone' => 'La réduction n\'est pas disponible dans cette zone.',
         'min_amount_not_reached' => 'Le montant minimum d\'achat n\'est pas atteint.',
         'min_quantity_not_reached' => 'La quantité minimum n\'est pas atteinte.',
+        'invalid_value' => 'La valeur de la réduction doit être supérieure à zéro.',
+        'invalid_percentage' => 'Une réduction en pourcentage ne peut pas dépasser 100 %.',
     ],
 
 ];

--- a/packages/cart/src/Actions/CreateOrderFromCartAction.php
+++ b/packages/cart/src/Actions/CreateOrderFromCartAction.php
@@ -9,8 +9,10 @@ use Illuminate\Support\Facades\DB;
 use Shopper\Cart\CartManager;
 use Shopper\Cart\Events\CartCompleted;
 use Shopper\Cart\Exceptions\CartCompletedException;
+use Shopper\Cart\Exceptions\DiscountLimitReachedException;
 use Shopper\Cart\Models\Cart;
 use Shopper\Cart\Models\CartAddress;
+use Shopper\Cart\Pipelines\CartPipelineContext;
 use Shopper\Core\Actions\CreateOrderTaxLinesAction;
 use Shopper\Core\Models\Contracts\ProductVariant;
 use Shopper\Core\Models\Discount;
@@ -36,6 +38,8 @@ final readonly class CreateOrderFromCartAction
             }
 
             $context = $this->cartManager->calculate($cart);
+
+            $this->reserveDiscount($cart, $context);
 
             $shippingAddress = $this->createOrderAddress($cart->shippingAddress(), $cart->customer_id);
             $billingAddress = $this->createOrderAddress($cart->billingAddress(), $cart->customer_id);
@@ -75,22 +79,40 @@ final readonly class CreateOrderFromCartAction
 
             $order->refresh();
 
-            if ($cart->coupon_code) {
-                Discount::query()
-                    ->where('code', $cart->coupon_code)
-                    ->where(function ($query): void {
-                        $query->whereNull('usage_limit')
-                            ->orWhereColumn('total_use', '<', 'usage_limit');
-                    })
-                    ->increment('total_use');
-            }
-
             $cart->update(['completed_at' => now()]);
 
             CartCompleted::dispatch($cart, $order);
 
             return $order;
         });
+    }
+
+    private function reserveDiscount(Cart $cart, CartPipelineContext $context): void
+    {
+        if (! $cart->coupon_code || $context->discountTotal === 0) {
+            return;
+        }
+
+        $discount = Discount::query()
+            ->where('code', $cart->coupon_code)
+            ->lockForUpdate()
+            ->first();
+
+        if ($discount === null) {
+            return;
+        }
+
+        $affected = Discount::query()
+            ->whereKey($discount->id)
+            ->where(function ($query): void {
+                $query->whereNull('usage_limit')
+                    ->orWhereColumn('total_use', '<', 'usage_limit');
+            })
+            ->increment('total_use');
+
+        if ($affected === 0) {
+            throw DiscountLimitReachedException::global($discount->code);
+        }
     }
 
     private function resolveItemName(Model $purchasable): string

--- a/packages/cart/src/Discounts/DiscountValidator.php
+++ b/packages/cart/src/Discounts/DiscountValidator.php
@@ -8,6 +8,7 @@ use Shopper\Cart\Pipelines\CartPipelineContext;
 use Shopper\Core\Enum\DiscountCondition;
 use Shopper\Core\Enum\DiscountEligibility;
 use Shopper\Core\Enum\DiscountRequirement;
+use Shopper\Core\Enum\DiscountType;
 use Shopper\Core\Models\Discount;
 
 final readonly class DiscountValidator
@@ -16,6 +17,14 @@ final readonly class DiscountValidator
     {
         if (! $discount->is_active) {
             return new DiscountValidationResult(false, __('shopper-cart::messages.discount.not_active'));
+        }
+
+        if ($discount->value <= 0) {
+            return new DiscountValidationResult(false, __('shopper-cart::messages.discount.invalid_value'));
+        }
+
+        if ($discount->type === DiscountType::Percentage && $discount->value > 100) {
+            return new DiscountValidationResult(false, __('shopper-cart::messages.discount.invalid_percentage'));
         }
 
         if ($discount->start_at->isFuture()) {

--- a/packages/cart/src/Exceptions/DiscountLimitReachedException.php
+++ b/packages/cart/src/Exceptions/DiscountLimitReachedException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Cart\Exceptions;
+
+use RuntimeException;
+
+final class DiscountLimitReachedException extends RuntimeException
+{
+    public static function global(string $code): self
+    {
+        return new self(
+            "The discount [{$code}] reached its global usage limit between cart validation and order commit. "
+            .'No order was created.'
+        );
+    }
+}

--- a/packages/core/database/factories/DiscountFactory.php
+++ b/packages/core/database/factories/DiscountFactory.php
@@ -25,11 +25,15 @@ class DiscountFactory extends Factory
      */
     public function definition(): array
     {
+        $type = $this->faker->randomElement(DiscountType::values());
+
         return [
             'code' => $this->faker->unique()->regexify('[A-Z0-9]{8}'),
             'is_active' => $this->faker->boolean(),
-            'type' => $this->faker->randomElement(DiscountType::values()),
-            'value' => $this->faker->numberBetween(10, 1000),
+            'type' => $type,
+            'value' => $type === DiscountType::Percentage->value
+                ? $this->faker->numberBetween(1, 100)
+                : $this->faker->numberBetween(100, 100000),
             'apply_to' => $this->faker->randomElement(DiscountApplyTo::values()),
             'min_required' => $this->faker->randomElement(DiscountRequirement::values()),
             'eligibility' => $this->faker->randomElement(DiscountEligibility::values()),

--- a/packages/core/src/CoreServiceProvider.php
+++ b/packages/core/src/CoreServiceProvider.php
@@ -14,6 +14,7 @@ use Shopper\Core\Models\Address;
 use Shopper\Core\Models\Attribute;
 use Shopper\Core\Models\Category;
 use Shopper\Core\Models\Channel;
+use Shopper\Core\Models\Discount;
 use Shopper\Core\Models\Inventory;
 use Shopper\Core\Models\Order;
 use Shopper\Core\Models\OrderItem;
@@ -23,6 +24,7 @@ use Shopper\Core\Observers\AddressObserver;
 use Shopper\Core\Observers\AttributeObserver;
 use Shopper\Core\Observers\CategoryObserver;
 use Shopper\Core\Observers\ChannelObserver;
+use Shopper\Core\Observers\DiscountObserver;
 use Shopper\Core\Observers\InventoryObserver;
 use Shopper\Core\Observers\OrderItemObserver;
 use Shopper\Core\Observers\OrderObserver;
@@ -89,6 +91,7 @@ final class CoreServiceProvider extends PackageServiceProvider
         ProductVariant::observeUsingConfiguredClass(ProductVariantObserver::class);
 
         Attribute::observe(AttributeObserver::class);
+        Discount::observe(DiscountObserver::class);
         OrderItem::observe(OrderItemObserver::class);
     }
 

--- a/packages/core/src/Exceptions/InvalidDiscountValueException.php
+++ b/packages/core/src/Exceptions/InvalidDiscountValueException.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Core\Exceptions;
+
+use Exception;
+
+final class InvalidDiscountValueException extends Exception
+{
+    public static function notPositive(int $value): self
+    {
+        return new self("Discount value must be greater than zero, [{$value}] given.");
+    }
+
+    public static function percentageOutOfRange(int $value): self
+    {
+        return new self("Percentage discount value cannot exceed 100, [{$value}] given.");
+    }
+}

--- a/packages/core/src/Models/Setting.php
+++ b/packages/core/src/Models/Setting.php
@@ -50,8 +50,8 @@ class Setting extends Model implements SettingContract
             'longitude' => __('shopper::forms.label.longitude'),
             'latitude' => __('shopper::forms.label.latitude'),
             'facebook_link' => __('shopper::words.socials.facebook'),
-            'instagram_link' => __('shopper::words.socials.twitter'),
-            'twitter_link' => __('shopper::words.socials.instagram'),
+            'instagram_link' => __('shopper::words.socials.instagram'),
+            'twitter_link' => __('shopper::words.socials.twitter'),
             default => Str::title($key),
         };
     }

--- a/packages/core/src/Observers/DiscountObserver.php
+++ b/packages/core/src/Observers/DiscountObserver.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Core\Observers;
+
+use Shopper\Core\Enum\DiscountType;
+use Shopper\Core\Exceptions\InvalidDiscountValueException;
+use Shopper\Core\Models\Discount;
+
+class DiscountObserver
+{
+    public function saving(Discount $discount): void
+    {
+        if ($discount->value <= 0) {
+            throw InvalidDiscountValueException::notPositive($discount->value);
+        }
+
+        if ($discount->type === DiscountType::Percentage && $discount->value > 100) {
+            throw InvalidDiscountValueException::percentageOutOfRange($discount->value);
+        }
+    }
+}

--- a/packages/core/src/Observers/InventoryObserver.php
+++ b/packages/core/src/Observers/InventoryObserver.php
@@ -23,16 +23,13 @@ class InventoryObserver
      */
     private function ensureOnlyOneIsDefault(Inventory $inventory): void
     {
-        if ($inventory->is_default) {
-            /** @var Inventory|null $defaultInventory */
-            $defaultInventory = resolve(Inventory::class)::query()
-                ->where('id', '!=', $inventory->id)
-                ->where('is_default', false)
-                ->first();
-
-            if ($defaultInventory instanceof Inventory) {
-                $defaultInventory->updateQuietly(['is_default' => false]);
-            }
+        if (! $inventory->is_default) {
+            return;
         }
+
+        resolve(Inventory::class)::query()
+            ->where('id', '!=', $inventory->id)
+            ->where('is_default', true)
+            ->update(['is_default' => false]);
     }
 }

--- a/packages/core/src/helpers.php
+++ b/packages/core/src/helpers.php
@@ -43,13 +43,11 @@ if (! function_exists('generate_number')) {
 if (! function_exists('shopper_setting')) {
     function shopper_setting(string $key, bool $withCache = true): mixed
     {
-        $setting = Cache::remember(
+        return Cache::remember(
             "shopper-setting.{$key}",
             $withCache ? 3600 * 24 : 1,
-            fn () => Setting::query()->where('key', $key)->first()
+            fn () => Setting::query()->where('key', $key)->first()?->value,
         );
-
-        return $setting?->value;
     }
 }
 
@@ -69,17 +67,17 @@ if (! function_exists('shopper_currency')) {
     {
         $currencyId = shopper_setting('default_currency_id');
 
-        if ($currencyId) {
-            $currency = Cache::remember(
-                'shopper-setting.default_currency',
-                now()->addHour(),
-                fn () => Currency::query()->find($currencyId)
-            );
-
-            return $currency ? $currency->code : 'USD';
+        if (! $currencyId) {
+            return 'USD';
         }
 
-        return 'USD';
+        return Cache::remember(
+            'shopper-setting.default_currency',
+            now()->addHour(),
+            fn (): string => Currency::query()
+                ->where('id', $currencyId)
+                ->value('code') ?? 'USD',
+        );
     }
 }
 

--- a/packages/types/src/discount.ts
+++ b/packages/types/src/discount.ts
@@ -40,7 +40,7 @@ export interface Discount extends Entity {
   /** What the discount applies to. */
   apply_to: DiscountApplyTo
   /** The minimum required type. */
-  min_required: string
+  min_required: DiscountRequirement
   /** The minimum required value. */
   min_required_value: string | null
   /** Who is eligible for this discount. */

--- a/packages/types/src/tax.ts
+++ b/packages/types/src/tax.ts
@@ -76,7 +76,7 @@ export interface TaxRateRule extends Entity {
   /** The morph type of the reference (e.g., product type, category). */
   reference_type: string
   /** The morph ID of the reference. */
-  reference_id: string
+  reference_id: string | number
   /** The tax rate ID. */
   tax_rate_id: number
   /** The tax rate. */

--- a/tests/Admin/Livewire/Components/Dashboard/SetupGuideTest.php
+++ b/tests/Admin/Livewire/Components/Dashboard/SetupGuideTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+use Livewire\Livewire;
+use Shopper\Core\Models\Setting;
+use Shopper\Livewire\Components\Dashboard\SetupGuide;
+use Tests\Core\Stubs\User;
+
+uses(Tests\Admin\TestCase::class);
+
+describe(SetupGuide::class, function (): void {
+    it('skips computation when setup_guide_done is already set', function (): void {
+        Setting::query()->create([
+            'key' => 'setup_guide_done',
+            'value' => true,
+            'display_name' => 'Setup guide done',
+            'locked' => true,
+        ]);
+
+        $this->actingAs(User::factory()->create(), config('shopper.auth.guard'));
+
+        Livewire::test(SetupGuide::class)
+            ->assertSet('dismissed', true)
+            ->assertSet('steps', []);
+    });
+
+    it('does not auto-mark complete on mount when user lacks `system.settings`', function (): void {
+        $this->actingAs(User::factory()->create(), config('shopper.auth.guard'));
+
+        Livewire::test(SetupGuide::class);
+
+        expect(Setting::query()->where('key', 'setup_guide_done')->exists())->toBeFalse();
+    });
+
+    it('rejects `complete()` for users without `system.settings`', function (): void {
+        $this->actingAs(User::factory()->create(), config('shopper.auth.guard'));
+
+        Livewire::test(SetupGuide::class)
+            ->call('complete')
+            ->assertStatus(403);
+    });
+
+    it('dispatches `setup-guide-completed` and writes `setup_guide_done`', function (): void {
+        $admin = User::factory()->create();
+        $admin->assignRole(config('shopper.admin.roles.admin'));
+
+        $this->actingAs($admin, config('shopper.auth.guard'));
+
+        Livewire::test(SetupGuide::class)
+            ->call('complete')
+            ->assertDispatched('setup-guide-completed')
+            ->assertSet('dismissed', true);
+
+        expect(shopper_setting('setup_guide_done'))->toBe(true);
+    });
+})->group('dashboard', 'setup-guide');

--- a/tests/Admin/Livewire/Pages/InitializationTest.php
+++ b/tests/Admin/Livewire/Pages/InitializationTest.php
@@ -4,13 +4,23 @@ declare(strict_types=1);
 
 use Livewire\Livewire;
 use Shopper\Livewire\Pages\Initialization;
+use Tests\Core\Stubs\User;
 
 uses(Tests\Admin\TestCase::class);
 
 describe(Initialization::class, function (): void {
     it('can render initialization component', function (): void {
+        $this->asAdmin();
+
         Livewire::test(Initialization::class)
             ->assertOk()
             ->assertViewIs('shopper::livewire.pages.initialization');
+    });
+
+    it('forbids a non-admin from rendering the initialization component', function (): void {
+        $this->actingAs(User::factory()->create());
+
+        Livewire::test(Initialization::class)
+            ->assertForbidden();
     });
 })->group('livewire', 'pages');

--- a/tests/Admin/Livewire/SlideOvers/DiscountFormTest.php
+++ b/tests/Admin/Livewire/SlideOvers/DiscountFormTest.php
@@ -56,6 +56,42 @@ describe(DiscountForm::class, function (): void {
         Queue::assertCount(2);
     });
 
+    it('should not create a discount with a negative value', function (): void {
+        Livewire::test(DiscountForm::class)
+            ->fillForm([
+                'code' => 'NEGATIVE',
+                'is_active' => true,
+                'type' => DiscountType::FixedAmount,
+                'value' => -99999999,
+                'apply_to' => DiscountApplyTo::Order,
+                'min_required' => DiscountRequirement::None,
+                'eligibility' => DiscountEligibility::Everyone,
+                'start_at' => now(),
+            ])
+            ->call('store')
+            ->assertHasFormErrors(['value']);
+
+        expect(Discount::query()->count())->toBe(0);
+    });
+
+    it('should not create a percentage discount above 100', function (): void {
+        Livewire::test(DiscountForm::class)
+            ->fillForm([
+                'code' => 'OVER100',
+                'is_active' => true,
+                'type' => DiscountType::Percentage,
+                'value' => 150,
+                'apply_to' => DiscountApplyTo::Order,
+                'min_required' => DiscountRequirement::None,
+                'eligibility' => DiscountEligibility::Everyone,
+                'start_at' => now(),
+            ])
+            ->call('store')
+            ->assertHasFormErrors(['value']);
+
+        expect(Discount::query()->count())->toBe(0);
+    });
+
     it('should not create a discount with a date in the past', function (): void {
         Livewire::test(DiscountForm::class)
             ->fillForm([

--- a/tests/Admin/StarterKit/ManifestTest.php
+++ b/tests/Admin/StarterKit/ManifestTest.php
@@ -142,14 +142,8 @@ it('parses dependencies in list-of-mappings format', function (): void {
     ]);
 });
 
-it('parses the real livewire starter kit manifest', function (): void {
-    $manifestPath = '/Users/chretiendev/Sites/OSS/shopperlabs/starters/packages/livewire-starter-kit/shopper-kit.yaml';
-
-    if (! file_exists($manifestPath)) {
-        $this->markTestSkipped('Livewire starter kit not available locally.');
-    }
-
-    $manifest = Manifest::fromPath($manifestPath);
+it('parses a starter kit manifest from a file', function (): void {
+    $manifest = Manifest::fromPath(__DIR__.'/fixtures/livewire-starter-kit.yaml');
 
     expect($manifest)
         ->name->toBe('Shopper Livewire Starter Kit')

--- a/tests/Admin/StarterKit/fixtures/livewire-starter-kit.yaml
+++ b/tests/Admin/StarterKit/fixtures/livewire-starter-kit.yaml
@@ -1,0 +1,25 @@
+name: "Shopper Livewire Starter Kit"
+description: "A Livewire and Tailwind storefront starter kit for Shopper."
+version: "1.0.0"
+author: "shopperlabs"
+url: "https://github.com/shopperlabs/livewire-starter-kit"
+shopper: "^3.0"
+php: "^8.3"
+laravel: "^12.0|^13.0"
+
+export_paths:
+  - resources/views
+  - resources/css
+  - routes/storefront.php
+
+dependencies:
+  livewire/livewire: "^3.7"
+  livewire/flux: "^2.0"
+  shopper/stripe: "^3.0"
+
+dev_dependencies:
+  pestphp/pest: "^4.0"
+
+post_install:
+  - php artisan migrate
+  - php artisan storage:link

--- a/tests/Cart/Feature/CreateOrderFromCartTest.php
+++ b/tests/Cart/Feature/CreateOrderFromCartTest.php
@@ -9,6 +9,7 @@ use Shopper\Cart\Events\CartCompleted;
 use Shopper\Cart\Exceptions\CartCompletedException;
 use Shopper\Cart\Models\Cart;
 use Shopper\Core\Enum\AddressType;
+use Shopper\Core\Enum\DiscountApplyTo;
 use Shopper\Core\Enum\DiscountEligibility;
 use Shopper\Core\Enum\DiscountRequirement;
 use Shopper\Core\Enum\DiscountType;
@@ -123,6 +124,7 @@ describe(CreateOrderFromCartAction::class, function (): void {
             'value' => 10,
             'total_use' => 0,
             'usage_limit' => 100,
+            'apply_to' => DiscountApplyTo::Order,
             'eligibility' => DiscountEligibility::Everyone,
             'min_required' => DiscountRequirement::None,
         ]);
@@ -153,6 +155,35 @@ describe(CreateOrderFromCartAction::class, function (): void {
         $this->action->execute($this->cart->refresh());
 
         expect($discount->refresh()->total_use)->toBe(5);
+    });
+
+    it('caps `total_use` at `usage_limit` across multiple checkouts', function (): void {
+        Discount::factory()->create([
+            'code' => 'ONCE',
+            'is_active' => true,
+            'type' => DiscountType::Percentage,
+            'value' => 10,
+            'total_use' => 0,
+            'usage_limit' => 1,
+            'apply_to' => DiscountApplyTo::Order,
+            'eligibility' => DiscountEligibility::Everyone,
+            'min_required' => DiscountRequirement::None,
+        ]);
+
+        $this->cartManager->add($this->cart, $this->product);
+        $this->cartManager->applyCoupon($this->cart, 'ONCE');
+        $this->action->execute($this->cart->refresh());
+
+        $secondCart = Cart::query()->create([
+            'currency_code' => 'USD',
+            'customer_id' => $this->user->id,
+        ]);
+        $this->cartManager->add($secondCart, $this->product);
+        $this->cartManager->applyCoupon($secondCart, 'ONCE');
+        $this->action->execute($secondCart->refresh());
+
+        expect(Discount::query()->where('code', 'ONCE')->value('total_use'))->toBe(1)
+            ->and(Order::query()->count())->toBe(2);
     });
 
     it('throws `CartCompletedException` for already completed cart', function (): void {

--- a/tests/Cart/Feature/DiscountValidatorTest.php
+++ b/tests/Cart/Feature/DiscountValidatorTest.php
@@ -77,6 +77,38 @@ describe(DiscountValidator::class, function (): void {
             ->and($result->failureReason)->toBeNull();
     });
 
+    it('rejects a discount with a negative value', function (): void {
+        $discount = Discount::factory()->make(array_merge(validDiscountAttributes(), [
+            'type' => DiscountType::FixedAmount,
+            'value' => -5000,
+        ]));
+
+        $result = $this->validator->validate($discount, $this->context);
+
+        expect($result->valid)->toBeFalse();
+    });
+
+    it('rejects a discount with a zero value', function (): void {
+        $discount = Discount::factory()->make(array_merge(validDiscountAttributes(), [
+            'value' => 0,
+        ]));
+
+        $result = $this->validator->validate($discount, $this->context);
+
+        expect($result->valid)->toBeFalse();
+    });
+
+    it('rejects a percentage discount above 100', function (): void {
+        $discount = Discount::factory()->make(array_merge(validDiscountAttributes(), [
+            'type' => DiscountType::Percentage,
+            'value' => 150,
+        ]));
+
+        $result = $this->validator->validate($discount, $this->context);
+
+        expect($result->valid)->toBeFalse();
+    });
+
     it('rejects an inactive discount', function (): void {
         $discount = Discount::factory()->create(array_merge(validDiscountAttributes(), [
             'is_active' => false,

--- a/tests/Core/Observers/DiscountObserverTest.php
+++ b/tests/Core/Observers/DiscountObserverTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+use Shopper\Core\Enum\DiscountType;
+use Shopper\Core\Exceptions\InvalidDiscountValueException;
+use Shopper\Core\Models\Discount;
+
+uses(Tests\Core\TestCase::class);
+
+describe('DiscountObserver', function (): void {
+    it('persists a valid discount', function (): void {
+        $discount = Discount::factory()->create([
+            'type' => DiscountType::FixedAmount,
+            'value' => 5000,
+        ]);
+
+        expect($discount->exists)->toBeTrue()
+            ->and($discount->value)->toBe(5000);
+    });
+
+    it('blocks creating a discount with a negative value', function (): void {
+        expect(fn () => Discount::factory()->create([
+            'type' => DiscountType::FixedAmount,
+            'value' => -5000,
+        ]))->toThrow(InvalidDiscountValueException::class);
+
+        expect(Discount::query()->count())->toBe(0);
+    });
+
+    it('blocks creating a discount with a zero value', function (): void {
+        expect(fn () => Discount::factory()->create([
+            'type' => DiscountType::Percentage,
+            'value' => 0,
+        ]))->toThrow(InvalidDiscountValueException::class);
+
+        expect(Discount::query()->count())->toBe(0);
+    });
+
+    it('blocks creating a percentage discount above 100', function (): void {
+        expect(fn () => Discount::factory()->create([
+            'type' => DiscountType::Percentage,
+            'value' => 150,
+        ]))->toThrow(InvalidDiscountValueException::class);
+
+        expect(Discount::query()->count())->toBe(0);
+    });
+
+    it('allows a percentage discount of exactly 100', function (): void {
+        $discount = Discount::factory()->create([
+            'type' => DiscountType::Percentage,
+            'value' => 100,
+        ]);
+
+        expect($discount->value)->toBe(100);
+    });
+
+    it('blocks updating a valid discount to a negative value', function (): void {
+        $discount = Discount::factory()->create([
+            'type' => DiscountType::FixedAmount,
+            'value' => 5000,
+        ]);
+
+        expect(fn () => $discount->update(['value' => -1]))
+            ->toThrow(InvalidDiscountValueException::class);
+
+        expect($discount->fresh()->value)->toBe(5000);
+    });
+})->group('core', 'observers', 'discounts');

--- a/tests/Core/Observers/InventoryObserverTest.php
+++ b/tests/Core/Observers/InventoryObserverTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+use Shopper\Core\Models\Inventory;
+
+uses(Tests\Core\TestCase::class);
+
+describe('InventoryObserver', function (): void {
+    it('demotes other defaults when an inventory is updated to default', function (): void {
+        $existing = Inventory::factory()->create(['is_default' => true]);
+        $other = Inventory::factory()->create(['is_default' => false]);
+
+        $other->update(['is_default' => true]);
+
+        expect($existing->fresh()->is_default)->toBeFalse()
+            ->and($other->fresh()->is_default)->toBeTrue();
+    });
+
+    it('is a no-op when the saved inventory is not default', function (): void {
+        $existing = Inventory::factory()->create(['is_default' => true]);
+        $other = Inventory::factory()->create(['is_default' => false]);
+
+        $other->update(['name' => 'Updated warehouse']);
+
+        expect($existing->fresh()->is_default)->toBeTrue()
+            ->and($other->fresh()->is_default)->toBeFalse();
+    });
+
+    it('demotes multiple stale defaults in a single update', function (): void {
+        $first = Inventory::factory()->create();
+        $second = Inventory::factory()->create();
+
+        $first->forceFill(['is_default' => true])->saveQuietly();
+        $second->forceFill(['is_default' => true])->saveQuietly();
+
+        $promoted = Inventory::factory()->create(['is_default' => false]);
+        $promoted->update(['is_default' => true]);
+
+        expect(Inventory::query()->where('is_default', true)->count())->toBe(1)
+            ->and($promoted->fresh()->is_default)->toBeTrue();
+    });
+})->group('inventory', 'observers');


### PR DESCRIPTION
Aligns 3.x with the hardening shipped on 2.x for the 2.9.0 release. Each change was re-applied to 3.x and adapted to its current code (Filament 5, the system.settings permission scheme, the DiscountDetail based discount tracking), not cherry-picked blindly.

## Discounts

Zero or negative discount values, and percentages above 100, are now rejected at three layers: the admin form constraints, a `DiscountObserver` that guards every Eloquent write, and a calculation time check in `DiscountValidator`. This closes advisory GHSA-5vf4-452p-jjhf on 3.x.

Checkout now reserves the discount before building the order: it locks the discount row, increments `total_use` atomically against the usage limit and throws `DiscountLimitReachedException` when the global limit is already consumed, instead of silently letting an order through with an over used discount. The reservation only runs when the discount is actually applied, so a maxed coupon left in the cart no longer fails the checkout.

## Cache correctness

`shopper_setting()` and `shopper_currency()` cache the resolved scalar instead of the Eloquent model, and `RecentOrders` caches order ids then re-queries. This removes the `__PHP_Incomplete_Class` crash on dashboard refresh in projects where the model classes are not autoloaded at unserialize time.

## Settings and onboarding hardening

`SaveSettings` is now `protected` and transactional with a batched locked check and derived cache invalidation, closing the remotely invocable settings write. The onboarding page, its steps and the setup guide require `system.settings` authorization through a shared `AuthorizesSettingsAccess` trait. The `InventoryObserver` default demotion guard is fixed to demote every stale default instead of being a no-op, and the swapped instagram and twitter setting labels are corrected.

## Types

`min_required` is typed with the `DiscountRequirement` enum and the tax rule `reference_id` accepts a numeric morph id.

## Notes

The per user discount limit is not addressed here: 3.x tracks it on `DiscountDetail` rather than on orders and the counter is never incremented at checkout, which is a separate 3.x design decision rather than a backport.