### PR TITLE
ci(types): fix npm publish by upgrading npm for OIDC trusted publishing

### DIFF
--- a/packages/types/.github/workflows/npm-publish.yml
+++ b/packages/types/.github/workflows/npm-publish.yml
@@ -4,6 +4,11 @@ on:
   push:
     tags:
       - '*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g. 2.9.0)'
+        required: true
 
 jobs:
   publish:
@@ -20,14 +25,17 @@ jobs:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Update npm for OIDC trusted publishing
+        run: npm install -g npm@latest
+
       - name: Install dependencies
         run: npm ci
 
       - name: Build
         run: npm run build
 
-      - name: Set version from tag
-        run: npm version ${{ github.ref_name }} --no-git-tag-version --allow-same-version
+      - name: Set version
+        run: npm version ${{ github.event.inputs.version || github.ref_name }} --no-git-tag-version --allow-same-version
 
       - name: Publish to npm
         run: npm publish --access public --provenance


### PR DESCRIPTION
The `@shopperlabs/shopper-types` package publishes through an npm OIDC trusted publisher, with tokens disallowed on the package. Trusted publishing requires the npm CLI 11.5.1 or later to exchange the GitHub Actions OIDC token for a short lived registry credential. Node 22 ships npm 10.9, which signs the provenance statement but does not perform that exchange, so the publish request reached the registry unauthenticated and failed with a 404. No version has published since the move to trusted publishing, leaving the npm `latest` tag stuck at 2.7.3.

## Fix

- Upgrade npm to the latest release before the publish step so the OIDC token exchange runs. Nothing else changes: the workflow keeps `id-token: write`, `--provenance`, and no token, matching the disallow tokens setting on the package.
- Add a `workflow_dispatch` trigger with a `version` input so a release whose publish failed can be republished without recreating the git tag.

## Recovery for 2.9.0

Once merged, the monorepo split pushes the corrected workflow to the `shopper-types` repository. From there, run the workflow manually with the version set to `2.9.0` to publish the release that failed.