### PR TITLE
fix(auth): resume expired sessions by refreshing the CSRF token

### DIFF
--- a/packages/admin/resources/views/livewire/components/session-expired.blade.php
+++ b/packages/admin/resources/views/livewire/components/session-expired.blade.php
@@ -32,12 +32,28 @@
 
 @script
     <script>
+        const refreshCsrfToken = async () => {
+            const response = await fetch(@js(route('shopper.csrf-token')), {
+                headers: { Accept: 'application/json' },
+                credentials: 'same-origin',
+            })
+
+            if (! response.ok) return
+
+            const { token } = await response.json()
+
+            document.querySelector('meta[name="csrf-token"]')?.setAttribute('content', token)
+        }
+
         Livewire.interceptRequest(({ onError }) => {
             onError(({ response, preventDefault }) => {
-                if (response.status === 419) {
-                    preventDefault()
+                if (response.status !== 419) return
+
+                preventDefault()
+
+                refreshCsrfToken().then(() => {
                     Livewire.dispatch('open-modal', { id: 'session-expired' })
-                }
+                })
             })
         })
     </script>

--- a/packages/admin/routes/web.php
+++ b/packages/admin/routes/web.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
 use Illuminate\Cookie\Middleware\EncryptCookies;
+use Illuminate\Foundation\Http\Middleware\PreventRequestForgery;
 use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Middleware\SubstituteBindings;
@@ -23,6 +25,10 @@ use Shopper\Livewire\Pages\Forbidden;
 use Shopper\Livewire\Pages\Initialization;
 use Shopper\Sidebar\Middleware\ResolveSidebars;
 
+$csrfMiddleware = class_exists(PreventRequestForgery::class)
+    ? PreventRequestForgery::class
+    : VerifyCsrfToken::class;
+
 Route::domain(config('shopper.admin.domain'))
     ->middleware([
         EncryptCookies::class,
@@ -30,7 +36,7 @@ Route::domain(config('shopper.admin.domain'))
         StartSession::class,
         AuthenticateSession::class,
         ShareErrorsFromSession::class,
-        VerifyCsrfToken::class,
+        $csrfMiddleware,
         SubstituteBindings::class,
         DispatchShopper::class,
         SetLocale::class,
@@ -54,6 +60,10 @@ Route::domain(config('shopper.admin.domain'))
 
                 return redirect()->route('shopper.login');
             })->name('shopper.logout');
+
+            Route::get('/csrf-token', fn (): JsonResponse => response()->json([
+                'token' => csrf_token(),
+            ]))->name('shopper.csrf-token');
 
             Route::middleware([
                 Authenticate::class,

--- a/packages/admin/src/Livewire/Components/SessionExpired.php
+++ b/packages/admin/src/Livewire/Components/SessionExpired.php
@@ -64,7 +64,13 @@ final class SessionExpired extends Component implements HasSchemas
 
         $user = shopper()->auth()->user();
 
-        if ($user === null || ! Hash::check($data['password'], $user->getAuthPassword())) {
+        if ($user === null) {
+            $this->redirect(route('shopper.login'), navigate: true);
+
+            return;
+        }
+
+        if (! Hash::check($data['password'], $user->getAuthPassword())) {
             throw ValidationException::withMessages([
                 'data.password' => __('shopper::pages/auth.login.failed'),
             ]);

--- a/tests/Admin/Livewire/Components/SessionExpiredTest.php
+++ b/tests/Admin/Livewire/Components/SessionExpiredTest.php
@@ -40,11 +40,12 @@ describe(SessionExpired::class, function (): void {
             ->assertHasErrors(['data.password']);
     });
 
-    it('rejects when the user is no longer authenticated', function (): void {
+    it('redirects to login when the user is no longer authenticated', function (): void {
         Livewire::test(SessionExpired::class)
             ->set('data.password', 'anything')
             ->call('attempt')
-            ->assertHasErrors(['data.password']);
+            ->assertHasNoErrors()
+            ->assertRedirect(route('shopper.login'));
     });
 
     it('clears the password field after a successful attempt', function (): void {


### PR DESCRIPTION
When a session expired, the "Resume your session" modal re-authenticated through Livewire. But the stale CSRF token made every `livewire/update` request return `419`, including the modal's own submit, so the password attempt never reached the server and the modal looped on 419 errors.

## Changes

- Add a dedicated `shopper.csrf-token` GET route that returns a fresh token. A `GET` request bypasses CSRF verification, so it works even when the page token is stale.
- On a `419`, fetch a fresh token and write it into the `<meta name="csrf-token">` tag **before** reopening the modal. Livewire reads the meta tag on every request, so the next `livewire/update` (the password submit) carries a valid token and reaches the server.
- Redirect to login when the session is gone entirely and no authenticated user can be resolved, instead of showing a misleading "invalid password" error.
- Resolve the CSRF middleware class at runtime: `PreventRequestForgery` on Laravel 13, `VerifyCsrfToken` on Laravel 12. This removes the deprecation warning while keeping both supported versions working, matching how Filament 5.x handles it.

## Notes

Resuming the session in place requires the user to still be resolvable server-side (a "remember me" cookie re-authenticates them on the token refresh). Without it, the session is truly gone and the user is redirected to login.