### PR TITLE
Storefront catalog API and JavaScript SDK

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,7 @@
     "spatie/laravel-medialibrary": "^11.5",
     "spatie/laravel-package-tools": "^1.9",
     "spatie/laravel-permission": "^7.0",
+    "spatie/laravel-query-builder": "^7.3",
     "staudenmeir/laravel-adjacency-list": "^1.0",
     "stevebauman/location": "^7.2",
     "stripe/stripe-php": "^19.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8730c4d6d34e0a152298aa54b3befc58",
+    "content-hash": "f205d55580c336074e0ee423ff66d53b",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -7256,6 +7256,80 @@
                 }
             ],
             "time": "2026-04-07T15:19:42+00:00"
+        },
+        {
+            "name": "spatie/laravel-query-builder",
+            "version": "7.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/laravel-query-builder.git",
+                "reference": "3554c005f778d9da89d44b9895d2cca149110fea"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/laravel-query-builder/zipball/3554c005f778d9da89d44b9895d2cca149110fea",
+                "reference": "3554c005f778d9da89d44b9895d2cca149110fea",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/database": "^12.0|^13.0",
+                "illuminate/http": "^12.0|^13.0",
+                "illuminate/support": "^12.0|^13.0",
+                "php": "^8.3",
+                "spatie/laravel-package-tools": "^1.11"
+            },
+            "require-dev": {
+                "ext-json": "*",
+                "larastan/larastan": "^3.3",
+                "mockery/mockery": "^1.4",
+                "orchestra/testbench": "^10.0|^11.0",
+                "pestphp/pest": "^4.0",
+                "phpunit/phpunit": "^12.0",
+                "spatie/invade": "^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Spatie\\QueryBuilder\\QueryBuilderServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\QueryBuilder\\": "src",
+                    "Spatie\\QueryBuilder\\Database\\Factories\\": "database/factories"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Alex Vanderbist",
+                    "email": "alex@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Easily build Eloquent queries from API requests",
+            "homepage": "https://github.com/spatie/laravel-query-builder",
+            "keywords": [
+                "laravel-query-builder",
+                "spatie"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/laravel-query-builder/issues",
+                "source": "https://github.com/spatie/laravel-query-builder"
+            },
+            "funding": [
+                {
+                    "url": "https://spatie.be/open-source/support-us",
+                    "type": "custom"
+                }
+            ],
+            "time": "2026-05-02T11:22:31+00:00"
         },
         {
             "name": "spatie/shiki-php",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,10 @@
     "": {
       "name": "laravel-shopper",
       "license": "MIT",
+      "workspaces": [
+        "packages/types",
+        "packages/sdk"
+      ],
       "devDependencies": {
         "@alpinejs/focus": "^3.15.4",
         "@awcodes/alpine-floating-ui": "^3.6.4",
@@ -942,6 +946,14 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@shopperlabs/shopper-sdk": {
+      "resolved": "packages/sdk",
+      "link": true
+    },
+    "node_modules/@shopperlabs/shopper-types": {
+      "resolved": "packages/types",
+      "link": true
+    },
     "node_modules/@tailwindcss/cli": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/@tailwindcss/cli/-/cli-4.2.1.tgz",
@@ -1435,9 +1447,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1465,7 +1477,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -1994,7 +2005,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -3160,9 +3170,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -3322,9 +3332,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
-      "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -3345,9 +3355,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -3566,9 +3576,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3624,9 +3634,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -3643,9 +3653,8 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -3728,7 +3737,6 @@
       "integrity": "sha512-yEPsovQfpxYfgWNhCfECjG5AQaO+K3dp6XERmOepyPDVqcJm+bjyCVO3pmU+nAPe0N5dDvekfGezt/EIiRe1TA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -4121,9 +4129,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4455,8 +4463,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.1.tgz",
       "integrity": "sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.3.0",
@@ -4569,6 +4576,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/unbox-primitive": {
@@ -4845,9 +4866,9 @@
       }
     },
     "node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -4863,6 +4884,25 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "packages/sdk": {
+      "name": "@shopperlabs/shopper-sdk",
+      "version": "3.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@shopperlabs/shopper-types": "^3.0.0"
+      },
+      "devDependencies": {
+        "typescript": "^5.2.2"
+      }
+    },
+    "packages/types": {
+      "name": "@shopperlabs/shopper-types",
+      "version": "3.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "typescript": "^5.2.2"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,12 @@
 {
   "name": "laravel-shopper",
   "license": "MIT",
+  "private": true,
   "type": "module",
+  "workspaces": [
+    "packages/types",
+    "packages/sdk"
+  ],
   "scripts": {
     "dev": "npm-run-all --parallel dev:panel dev:sidebar",
     "dev:panel": "npm-run-all --parallel dev:panel:css dev:panel:js",

--- a/packages/api/composer.json
+++ b/packages/api/composer.json
@@ -13,6 +13,8 @@
     "dedoc/scramble": "^0.13",
     "shopper/core": "*",
     "shopper/http": "*",
+    "spatie/laravel-medialibrary": "^11.5",
+    "spatie/laravel-query-builder": "^7.3",
     "timacdonald/json-api": "^1.0@beta"
   },
   "autoload": {

--- a/packages/api/config/api.php
+++ b/packages/api/config/api.php
@@ -16,4 +16,53 @@ return [
         'per_page' => (int) env('SHOPPER_API_PER_PAGE', 15),
         'max_per_page' => 100,
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Resource query allowlists
+    |--------------------------------------------------------------------------
+    |
+    | Filters, sorts, and includes a client is allowed to request per resource
+    | (spatie/laravel-query-builder). Sparse fieldsets (fields[type]) are handled
+    | on the response side by the JSON:API resources. Extend these to expose more
+    | of your own columns and relations.
+    |
+    */
+    'resources' => [
+        'product' => [
+            'filters' => ['name', 'sku'],
+            'sorts' => ['name', 'created_at', 'published_at'],
+            'includes' => ['brand', 'variants', 'categories', 'collections', 'options'],
+            'include_loads' => [
+                'variants' => ['variants.prices.currency'],
+                'options' => ['options.values'],
+            ],
+        ],
+        'category' => [
+            'filters' => ['name'],
+            'sorts' => ['name', 'position'],
+            'includes' => ['parent', 'children', 'products'],
+            'include_loads' => [
+                'products' => ['products.prices.currency'],
+            ],
+        ],
+        'collection' => [
+            'filters' => ['name'],
+            'sorts' => ['name'],
+            'includes' => [],
+        ],
+        'brand' => [
+            'filters' => ['name'],
+            'sorts' => ['name', 'position'],
+            'includes' => ['products'],
+            'include_loads' => [
+                'products' => ['products.prices.currency'],
+            ],
+        ],
+        'attribute' => [
+            'filters' => ['name'],
+            'sorts' => ['name', 'position'],
+            'includes' => [],
+        ],
+    ],
 ];

--- a/packages/api/config/api.php
+++ b/packages/api/config/api.php
@@ -30,16 +30,26 @@ return [
     */
     'resources' => [
         'product' => [
-            'filters' => ['name', 'sku'],
+            'filters' => [
+                'name' => 'partial',
+                'sku' => 'exact',
+                'q' => ['scope', 'search'],
+                'category' => 'scope',
+                'collection' => ['scope', 'collection'],
+                'brand' => ['scope', 'byBrand'],
+                'tag' => ['scope', 'tag'],
+                'option' => ['scope', 'option'],
+            ],
             'sorts' => ['name', 'created_at', 'published_at'],
-            'includes' => ['brand', 'variants', 'categories', 'collections', 'options'],
+            'includes' => ['brand', 'variants', 'categories', 'collections', 'options', 'relatedProducts'],
             'include_loads' => [
-                'variants' => ['variants.prices.currency'],
+                'variants' => ['variants.prices.currency', 'variants.values.attribute'],
                 'options' => ['options.values'],
+                'relatedProducts' => ['relatedProducts.prices.currency'],
             ],
         ],
         'category' => [
-            'filters' => ['name'],
+            'filters' => ['name' => 'partial'],
             'sorts' => ['name', 'position'],
             'includes' => ['parent', 'children', 'products'],
             'include_loads' => [
@@ -47,12 +57,12 @@ return [
             ],
         ],
         'collection' => [
-            'filters' => ['name'],
+            'filters' => ['name' => 'partial'],
             'sorts' => ['name'],
             'includes' => [],
         ],
         'brand' => [
-            'filters' => ['name'],
+            'filters' => ['name' => 'partial'],
             'sorts' => ['name', 'position'],
             'includes' => ['products'],
             'include_loads' => [
@@ -60,7 +70,7 @@ return [
             ],
         ],
         'attribute' => [
-            'filters' => ['name'],
+            'filters' => ['name' => 'partial'],
             'sorts' => ['name', 'position'],
             'includes' => [],
         ],

--- a/packages/api/routes/store.php
+++ b/packages/api/routes/store.php
@@ -2,20 +2,8 @@
 
 declare(strict_types=1);
 
-/*
-|--------------------------------------------------------------------------
-| Shopper Store API routes
-|--------------------------------------------------------------------------
-|
-| Endpoints are added per domain group (catalog, auth, account, checkout,
-| payment, shipping) in their own branches. Register them through the
-| ShopperApi facade so they inherit the store prefix, JSON:API response,
-| zone resolution, and rate limiting from shopper/http:
-|
-|   use Shopper\Http\Facades\ShopperApi;
-|
-|   ShopperApi::store(function (): void {
-|       Route::get('/products', [ProductController::class, 'index']);
-|   });
-|
-*/
+use Shopper\Http\Facades\ShopperApi;
+
+ShopperApi::store(function (): void {
+    require __DIR__.'/store/catalog.php';
+});

--- a/packages/api/routes/store/catalog.php
+++ b/packages/api/routes/store/catalog.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Route;
+use Shopper\Api\Http\Controllers\Catalog\AttributeController;
+use Shopper\Api\Http\Controllers\Catalog\BrandController;
+use Shopper\Api\Http\Controllers\Catalog\CategoryController;
+use Shopper\Api\Http\Controllers\Catalog\CollectionController;
+use Shopper\Api\Http\Controllers\Catalog\ProductController;
+
+Route::get('/products', [ProductController::class, 'index']);
+Route::get('/products/{slug}', [ProductController::class, 'show']);
+Route::get('/categories', [CategoryController::class, 'index']);
+Route::get('/categories/{slug}', [CategoryController::class, 'show']);
+Route::get('/collections', [CollectionController::class, 'index']);
+Route::get('/collections/{slug}', [CollectionController::class, 'show']);
+Route::get('/brands', [BrandController::class, 'index']);
+Route::get('/brands/{slug}', [BrandController::class, 'show']);
+Route::get('/attributes', [AttributeController::class, 'index']);

--- a/packages/api/src/Concerns/BuildsApiQueries.php
+++ b/packages/api/src/Concerns/BuildsApiQueries.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Api\Concerns;
+
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Spatie\QueryBuilder\QueryBuilder;
+use Spatie\QueryBuilder\QueryBuilderRequest;
+
+trait BuildsApiQueries
+{
+    /**
+     * Wrap an Eloquent query with the spatie query builder, applying the
+     * filter / sort / include allowlist configured for the given resource.
+     * Sparse fieldsets are handled on the response side by the resources.
+     *
+     * @template TModel of Model
+     *
+     * @param  Builder<TModel>  $query
+     */
+    protected function apiQuery(string $resource, Builder $query): QueryBuilder
+    {
+        $allowlist = (array) config('shopper.api.resources.'.$resource, []);
+        $request = QueryBuilderRequest::fromRequest(request());
+
+        $builder = QueryBuilder::for($query, $request)
+            ->allowedFilters(...($allowlist['filters'] ?? []))
+            ->allowedSorts(...($allowlist['sorts'] ?? []))
+            ->allowedIncludes(...($allowlist['includes'] ?? []));
+
+        $loads = $this->requestedIncludeLoads($resource);
+
+        if ($loads !== []) {
+            $builder->with($loads);
+        }
+
+        return $builder;
+    }
+
+    /**
+     * Deep eager-load paths for the includes requested on the current request
+     * (e.g. include=variants also needs variants.prices), killing the N+1 that
+     * spatie's allowedIncludes would otherwise leave on those nested attributes.
+     * Usable from both list (apiQuery) and show endpoints.
+     *
+     * @return array<int, string>
+     */
+    protected function requestedIncludeLoads(string $resource): array
+    {
+        /** @var array<string, array<int, string>> $map */
+        $map = (array) config('shopper.api.resources.'.$resource.'.include_loads', []);
+
+        if ($map === []) {
+            return [];
+        }
+
+        $loads = [];
+
+        foreach (QueryBuilderRequest::fromRequest(request())->includes() as $include) {
+            $loads = array_merge($loads, $map[$include] ?? []);
+        }
+
+        return array_values(array_unique($loads));
+    }
+
+    /**
+     * Eager-load the media relation only when the model supports it (the
+     * default models do; a swapped core-only model may not).
+     *
+     * @template TModel of Model
+     *
+     * @param  Builder<TModel>  $query
+     * @return Builder<TModel>
+     */
+    protected function withMediaIfSupported(Builder $query): Builder
+    {
+        if (method_exists($query->getModel(), 'getMedia')) {
+            $query->with('media');
+        }
+
+        return $query;
+    }
+
+    /**
+     * Apply the resource allowlist then paginate with the configured page size.
+     *
+     * @template TModel of Model
+     *
+     * @param  Builder<TModel>  $query
+     */
+    protected function paginated(string $resource, Builder $query): LengthAwarePaginator
+    {
+        $default = (int) config('shopper.api.pagination.per_page', 15);
+        $max = (int) config('shopper.api.pagination.max_per_page', 100);
+
+        $size = min(max((int) request()->input('page.size', $default), 1), $max);
+        $page = max((int) request()->input('page.number', 1), 1);
+
+        return $this->apiQuery($resource, $query)
+            ->paginate(perPage: $size, pageName: 'page[number]', page: $page)
+            ->withQueryString();
+    }
+}

--- a/packages/api/src/Concerns/BuildsApiQueries.php
+++ b/packages/api/src/Concerns/BuildsApiQueries.php
@@ -7,6 +7,7 @@ namespace Shopper\Api\Concerns;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Spatie\QueryBuilder\AllowedFilter;
 use Spatie\QueryBuilder\QueryBuilder;
 use Spatie\QueryBuilder\QueryBuilderRequest;
 
@@ -27,7 +28,7 @@ trait BuildsApiQueries
         $request = QueryBuilderRequest::fromRequest(request());
 
         $builder = QueryBuilder::for($query, $request)
-            ->allowedFilters(...($allowlist['filters'] ?? []))
+            ->allowedFilters(...$this->allowedFilters((array) ($allowlist['filters'] ?? [])))
             ->allowedSorts(...($allowlist['sorts'] ?? []))
             ->allowedIncludes(...($allowlist['includes'] ?? []));
 
@@ -67,9 +68,6 @@ trait BuildsApiQueries
     }
 
     /**
-     * Eager-load the media relation only when the model supports it (the
-     * default models do; a swapped core-only model may not).
-     *
      * @template TModel of Model
      *
      * @param  Builder<TModel>  $query
@@ -102,5 +100,37 @@ trait BuildsApiQueries
         return $this->apiQuery($resource, $query)
             ->paginate(perPage: $size, pageName: 'page[number]', page: $page)
             ->withQueryString();
+    }
+
+    /**
+     * Build spatie AllowedFilter instances from a config descriptor map.
+     * Each entry is `key => type` where type is 'partial' (default), 'exact',
+     * 'scope', or ['scope', 'internalScopeName']. A plain string entry (no key)
+     * is treated as a partial filter for backward compatibility.
+     *
+     * @param  array<int|string, string|array{0: string, 1?: string}>  $filters
+     * @return array<int, AllowedFilter>
+     */
+    private function allowedFilters(array $filters): array
+    {
+        $allowed = [];
+
+        foreach ($filters as $key => $type) {
+            if (is_int($key)) {
+                $allowed[] = AllowedFilter::partial((string) $type);
+
+                continue;
+            }
+
+            [$kind, $internal] = is_array($type) ? [$type[0], $type[1] ?? null] : [$type, null];
+
+            $allowed[] = match ($kind) {
+                'exact' => AllowedFilter::exact($key),
+                'scope' => $internal !== null ? AllowedFilter::scope($key, $internal) : AllowedFilter::scope($key),
+                default => AllowedFilter::partial($key),
+            };
+        }
+
+        return $allowed;
     }
 }

--- a/packages/api/src/Concerns/SerializesMedia.php
+++ b/packages/api/src/Concerns/SerializesMedia.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Api\Concerns;
+
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
+
+trait SerializesMedia
+{
+    /**
+     * Every media in the default (images) collection.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    protected function imagesPayload(): array
+    {
+        return $this->mediaPayload((string) config('shopper.media.storage.collection_name', 'default'));
+    }
+
+    /**
+     * The single thumbnail media, or null.
+     *
+     * @return array<string, mixed>|null
+     */
+    protected function thumbnailPayload(): ?array
+    {
+        return $this->firstMediaPayload((string) config('shopper.media.storage.thumbnail_collection', 'thumbnail'));
+    }
+
+    /**
+     * Every media in the files collection.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    protected function filesPayload(): array
+    {
+        return $this->mediaPayload('files');
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function mediaPayload(string $collection): array
+    {
+        if (! method_exists($this->resource, 'getMedia')) {
+            return [];
+        }
+
+        return $this->resource->getMedia($collection)
+            ->map(fn (Media $media): array => $this->mediaToArray($media))
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function firstMediaPayload(string $collection): ?array
+    {
+        if (! method_exists($this->resource, 'getFirstMedia')) {
+            return null;
+        }
+
+        $media = $this->resource->getFirstMedia($collection);
+
+        return $media instanceof Media ? $this->mediaToArray($media) : null;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function mediaToArray(Media $media): array
+    {
+        return [
+            'id' => $media->uuid,
+            'url' => $media->getFullUrl(),
+            'name' => $media->name,
+            'extension' => $media->extension,
+            'created_at' => $media->created_at?->toIso8601String(),
+            'updated_at' => $media->updated_at?->toIso8601String(),
+        ];
+    }
+}

--- a/packages/api/src/Concerns/SerializesPrices.php
+++ b/packages/api/src/Concerns/SerializesPrices.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Api\Concerns;
+
+use Shopper\Core\Models\Price;
+
+trait SerializesPrices
+{
+    /**
+     * Map the loaded prices relation to a flat multi-currency array. Amounts
+     * stay in cents; the storefront picks the currency it needs.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    protected function pricesPayload(): array
+    {
+        return $this->prices->map(fn (Price $price): array => [
+            'amount' => $price->amount,
+            'compare_amount' => $price->compare_amount,
+            'currency_code' => $price->currency_code,
+        ])->values()->all();
+    }
+}

--- a/packages/api/src/Concerns/SerializesPrices.php
+++ b/packages/api/src/Concerns/SerializesPrices.php
@@ -17,6 +17,7 @@ trait SerializesPrices
     protected function pricesPayload(): array
     {
         return $this->prices->map(fn (Price $price): array => [
+            'public_id' => $price->public_id,
             'amount' => $price->amount,
             'compare_amount' => $price->compare_amount,
             'currency_code' => $price->currency_code,

--- a/packages/api/src/Http/Controllers/Catalog/AttributeController.php
+++ b/packages/api/src/Http/Controllers/Catalog/AttributeController.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Api\Http\Controllers\Catalog;
+
+use Shopper\Api\Concerns\BuildsApiQueries;
+use Shopper\Api\Http\Resources\AttributeResource;
+use Shopper\Core\Models\Attribute;
+use TiMacDonald\JsonApi\JsonApiResourceCollection;
+
+final class AttributeController
+{
+    use BuildsApiQueries;
+
+    public function index(): JsonApiResourceCollection
+    {
+        $query = Attribute::query()->enabled()->with('values');
+
+        return AttributeResource::collection($this->paginated('attribute', $query));
+    }
+}

--- a/packages/api/src/Http/Controllers/Catalog/BrandController.php
+++ b/packages/api/src/Http/Controllers/Catalog/BrandController.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Api\Http\Controllers\Catalog;
+
+use Shopper\Api\Concerns\BuildsApiQueries;
+use Shopper\Api\Http\Resources\BrandResource;
+use Shopper\Core\Models\Contracts\Brand as BrandContract;
+use TiMacDonald\JsonApi\JsonApiResource;
+use TiMacDonald\JsonApi\JsonApiResourceCollection;
+
+final class BrandController
+{
+    use BuildsApiQueries;
+
+    public function index(): JsonApiResourceCollection
+    {
+        $query = $this->withMediaIfSupported(resolve(BrandContract::class)::query()->enabled());
+
+        return BrandResource::collection($this->paginated('brand', $query));
+    }
+
+    public function show(string $slug): JsonApiResource
+    {
+        $brand = $this->withMediaIfSupported(resolve(BrandContract::class)::query()->enabled())
+            ->with($this->requestedIncludeLoads('brand'))
+            ->where('slug', $slug)
+            ->firstOrFail();
+
+        return BrandResource::make($brand);
+    }
+}

--- a/packages/api/src/Http/Controllers/Catalog/BrandController.php
+++ b/packages/api/src/Http/Controllers/Catalog/BrandController.php
@@ -6,7 +6,7 @@ namespace Shopper\Api\Http\Controllers\Catalog;
 
 use Shopper\Api\Concerns\BuildsApiQueries;
 use Shopper\Api\Http\Resources\BrandResource;
-use Shopper\Core\Models\Contracts\Brand as BrandContract;
+use Shopper\Core\Models\Contracts\Brand;
 use TiMacDonald\JsonApi\JsonApiResource;
 use TiMacDonald\JsonApi\JsonApiResourceCollection;
 
@@ -16,14 +16,14 @@ final class BrandController
 
     public function index(): JsonApiResourceCollection
     {
-        $query = $this->withMediaIfSupported(resolve(BrandContract::class)::query()->enabled());
+        $query = $this->withMediaIfSupported(resolve(Brand::class)::query()->enabled());
 
         return BrandResource::collection($this->paginated('brand', $query));
     }
 
     public function show(string $slug): JsonApiResource
     {
-        $brand = $this->withMediaIfSupported(resolve(BrandContract::class)::query()->enabled())
+        $brand = $this->withMediaIfSupported(resolve(Brand::class)::query()->enabled())
             ->with($this->requestedIncludeLoads('brand'))
             ->where('slug', $slug)
             ->firstOrFail();

--- a/packages/api/src/Http/Controllers/Catalog/CategoryController.php
+++ b/packages/api/src/Http/Controllers/Catalog/CategoryController.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Api\Http\Controllers\Catalog;
+
+use Shopper\Api\Concerns\BuildsApiQueries;
+use Shopper\Api\Http\Resources\CategoryResource;
+use Shopper\Core\Models\Contracts\Category;
+use TiMacDonald\JsonApi\JsonApiResource;
+use TiMacDonald\JsonApi\JsonApiResourceCollection;
+
+final class CategoryController
+{
+    use BuildsApiQueries;
+
+    public function index(): JsonApiResourceCollection
+    {
+        $query = $this->withMediaIfSupported(resolve(Category::class)::query()->enabled());
+
+        return CategoryResource::collection($this->paginated('category', $query));
+    }
+
+    public function show(string $slug): JsonApiResource
+    {
+        $category = $this->withMediaIfSupported(resolve(Category::class)::query()->enabled())
+            ->with($this->requestedIncludeLoads('category'))
+            ->where('slug', $slug)
+            ->firstOrFail();
+
+        return CategoryResource::make($category);
+    }
+}

--- a/packages/api/src/Http/Controllers/Catalog/CollectionController.php
+++ b/packages/api/src/Http/Controllers/Catalog/CollectionController.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Api\Http\Controllers\Catalog;
+
+use Shopper\Api\Concerns\BuildsApiQueries;
+use Shopper\Api\Http\Resources\CollectionResource;
+use Shopper\Core\Models\Contracts\Collection;
+use TiMacDonald\JsonApi\JsonApiResource;
+use TiMacDonald\JsonApi\JsonApiResourceCollection;
+
+final class CollectionController
+{
+    use BuildsApiQueries;
+
+    public function index(): JsonApiResourceCollection
+    {
+        $query = $this->withMediaIfSupported(resolve(Collection::class)::query()->published());
+
+        return CollectionResource::collection($this->paginated('collection', $query));
+    }
+
+    public function show(string $slug): JsonApiResource
+    {
+        $collection = $this->withMediaIfSupported(resolve(Collection::class)::query()->published())
+            ->where('slug', $slug)
+            ->firstOrFail();
+
+        return CollectionResource::make($collection);
+    }
+}

--- a/packages/api/src/Http/Controllers/Catalog/ProductController.php
+++ b/packages/api/src/Http/Controllers/Catalog/ProductController.php
@@ -6,7 +6,7 @@ namespace Shopper\Api\Http\Controllers\Catalog;
 
 use Shopper\Api\Concerns\BuildsApiQueries;
 use Shopper\Api\Http\Resources\ProductResource;
-use Shopper\Core\Models\Contracts\Product as ProductContract;
+use Shopper\Core\Models\Contracts\Product;
 use TiMacDonald\JsonApi\JsonApiResource;
 use TiMacDonald\JsonApi\JsonApiResourceCollection;
 
@@ -16,7 +16,7 @@ final class ProductController
 
     public function index(): JsonApiResourceCollection
     {
-        $query = resolve(ProductContract::class)::query()
+        $query = resolve(Product::class)::query()
             ->publish()
             ->with('prices.currency');
 
@@ -26,7 +26,7 @@ final class ProductController
     public function show(string $slug): JsonApiResource
     {
         $product = $this->withMediaIfSupported(
-            resolve(ProductContract::class)::query()->publish()->with('prices.currency')
+            resolve(Product::class)::query()->publish()->with('prices.currency')
         )
             ->with($this->requestedIncludeLoads('product'))
             ->where('slug', $slug)

--- a/packages/api/src/Http/Controllers/Catalog/ProductController.php
+++ b/packages/api/src/Http/Controllers/Catalog/ProductController.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Shopper\Api\Http\Controllers\Catalog;
 
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 use Shopper\Api\Concerns\BuildsApiQueries;
 use Shopper\Api\Http\Resources\ProductResource;
 use Shopper\Core\Models\Contracts\Product;
@@ -16,22 +18,38 @@ final class ProductController
 
     public function index(): JsonApiResourceCollection
     {
-        $query = resolve(Product::class)::query()
-            ->publish()
-            ->with('prices.currency');
+        $query = $this->withMediaIfSupported(
+            $this->withRatingSummary(resolve(Product::class)::query()->publish()->with('prices.currency'))
+        );
 
-        return ProductResource::collection($this->paginated('product', $this->withMediaIfSupported($query)));
+        return ProductResource::collection($this->paginated('product', $query));
     }
 
     public function show(string $slug): JsonApiResource
     {
         $product = $this->withMediaIfSupported(
-            resolve(Product::class)::query()->publish()->with('prices.currency')
+            $this->withRatingSummary(resolve(Product::class)::query()->publish()->with('prices.currency'))
         )
             ->with($this->requestedIncludeLoads('product'))
             ->where('slug', $slug)
             ->firstOrFail();
 
         return ProductResource::make($product);
+    }
+
+    /**
+     * Aggregate the approved-review count and average rating without an N+1,
+     * exposed as `reviews_count` and `average_rating` on each product row.
+     *
+     * @template TModel of Model
+     *
+     * @param  Builder<TModel>  $query
+     * @return Builder<TModel>
+     */
+    private function withRatingSummary(Builder $query): Builder
+    {
+        return $query
+            ->withCount(['ratings as reviews_count' => fn (Builder $query) => $query->where('approved', true)])
+            ->withAvg(['ratings as average_rating' => fn (Builder $query) => $query->where('approved', true)], 'rating');
     }
 }

--- a/packages/api/src/Http/Controllers/Catalog/ProductController.php
+++ b/packages/api/src/Http/Controllers/Catalog/ProductController.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Api\Http\Controllers\Catalog;
+
+use Shopper\Api\Concerns\BuildsApiQueries;
+use Shopper\Api\Http\Resources\ProductResource;
+use Shopper\Core\Models\Contracts\Product as ProductContract;
+use TiMacDonald\JsonApi\JsonApiResource;
+use TiMacDonald\JsonApi\JsonApiResourceCollection;
+
+final class ProductController
+{
+    use BuildsApiQueries;
+
+    public function index(): JsonApiResourceCollection
+    {
+        $query = resolve(ProductContract::class)::query()
+            ->publish()
+            ->with('prices.currency');
+
+        return ProductResource::collection($this->paginated('product', $this->withMediaIfSupported($query)));
+    }
+
+    public function show(string $slug): JsonApiResource
+    {
+        $product = $this->withMediaIfSupported(
+            resolve(ProductContract::class)::query()->publish()->with('prices.currency')
+        )
+            ->with($this->requestedIncludeLoads('product'))
+            ->where('slug', $slug)
+            ->firstOrFail();
+
+        return ProductResource::make($product);
+    }
+}

--- a/packages/api/src/Http/Resources/AttributeResource.php
+++ b/packages/api/src/Http/Resources/AttributeResource.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Api\Http\Resources;
+
+use Illuminate\Http\Request;
+use Shopper\Core\Models\Attribute;
+use Shopper\Core\Models\AttributeValue;
+
+/**
+ * @mixin Attribute
+ */
+final class AttributeResource extends JsonApiResource
+{
+    public function toType(Request $request): string
+    {
+        return 'attributes';
+    }
+
+    public function toAttributes(Request $request): array
+    {
+        return [
+            'name' => $this->name,
+            'slug' => $this->slug,
+            'description' => $this->description,
+            'type' => $this->type->value,
+            'is_filterable' => $this->is_filterable,
+            'is_searchable' => $this->is_searchable,
+            'icon' => $this->icon,
+            'values' => $this->values->map(fn (AttributeValue $value): array => [
+                'key' => $value->key,
+                'value' => $value->value,
+                'position' => $value->position,
+            ])->values()->all(),
+        ];
+    }
+}

--- a/packages/api/src/Http/Resources/AttributeResource.php
+++ b/packages/api/src/Http/Resources/AttributeResource.php
@@ -25,6 +25,7 @@ final class AttributeResource extends JsonApiResource
             'slug' => $this->slug,
             'description' => $this->description,
             'type' => $this->type->value,
+            'is_enabled' => $this->is_enabled,
             'is_filterable' => $this->is_filterable,
             'is_searchable' => $this->is_searchable,
             'icon' => $this->icon,

--- a/packages/api/src/Http/Resources/BrandResource.php
+++ b/packages/api/src/Http/Resources/BrandResource.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Api\Http\Resources;
+
+use Illuminate\Http\Request;
+use Shopper\Api\Concerns\SerializesMedia;
+use Shopper\Core\Models\Brand;
+
+/**
+ * @mixin Brand
+ */
+final class BrandResource extends JsonApiResource
+{
+    use SerializesMedia;
+
+    public function toType(Request $request): string
+    {
+        return 'brands';
+    }
+
+    public function toAttributes(Request $request): array
+    {
+        return [
+            'name' => $this->name,
+            'slug' => $this->slug,
+            'website' => $this->website,
+            'description' => $this->description,
+            'seo_title' => $this->seo_title,
+            'seo_description' => $this->seo_description,
+            'metadata' => $this->metadata,
+            'thumbnail' => $this->thumbnailPayload(),
+            'created_at' => $this->created_at->toIso8601String(),
+            'updated_at' => $this->updated_at->toIso8601String(),
+        ];
+    }
+
+    public function toRelationships(Request $request): array
+    {
+        return [
+            'products' => fn () => ProductResource::collection($this->products),
+        ];
+    }
+}

--- a/packages/api/src/Http/Resources/CategoryResource.php
+++ b/packages/api/src/Http/Resources/CategoryResource.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Api\Http\Resources;
+
+use Illuminate\Http\Request;
+use Shopper\Api\Concerns\SerializesMedia;
+use Shopper\Core\Models\Category;
+
+/**
+ * @mixin Category
+ */
+final class CategoryResource extends JsonApiResource
+{
+    use SerializesMedia;
+
+    public function toType(Request $request): string
+    {
+        return 'categories';
+    }
+
+    public function toAttributes(Request $request): array
+    {
+        return [
+            'name' => $this->name,
+            'slug' => $this->slug,
+            'description' => $this->description,
+            'position' => $this->position,
+            'parent_id' => $this->parent_id,
+            'seo_title' => $this->seo_title,
+            'seo_description' => $this->seo_description,
+            'metadata' => $this->metadata,
+            'thumbnail' => $this->thumbnailPayload(),
+            'created_at' => $this->created_at->toIso8601String(),
+            'updated_at' => $this->updated_at->toIso8601String(),
+        ];
+    }
+
+    public function toRelationships(Request $request): array
+    {
+        return [
+            'parent' => fn () => CategoryResource::make($this->parent),
+            'children' => fn () => CategoryResource::collection($this->children),
+            'products' => fn () => ProductResource::collection($this->products),
+        ];
+    }
+}

--- a/packages/api/src/Http/Resources/CollectionResource.php
+++ b/packages/api/src/Http/Resources/CollectionResource.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Api\Http\Resources;
+
+use Illuminate\Http\Request;
+use Shopper\Api\Concerns\SerializesMedia;
+use Shopper\Models\Collection;
+
+/**
+ * @mixin Collection
+ */
+final class CollectionResource extends JsonApiResource
+{
+    use SerializesMedia;
+
+    public function toType(Request $request): string
+    {
+        return 'collections';
+    }
+
+    public function toAttributes(Request $request): array
+    {
+        return [
+            'name' => $this->name,
+            'slug' => $this->slug,
+            'description' => $this->description,
+            'type' => $this->type->value,
+            'published_at' => $this->published_at->toIso8601String(),
+            'seo_title' => $this->seo_title,
+            'seo_description' => $this->seo_description,
+            'metadata' => $this->metadata,
+            'thumbnail' => $this->thumbnailPayload(),
+            'created_at' => $this->created_at->toIso8601String(),
+            'updated_at' => $this->updated_at->toIso8601String(),
+        ];
+    }
+
+    public function toRelationships(Request $request): array
+    {
+        return [
+            'products' => fn () => ProductResource::collection($this->products),
+        ];
+    }
+}

--- a/packages/api/src/Http/Resources/JsonApiResource.php
+++ b/packages/api/src/Http/Resources/JsonApiResource.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Shopper\Api\Http\Resources;
 
+use Illuminate\Http\Request;
 use TiMacDonald\JsonApi\JsonApiResource as BaseJsonApiResource;
 
 /**
@@ -15,4 +16,15 @@ use TiMacDonald\JsonApi\JsonApiResource as BaseJsonApiResource;
  * `$relationships` properties or by overriding `toAttributes()` /
  * `toRelationships()`.
  */
-abstract class JsonApiResource extends BaseJsonApiResource {}
+abstract class JsonApiResource extends BaseJsonApiResource
+{
+    /**
+     * The external id is the stable, non-sequential public_id (ULID) rather
+     * than the auto-increment primary key. Models without a public_id fall
+     * back to their key so the API never breaks.
+     */
+    public function toId(Request $request): string
+    {
+        return (string) ($this->resource->public_id ?? $this->resource->getKey());
+    }
+}

--- a/packages/api/src/Http/Resources/ProductResource.php
+++ b/packages/api/src/Http/Resources/ProductResource.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Shopper\Api\Http\Resources;
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Collection;
 use Shopper\Api\Concerns\SerializesMedia;
 use Shopper\Api\Concerns\SerializesPrices;
+use Shopper\Core\Models\Attribute;
 use Shopper\Core\Models\Product;
 
 /**
@@ -53,7 +55,32 @@ final class ProductResource extends JsonApiResource
             'variants' => fn () => ProductVariantResource::collection($this->variants),
             'categories' => fn () => CategoryResource::collection($this->categories),
             'collections' => fn () => CollectionResource::collection($this->collections),
-            'options' => fn () => AttributeResource::collection($this->options),
+            'options' => fn () => AttributeResource::collection($this->scopedOptions()),
+            'relatedProducts' => fn () => ProductResource::collection($this->relatedProducts),
         ];
+    }
+
+    /**
+     * The product's option types (Color, Storage, ...), deduplicated, with each
+     * option's values narrowed to the ones this product actually uses (from the
+     * options pivot). A storefront then only renders the relevant swatches and
+     * builds combinations from the selected values, not every global value.
+     *
+     * @return Collection<int, Attribute>
+     */
+    private function scopedOptions(): Collection
+    {
+        $usedValueIds = $this->options
+            ->pluck('pivot.attribute_value_id')
+            ->filter()
+            ->unique();
+
+        return $this->options
+            ->unique('id')
+            ->values()
+            ->each(fn (Attribute $option) => $option->setRelation(
+                'values',
+                $option->values->whereIn('id', $usedValueIds)->values(),
+            ));
     }
 }

--- a/packages/api/src/Http/Resources/ProductResource.php
+++ b/packages/api/src/Http/Resources/ProductResource.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Api\Http\Resources;
+
+use Illuminate\Http\Request;
+use Shopper\Api\Concerns\SerializesMedia;
+use Shopper\Api\Concerns\SerializesPrices;
+use Shopper\Core\Models\Product;
+
+/**
+ * @mixin Product
+ */
+final class ProductResource extends JsonApiResource
+{
+    use SerializesMedia;
+    use SerializesPrices;
+
+    public function toType(Request $request): string
+    {
+        return 'products';
+    }
+
+    public function toAttributes(Request $request): array
+    {
+        return [
+            'name' => $this->name,
+            'slug' => $this->slug,
+            'sku' => $this->sku,
+            'barcode' => $this->barcode,
+            'summary' => $this->summary,
+            'description' => $this->description,
+            'featured' => $this->featured,
+            'type' => $this->type?->value,
+            'published_at' => $this->published_at?->toIso8601String(),
+            'seo_title' => $this->seo_title,
+            'seo_description' => $this->seo_description,
+            'metadata' => $this->metadata,
+            'prices' => $this->pricesPayload(),
+            'images' => $this->imagesPayload(),
+            'thumbnail' => $this->thumbnailPayload(),
+            'files' => $this->filesPayload(),
+            'created_at' => $this->created_at->toIso8601String(),
+            'updated_at' => $this->updated_at->toIso8601String(),
+        ];
+    }
+
+    public function toRelationships(Request $request): array
+    {
+        return [
+            'brand' => fn () => BrandResource::make($this->brand),
+            'variants' => fn () => ProductVariantResource::collection($this->variants),
+            'categories' => fn () => CategoryResource::collection($this->categories),
+            'collections' => fn () => CollectionResource::collection($this->collections),
+            'options' => fn () => AttributeResource::collection($this->options),
+        ];
+    }
+}

--- a/packages/api/src/Http/Resources/ProductResource.php
+++ b/packages/api/src/Http/Resources/ProductResource.php
@@ -43,6 +43,8 @@ final class ProductResource extends JsonApiResource
             'images' => $this->imagesPayload(),
             'thumbnail' => $this->thumbnailPayload(),
             'files' => $this->filesPayload(),
+            'rating' => $this->ratingValue(),
+            'reviews_count' => (int) $this->resource->getAttribute('reviews_count'),
             'created_at' => $this->created_at->toIso8601String(),
             'updated_at' => $this->updated_at->toIso8601String(),
         ];
@@ -58,6 +60,17 @@ final class ProductResource extends JsonApiResource
             'options' => fn () => AttributeResource::collection($this->scopedOptions()),
             'relatedProducts' => fn () => ProductResource::collection($this->relatedProducts),
         ];
+    }
+
+    /**
+     * The average approved rating, rounded to one decimal, or null when the
+     * product has no approved reviews. Read from the withAvg aggregate alias.
+     */
+    private function ratingValue(): ?float
+    {
+        $average = $this->resource->getAttribute('average_rating');
+
+        return $average !== null ? round((float) $average, 1) : null;
     }
 
     /**

--- a/packages/api/src/Http/Resources/ProductVariantResource.php
+++ b/packages/api/src/Http/Resources/ProductVariantResource.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Api\Http\Resources;
+
+use Illuminate\Http\Request;
+use Shopper\Api\Concerns\SerializesMedia;
+use Shopper\Api\Concerns\SerializesPrices;
+use Shopper\Core\Models\ProductVariant;
+
+/**
+ * @mixin ProductVariant
+ */
+final class ProductVariantResource extends JsonApiResource
+{
+    use SerializesMedia;
+    use SerializesPrices;
+
+    public function toType(Request $request): string
+    {
+        return 'variants';
+    }
+
+    public function toAttributes(Request $request): array
+    {
+        return [
+            'name' => $this->name,
+            'sku' => $this->sku,
+            'barcode' => $this->barcode,
+            'ean' => $this->ean,
+            'upc' => $this->upc,
+            'position' => $this->position,
+            'metadata' => $this->metadata,
+            'prices' => $this->pricesPayload(),
+            'images' => $this->imagesPayload(),
+            'thumbnail' => $this->thumbnailPayload(),
+            'created_at' => $this->created_at->toIso8601String(),
+            'updated_at' => $this->updated_at->toIso8601String(),
+        ];
+    }
+
+    public function toRelationships(Request $request): array
+    {
+        return [
+            'product' => fn () => ProductResource::make($this->product),
+        ];
+    }
+}

--- a/packages/api/src/Http/Resources/ProductVariantResource.php
+++ b/packages/api/src/Http/Resources/ProductVariantResource.php
@@ -7,6 +7,7 @@ namespace Shopper\Api\Http\Resources;
 use Illuminate\Http\Request;
 use Shopper\Api\Concerns\SerializesMedia;
 use Shopper\Api\Concerns\SerializesPrices;
+use Shopper\Core\Models\AttributeValue;
 use Shopper\Core\Models\ProductVariant;
 
 /**
@@ -31,13 +32,38 @@ final class ProductVariantResource extends JsonApiResource
             'ean' => $this->ean,
             'upc' => $this->upc,
             'position' => $this->position,
+            'allow_backorder' => $this->allow_backorder,
             'metadata' => $this->metadata,
             'prices' => $this->pricesPayload(),
+            'values' => $this->optionValuesPayload(),
             'images' => $this->imagesPayload(),
             'thumbnail' => $this->thumbnailPayload(),
             'created_at' => $this->created_at->toIso8601String(),
             'updated_at' => $this->updated_at->toIso8601String(),
         ];
+    }
+
+    /**
+     * The option values this variant is built from (e.g. Color=Black, Storage=256),
+     * so a storefront can match a selected option set to a variant and render swatches.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    private function optionValuesPayload(): array
+    {
+        if (! $this->resource->relationLoaded('values')) {
+            return [];
+        }
+
+        return $this->values
+            ->map(fn (AttributeValue $value): array => [
+                'value' => $value->value,
+                'key' => $value->key,
+                'attribute' => $value->attribute->name,
+                'attribute_slug' => $value->attribute->slug,
+            ])
+            ->values()
+            ->all();
     }
 
     public function toRelationships(Request $request): array

--- a/packages/api/src/Http/Resources/ProductVariantResource.php
+++ b/packages/api/src/Http/Resources/ProductVariantResource.php
@@ -43,6 +43,13 @@ final class ProductVariantResource extends JsonApiResource
         ];
     }
 
+    public function toRelationships(Request $request): array
+    {
+        return [
+            'product' => fn () => ProductResource::make($this->product),
+        ];
+    }
+
     /**
      * The option values this variant is built from (e.g. Color=Black, Storage=256),
      * so a storefront can match a selected option set to a variant and render swatches.
@@ -64,12 +71,5 @@ final class ProductVariantResource extends JsonApiResource
             ])
             ->values()
             ->all();
-    }
-
-    public function toRelationships(Request $request): array
-    {
-        return [
-            'product' => fn () => ProductResource::make($this->product),
-        ];
     }
 }

--- a/packages/cart/database/migrations/2026_06_11_000001_add_public_id_to_cart_tables.php
+++ b/packages/cart/database/migrations/2026_06_11_000001_add_public_id_to_cart_tables.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+
+return new class extends Migration
+{
+    /**
+     * @var array<int, string>
+     */
+    private array $tables = [
+        'carts',
+        'cart_lines',
+        'cart_addresses',
+    ];
+
+    public function up(): void
+    {
+        foreach ($this->tables as $name) {
+            $table = shopper_table($name);
+
+            if (! Schema::hasTable($table) || Schema::hasColumn($table, 'public_id')) {
+                continue;
+            }
+
+            Schema::table($table, static function (Blueprint $blueprint): void {
+                $blueprint->ulid('public_id')->nullable()->unique()->after('id');
+            });
+
+            DB::table($table)->whereNull('public_id')->orderBy('id')->lazyById()->each(
+                fn (object $row) => DB::table($table)
+                    ->where('id', $row->id)
+                    ->update(['public_id' => (string) Str::ulid()])
+            );
+        }
+    }
+};

--- a/packages/cart/src/Models/Cart.php
+++ b/packages/cart/src/Models/Cart.php
@@ -12,11 +12,13 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Shopper\Core\Enum\AddressType;
 use Shopper\Core\Models\Channel;
 use Shopper\Core\Models\Contracts\Cart as CartContract;
+use Shopper\Core\Models\Traits\HasPublicId;
 use Shopper\Core\Models\Zone;
 use Shopper\Core\Traits\HasModelContract;
 
 /**
  * @property-read int $id
+ * @property-read ?string $public_id
  * @property-read string $currency_code
  * @property-read ?string $coupon_code
  * @property-read ?CarbonInterface $completed_at
@@ -35,6 +37,7 @@ use Shopper\Core\Traits\HasModelContract;
 class Cart extends Model implements CartContract
 {
     use HasModelContract;
+    use HasPublicId;
 
     protected $guarded = [];
 

--- a/packages/cart/src/Models/CartAddress.php
+++ b/packages/cart/src/Models/CartAddress.php
@@ -10,9 +10,11 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Shopper\Core\Enum\AddressType;
 use Shopper\Core\Models\Country;
+use Shopper\Core\Models\Traits\HasPublicId;
 
 /**
  * @property-read int $id
+ * @property-read ?string $public_id
  * @property-read int $cart_id
  * @property-read AddressType $type
  * @property-read ?int $country_id
@@ -33,6 +35,8 @@ use Shopper\Core\Models\Country;
  */
 class CartAddress extends Model
 {
+    use HasPublicId;
+
     protected $guarded = [];
 
     public function getTable(): string

--- a/packages/cart/src/Models/CartLine.php
+++ b/packages/cart/src/Models/CartLine.php
@@ -11,10 +11,12 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Shopper\Core\Models\Contracts\CartLine as CartLineContract;
+use Shopper\Core\Models\Traits\HasPublicId;
 use Shopper\Core\Traits\HasModelContract;
 
 /**
  * @property-read int $id
+ * @property-read ?string $public_id
  * @property-read int $cart_id
  * @property-read string $purchasable_type
  * @property-read int $purchasable_id
@@ -31,6 +33,7 @@ use Shopper\Core\Traits\HasModelContract;
 class CartLine extends Model implements CartLineContract
 {
     use HasModelContract;
+    use HasPublicId;
 
     protected $guarded = [];
 

--- a/packages/core/database/migrations/2026_06_11_000001_add_public_id_to_domain_tables.php
+++ b/packages/core/database/migrations/2026_06_11_000001_add_public_id_to_domain_tables.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+
+return new class extends Migration
+{
+    /**
+     * @var array<int, string>
+     */
+    private array $tables = [
+        'products',
+        'product_variants',
+        'product_tags',
+        'attributes',
+        'brands',
+        'categories',
+        'carriers',
+        'carrier_options',
+        'channels',
+        'collections',
+        'countries',
+        'currencies',
+        'discounts',
+        'payment_methods',
+        'prices',
+        'inventories',
+        'orders',
+        'order_shipping',
+        'suppliers',
+        'zones',
+    ];
+
+    public function up(): void
+    {
+        foreach ($this->tables as $name) {
+            $table = shopper_table($name);
+
+            if (! Schema::hasTable($table) || Schema::hasColumn($table, 'public_id')) {
+                continue;
+            }
+
+            Schema::table($table, static function (Blueprint $blueprint): void {
+                $blueprint->ulid('public_id')->nullable()->unique()->after('id');
+            });
+
+            DB::table($table)->whereNull('public_id')->orderBy('id')->lazyById()->each(
+                fn (object $row) => DB::table($table)
+                    ->where('id', $row->id)
+                    ->update(['public_id' => (string) Str::ulid()])
+            );
+        }
+    }
+};

--- a/packages/core/src/Models/Attribute.php
+++ b/packages/core/src/Models/Attribute.php
@@ -14,10 +14,12 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Shopper\Core\Database\Factories\AttributeFactory;
 use Shopper\Core\Enum\FieldType;
 use Shopper\Core\Models\Contracts\Attribute as AttributeContract;
+use Shopper\Core\Models\Traits\HasPublicId;
 use Shopper\Core\Models\Traits\HasSlug;
 
 /**
  * @property-read int $id
+ * @property-read ?string $public_id
  * @property-read string $name
  * @property-read string $slug
  * @property-read ?string $description
@@ -36,6 +38,7 @@ class Attribute extends Model implements AttributeContract
     /** @use HasFactory<AttributeFactory> */
     use HasFactory;
 
+    use HasPublicId;
     use HasSlug;
 
     protected $guarded = [];

--- a/packages/core/src/Models/Brand.php
+++ b/packages/core/src/Models/Brand.php
@@ -13,11 +13,13 @@ use Shopper\Core\Contracts\Media\HasMedia as ShopperHasMedia;
 use Shopper\Core\Database\Factories\BrandFactory;
 use Shopper\Core\Models\Contracts\Brand as BrandContract;
 use Shopper\Core\Models\Traits\HasMediaCollections;
+use Shopper\Core\Models\Traits\HasPublicId;
 use Shopper\Core\Models\Traits\HasSlug;
 use Shopper\Core\Traits\HasModelContract;
 
 /**
  * @property-read int $id
+ * @property-read ?string $public_id
  * @property-read string $name
  * @property-read ?string $slug
  * @property-read ?string $website
@@ -38,6 +40,7 @@ class Brand extends Model implements BrandContract, ShopperHasMedia
 
     use HasMediaCollections;
     use HasModelContract;
+    use HasPublicId;
     use HasSlug;
 
     protected $guarded = [];

--- a/packages/core/src/Models/Carrier.php
+++ b/packages/core/src/Models/Carrier.php
@@ -12,11 +12,13 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Shopper\Core\Database\Factories\CarrierFactory;
 use Shopper\Core\Models\Contracts\Carrier as CarrierContract;
+use Shopper\Core\Models\Traits\HasPublicId;
 use Shopper\Core\Models\Traits\HasSlug;
 use Shopper\Core\Models\Traits\HasZones;
 
 /**
  * @property-read int $id
+ * @property-read ?string $public_id
  * @property-read string $name
  * @property-read bool $is_enabled
  * @property-read ?string $slug
@@ -34,6 +36,7 @@ class Carrier extends Model implements CarrierContract
     /** @use HasFactory<CarrierFactory> */
     use HasFactory;
 
+    use HasPublicId;
     use HasSlug;
     use HasZones;
 

--- a/packages/core/src/Models/CarrierOption.php
+++ b/packages/core/src/Models/CarrierOption.php
@@ -11,9 +11,11 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Shopper\Core\Database\Factories\CarrierOptionFactory;
 use Shopper\Core\Models\Contracts\CarrierOption as CarrierOptionContract;
+use Shopper\Core\Models\Traits\HasPublicId;
 
 /**
  * @property-read int $id
+ * @property-read ?string $public_id
  * @property-read string $name
  * @property-read ?string $description
  * @property-read int $price
@@ -30,6 +32,8 @@ class CarrierOption extends Model implements CarrierOptionContract
 {
     /** @use HasFactory<CarrierOptionFactory> */
     use HasFactory;
+
+    use HasPublicId;
 
     protected $guarded = [];
 

--- a/packages/core/src/Models/Category.php
+++ b/packages/core/src/Models/Category.php
@@ -14,6 +14,7 @@ use Shopper\Core\Contracts\Media\HasMedia as ShopperHasMedia;
 use Shopper\Core\Database\Factories\CategoryFactory;
 use Shopper\Core\Models\Contracts\Category as CategoryContract;
 use Shopper\Core\Models\Traits\HasMediaCollections;
+use Shopper\Core\Models\Traits\HasPublicId;
 use Shopper\Core\Models\Traits\HasSlug;
 use Shopper\Core\Traits\HasModelContract;
 use Staudenmeir\LaravelAdjacencyList\Eloquent\HasRecursiveRelationships;
@@ -21,6 +22,7 @@ use Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\HasManyOfDescendants;
 
 /**
  * @property-read int $id
+ * @property-read ?string $public_id
  * @property-read string $name
  * @property-read string $slug
  * @property-read ?string $description
@@ -42,6 +44,7 @@ class Category extends Model implements CategoryContract, ShopperHasMedia
 
     use HasMediaCollections;
     use HasModelContract;
+    use HasPublicId;
     use HasRecursiveRelationships;
     use HasSlug;
 

--- a/packages/core/src/Models/Channel.php
+++ b/packages/core/src/Models/Channel.php
@@ -12,11 +12,13 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Shopper\Core\Database\Factories\ChannelFactory;
 use Shopper\Core\Models\Contracts\Channel as ChannelContract;
+use Shopper\Core\Models\Traits\HasPublicId;
 use Shopper\Core\Models\Traits\HasSlug;
 use Shopper\Core\Traits\HasModelContract;
 
 /**
  * @property-read int $id
+ * @property-read ?string $public_id
  * @property-read string $name
  * @property-read ?string $slug
  * @property-read ?string $description
@@ -35,6 +37,7 @@ class Channel extends Model implements ChannelContract
     use HasFactory;
 
     use HasModelContract;
+    use HasPublicId;
     use HasSlug;
 
     protected $guarded = [];

--- a/packages/core/src/Models/Collection.php
+++ b/packages/core/src/Models/Collection.php
@@ -16,12 +16,14 @@ use Shopper\Core\Database\Factories\CollectionFactory;
 use Shopper\Core\Enum\CollectionType;
 use Shopper\Core\Models\Contracts\Collection as CollectionContract;
 use Shopper\Core\Models\Traits\HasMediaCollections;
+use Shopper\Core\Models\Traits\HasPublicId;
 use Shopper\Core\Models\Traits\HasSlug;
 use Shopper\Core\Queries\CollectionProductsQuery;
 use Shopper\Core\Traits\HasModelContract;
 
 /**
  * @property-read int $id
+ * @property-read ?string $public_id
  * @property-read string $name
  * @property-read string $slug
  * @property-read CollectionType $type
@@ -45,6 +47,7 @@ class Collection extends Model implements CollectionContract, ShopperHasMedia
 
     use HasMediaCollections;
     use HasModelContract;
+    use HasPublicId;
     use HasSlug;
 
     protected $guarded = [];

--- a/packages/core/src/Models/Country.php
+++ b/packages/core/src/Models/Country.php
@@ -9,10 +9,12 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Shopper\Core\Database\Factories\CountryFactory;
 use Shopper\Core\Models\Contracts\Country as CountryContract;
+use Shopper\Core\Models\Traits\HasPublicId;
 use Shopper\Core\Models\Traits\HasZones;
 
 /**
  * @property-read int $id
+ * @property-read ?string $public_id
  * @property-read string $name
  * @property-read string $name_official
  * @property-read string $region
@@ -32,6 +34,7 @@ class Country extends Model implements CountryContract
     /** @use HasFactory<CountryFactory> */
     use HasFactory;
 
+    use HasPublicId;
     use HasZones;
 
     public $timestamps = false;

--- a/packages/core/src/Models/Currency.php
+++ b/packages/core/src/Models/Currency.php
@@ -10,9 +10,11 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Shopper\Core\Database\Factories\CurrencyFactory;
 use Shopper\Core\Models\Contracts\Currency as CurrencyContract;
+use Shopper\Core\Models\Traits\HasPublicId;
 
 /**
  * @property-read int $id
+ * @property-read ?string $public_id
  * @property-read string $name
  * @property-read string $code
  * @property-read string $symbol
@@ -25,6 +27,8 @@ class Currency extends Model implements CurrencyContract
 {
     /** @use HasFactory<CurrencyFactory> */
     use HasFactory;
+
+    use HasPublicId;
 
     public $timestamps = false;
 

--- a/packages/core/src/Models/Discount.php
+++ b/packages/core/src/Models/Discount.php
@@ -19,9 +19,11 @@ use Shopper\Core\Enum\DiscountStatus;
 use Shopper\Core\Enum\DiscountType;
 use Shopper\Core\Exceptions\DiscountZoneFrozenException;
 use Shopper\Core\Models\Contracts\Discount as DiscountContract;
+use Shopper\Core\Models\Traits\HasPublicId;
 
 /**
  * @property-read int $id
+ * @property-read ?string $public_id
  * @property-read string $code
  * @property-read DiscountType $type
  * @property-read int $value
@@ -48,6 +50,8 @@ class Discount extends Model implements DiscountContract
 {
     /** @use HasFactory<DiscountFactory> */
     use HasFactory;
+
+    use HasPublicId;
 
     protected $guarded = [];
 

--- a/packages/core/src/Models/Inventory.php
+++ b/packages/core/src/Models/Inventory.php
@@ -12,10 +12,12 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Shopper\Core\Database\Factories\InventoryFactory;
 use Shopper\Core\Models\Contracts\Inventory as InventoryContract;
+use Shopper\Core\Models\Traits\HasPublicId;
 use Shopper\Core\Traits\HasModelContract;
 
 /**
  * @property-read int $id
+ * @property-read ?string $public_id
  * @property-read int $country_id
  * @property-read string $name
  * @property-read string $code
@@ -42,6 +44,7 @@ class Inventory extends Model implements InventoryContract
     use HasFactory;
 
     use HasModelContract;
+    use HasPublicId;
 
     protected $guarded = [];
 

--- a/packages/core/src/Models/Order.php
+++ b/packages/core/src/Models/Order.php
@@ -19,10 +19,12 @@ use Shopper\Core\Enum\PaymentStatus;
 use Shopper\Core\Enum\ShippingStatus;
 use Shopper\Core\Models\Contracts\Order as OrderContract;
 use Shopper\Core\Models\Contracts\ShopperUser;
+use Shopper\Core\Models\Traits\HasPublicId;
 use Shopper\Core\Traits\HasModelContract;
 
 /**
  * @property-read int $id
+ * @property-read ?string $public_id
  * @property-read string $number
  * @property-read int $price_amount
  * @property-read ?int $tax_amount
@@ -63,6 +65,7 @@ class Order extends Model implements OrderContract
     use HasFactory;
 
     use HasModelContract;
+    use HasPublicId;
     use SoftDeletes;
 
     protected $guarded = [];

--- a/packages/core/src/Models/OrderShipping.php
+++ b/packages/core/src/Models/OrderShipping.php
@@ -13,10 +13,12 @@ use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Shopper\Core\Database\Factories\OrderShippingFactory;
 use Shopper\Core\Enum\ShipmentStatus;
 use Shopper\Core\Models\Contracts\OrderShipping as OrderShippingContract;
+use Shopper\Core\Models\Traits\HasPublicId;
 use Shopper\Core\Traits\HasFulfillmentTransitions;
 
 /**
  * @property-read int $id
+ * @property-read ?string $public_id
  * @property-read ?ShipmentStatus $status
  * @property-read CarbonInterface $created_at
  * @property-read CarbonInterface $updated_at
@@ -40,6 +42,7 @@ class OrderShipping extends Model implements OrderShippingContract
     use HasFactory;
 
     use HasFulfillmentTransitions;
+    use HasPublicId;
 
     protected $guarded = [];
 

--- a/packages/core/src/Models/PaymentMethod.php
+++ b/packages/core/src/Models/PaymentMethod.php
@@ -10,11 +10,13 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Shopper\Core\Database\Factories\PaymentMethodFactory;
 use Shopper\Core\Models\Contracts\PaymentMethod as PaymentMethodContract;
+use Shopper\Core\Models\Traits\HasPublicId;
 use Shopper\Core\Models\Traits\HasSlug;
 use Shopper\Core\Models\Traits\HasZones;
 
 /**
  * @property-read int $id
+ * @property-read ?string $public_id
  * @property-read string $title
  * @property-read string $slug
  * @property-read bool $is_enabled
@@ -31,6 +33,7 @@ class PaymentMethod extends Model implements PaymentMethodContract
     /** @use HasFactory<PaymentMethodFactory> */
     use HasFactory;
 
+    use HasPublicId;
     use HasSlug;
     use HasZones;
 

--- a/packages/core/src/Models/Price.php
+++ b/packages/core/src/Models/Price.php
@@ -13,9 +13,11 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Shopper\Core\Database\Factories\PriceFactory;
 use Shopper\Core\Helpers\Price as PriceHelper;
 use Shopper\Core\Models\Contracts\Price as PriceContract;
+use Shopper\Core\Models\Traits\HasPublicId;
 
 /**
  * @property-read int $id
+ * @property-read ?string $public_id
  * @property-read ?int $amount
  * @property-read ?int $compare_amount
  * @property-read ?int $cost_amount
@@ -31,6 +33,8 @@ class Price extends Model implements PriceContract
 {
     /** @use HasFactory<PriceFactory> */
     use HasFactory;
+
+    use HasPublicId;
 
     protected $guarded = [];
 

--- a/packages/core/src/Models/Product.php
+++ b/packages/core/src/Models/Product.php
@@ -29,6 +29,7 @@ use Shopper\Core\Models\Traits\HasDimensions;
 use Shopper\Core\Models\Traits\HasDiscounts;
 use Shopper\Core\Models\Traits\HasMediaCollections;
 use Shopper\Core\Models\Traits\HasPrices;
+use Shopper\Core\Models\Traits\HasPublicId;
 use Shopper\Core\Models\Traits\HasSlug;
 use Shopper\Core\Models\Traits\HasStock;
 use Shopper\Core\Models\Traits\InteractsWithReviews;
@@ -36,6 +37,7 @@ use Shopper\Core\Traits\HasModelContract;
 
 /**
  * @property-read int $id
+ * @property-read ?string $public_id
  * @property-read string $name
  * @property-read string $slug
  * @property-read ?string $sku
@@ -92,6 +94,7 @@ class Product extends Model implements HasReviews, Priceable, ProductContract, S
     use HasMediaCollections;
     use HasModelContract;
     use HasPrices;
+    use HasPublicId;
     use HasSlug;
     use HasStock;
     use InteractsWithReviews;

--- a/packages/core/src/Models/Product.php
+++ b/packages/core/src/Models/Product.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Shopper\Core\Models;
 
 use Carbon\CarbonInterface;
+use Illuminate\Database\Eloquent\Attributes\Scope;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute as LaravelAttribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -152,29 +153,6 @@ class Product extends Model implements HasReviews, Priceable, ProductContract, S
         return $this->is_visible && $this->published_at && $this->published_at <= now();
     }
 
-    /**
-     * @param  Builder<Product>  $query
-     */
-    public function scopePublish(Builder $query): void
-    {
-        $query->whereDate('published_at', '<=', now())
-            ->where('is_visible', true);
-    }
-
-    /**
-     * @param  Builder<Product>  $query
-     * @param  string|array<string>  $channel
-     * @return Builder<Product>
-     */
-    public function scopeForChannel(Builder $query, string|array $channel): Builder
-    {
-        $channels = Arr::wrap($channel);
-
-        return $query->whereHas('channels', function (Builder $query) use ($channels): void {
-            $query->whereIn('id', $channels);
-        });
-    }
-
     /** @return array<string, MediaCollectionConfig> */
     public function getMediaCollections(): array
     {
@@ -270,6 +248,94 @@ class Product extends Model implements HasReviews, Priceable, ProductContract, S
     protected static function newFactory(): ProductFactory
     {
         return ProductFactory::new();
+    }
+
+    /**
+     * @param  Builder<Product>  $query
+     */
+    #[Scope]
+    protected function collection(Builder $query, string $value): void
+    {
+        $query->whereHas('collections', fn (Builder $query): Builder => $query->where('slug', $value)->orWhere('public_id', $value));
+    }
+
+    /**
+     * @param  Builder<Product>  $query
+     */
+    #[Scope]
+    protected function byBrand(Builder $query, string $value): void
+    {
+        $query->whereHas('brand', fn (Builder $query): Builder => $query->where('slug', $value)->orWhere('public_id', $value));
+    }
+
+    /**
+     * @param  Builder<Product>  $query
+     */
+    #[Scope]
+    protected function tag(Builder $query, string $value): void
+    {
+        $query->whereHas('tags', fn (Builder $query): Builder => $query->where('slug', $value)->orWhere('public_id', $value));
+    }
+
+    /**
+     * Products having a variant carrying the given attribute value (by key or
+     * value), e.g. filter[option]=red. Powers faceted listing filters.
+     *
+     * @param  Builder<Product>  $query
+     */
+    #[Scope]
+    protected function option(Builder $query, string $value): void
+    {
+        $query->whereHas('variants.values', fn (Builder $query): Builder => $query->where('key', $value)->orWhere('value', $value));
+    }
+
+    /**
+     * @param  Builder<Product>  $query
+     */
+    #[Scope]
+    protected function category(Builder $query, string $value): void
+    {
+        $query->whereHas('categories', fn (Builder $query): Builder => $query->where('slug', $value)->orWhere('public_id', $value));
+    }
+
+    /**
+     * @param  Builder<Product>  $query
+     */
+    #[Scope]
+    protected function publish(Builder $query): void
+    {
+        $query->whereDate('published_at', '<=', now())
+            ->where('is_visible', true);
+    }
+
+    /**
+     * @param  Builder<Product>  $query
+     * @param  string|array<string>  $channel
+     * @return Builder<Product>
+     */
+    #[Scope]
+    protected function channel(Builder $query, string|array $channel): Builder
+    {
+        $channels = Arr::wrap($channel);
+
+        return $query->whereHas('channels', function (Builder $query) use ($channels): void {
+            $query->whereIn('id', $channels);
+        });
+    }
+
+    /**
+     * @param  Builder<Product>  $query
+     */
+    #[Scope]
+    protected function search(Builder $query, string $term): void
+    {
+        $term = '%'.mb_strtolower($term).'%';
+
+        $query->where(function (Builder $query) use ($term): void {
+            $query->whereRaw('LOWER(name) LIKE ?', [$term])
+                ->orWhereRaw('LOWER(description) LIKE ?', [$term])
+                ->orWhereRaw('LOWER(sku) LIKE ?', [$term]);
+        });
     }
 
     protected function variantsStock(): LaravelAttribute

--- a/packages/core/src/Models/ProductTag.php
+++ b/packages/core/src/Models/ProductTag.php
@@ -9,10 +9,12 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Shopper\Core\Database\Factories\ProductTagFactory;
+use Shopper\Core\Models\Traits\HasPublicId;
 use Shopper\Core\Models\Traits\HasSlug;
 
 /**
  * @property-read int $id
+ * @property-read ?string $public_id
  * @property-read string $name
  * @property-read ?string $slug
  * @property-read CarbonInterface $created_at
@@ -24,6 +26,7 @@ class ProductTag extends Model
     /** @use HasFactory<ProductTagFactory> */
     use HasFactory;
 
+    use HasPublicId;
     use HasSlug;
 
     protected $guarded = [];

--- a/packages/core/src/Models/ProductVariant.php
+++ b/packages/core/src/Models/ProductVariant.php
@@ -20,11 +20,13 @@ use Shopper\Core\Models\Contracts\ProductVariant as ProductVariantContract;
 use Shopper\Core\Models\Traits\HasDimensions;
 use Shopper\Core\Models\Traits\HasMediaCollections;
 use Shopper\Core\Models\Traits\HasPrices;
+use Shopper\Core\Models\Traits\HasPublicId;
 use Shopper\Core\Models\Traits\HasStock;
 use Shopper\Core\Traits\HasModelContract;
 
 /**
  * @property-read int $id
+ * @property-read ?string $public_id
  * @property-read string $name
  * @property-read ?string $sku
  * @property-read ?string $barcode
@@ -62,6 +64,7 @@ class ProductVariant extends Model implements Priceable, ProductVariantContract,
     use HasMediaCollections;
     use HasModelContract;
     use HasPrices;
+    use HasPublicId;
     use HasStock;
 
     protected $guarded = [];

--- a/packages/core/src/Models/Supplier.php
+++ b/packages/core/src/Models/Supplier.php
@@ -11,11 +11,13 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Shopper\Core\Database\Factories\SupplierFactory;
 use Shopper\Core\Models\Contracts\Supplier as SupplierContract;
+use Shopper\Core\Models\Traits\HasPublicId;
 use Shopper\Core\Models\Traits\HasSlug;
 use Shopper\Core\Traits\HasModelContract;
 
 /**
  * @property-read int $id
+ * @property-read ?string $public_id
  * @property-read string $name
  * @property-read ?string $slug
  * @property-read ?string $email
@@ -36,6 +38,7 @@ class Supplier extends Model implements SupplierContract
     use HasFactory;
 
     use HasModelContract;
+    use HasPublicId;
     use HasSlug;
 
     protected $guarded = [];

--- a/packages/core/src/Models/Traits/HasPublicId.php
+++ b/packages/core/src/Models/Traits/HasPublicId.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Core\Models\Traits;
+
+use Illuminate\Database\Eloquent\Attributes\Scope;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
+
+trait HasPublicId
+{
+    public static function bootHasPublicId(): void
+    {
+        static::creating(function (self $model): void {
+            if (blank($model->getAttribute('public_id'))) {
+                $model->setAttribute('public_id', (string) Str::ulid());
+            }
+        });
+
+        // A replicated model must get its own identifier, never the source's.
+        static::replicating(function (self $model): void {
+            $model->setAttribute('public_id', null);
+        });
+    }
+
+    /**
+     * @param  array<string>  $columns
+     */
+    public static function findByPublicId(string $publicId, array $columns = ['*']): ?static
+    {
+        return static::query()->select($columns)
+            ->where('public_id', $publicId)
+            ->first();
+    }
+
+    /**
+     * @template TModel of Model
+     *
+     * @param  Builder<TModel>  $query
+     * @return Builder<TModel>
+     */
+    #[Scope]
+    protected function wherePublicId(Builder $query, string $publicId): Builder
+    {
+        return $query->where('public_id', $publicId);
+    }
+}

--- a/packages/core/src/Models/Zone.php
+++ b/packages/core/src/Models/Zone.php
@@ -15,10 +15,12 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Shopper\Core\Database\Factories\ZoneFactory;
 use Shopper\Core\Models\Contracts\Zone as ZoneContract;
+use Shopper\Core\Models\Traits\HasPublicId;
 use Shopper\Core\Models\Traits\HasSlug;
 
 /**
  * @property-read int $id
+ * @property-read ?string $public_id
  * @property-read string $name
  * @property-read string $slug
  * @property-read ?string $code
@@ -43,6 +45,7 @@ class Zone extends Model implements ZoneContract
     /** @use HasFactory<ZoneFactory> */
     use HasFactory;
 
+    use HasPublicId;
     use HasSlug;
 
     protected $guarded = [];

--- a/packages/core/src/Traits/HasModelContract.php
+++ b/packages/core/src/Traits/HasModelContract.php
@@ -24,6 +24,16 @@ trait HasModelContract
      */
     public static function __callStatic($method, $parameters)
     {
+        // Mirror Laravel 12's native Model::__callStatic: a #[Scope] method is a
+        // real (protected) method, so it must run through the query builder to
+        // receive the Builder. Without this, the override below would call it
+        // directly on the instance with no argument.
+        if (static::isScopeMethodWithAttribute($method)) {
+            return static::isShopperInstance()
+                ? static::query()->$method(...$parameters)
+                : static::configuredClass()::query()->$method(...$parameters);
+        }
+
         if (! static::isShopperInstance()) {
             return (new (static::configuredClass()))->$method(...$parameters);
         }

--- a/packages/http/src/Exceptions/JsonApiErrorRenderer.php
+++ b/packages/http/src/Exceptions/JsonApiErrorRenderer.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Http\Exceptions;
+
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Auth\AuthenticationException;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\ValidationException;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
+use Throwable;
+
+/**
+ * Renders exceptions thrown on Shopper API routes as JSON:API error documents
+ * ({ "errors": [...] }) with the application/vnd.api+json content type, so the
+ * error contract matches the success contract. Returns null for non-API routes,
+ * letting the default handler take over.
+ */
+final class JsonApiErrorRenderer
+{
+    public function render(Throwable $exception, Request $request): ?JsonResponse
+    {
+        if (! $this->handlesRequest($request)) {
+            return null;
+        }
+
+        if ($exception instanceof ValidationException) {
+            return $this->response($exception->status, $this->validationErrors($exception));
+        }
+
+        $status = match (true) {
+            $exception instanceof AuthenticationException => Response::HTTP_UNAUTHORIZED,
+            $exception instanceof AuthorizationException => Response::HTTP_FORBIDDEN,
+            $exception instanceof ModelNotFoundException => Response::HTTP_NOT_FOUND,
+            $exception instanceof HttpExceptionInterface => $exception->getStatusCode(),
+            default => Response::HTTP_INTERNAL_SERVER_ERROR,
+        };
+
+        $detail = $exception instanceof HttpExceptionInterface && $exception->getMessage() !== ''
+            ? $exception->getMessage()
+            : $this->title($status);
+
+        return $this->response($status, [[
+            'status' => (string) $status,
+            'title' => $this->title($status),
+            'detail' => $detail,
+        ]]);
+    }
+
+    private function handlesRequest(Request $request): bool
+    {
+        $prefix = mb_trim((string) config('shopper.http.prefix', 'store'), '/');
+
+        return $prefix !== '' && $request->is($prefix.'/*');
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $errors
+     */
+    private function response(int $status, array $errors): JsonResponse
+    {
+        return new JsonResponse(
+            data: ['errors' => $errors],
+            status: $status,
+            headers: ['Content-Type' => 'application/vnd.api+json'],
+        );
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function validationErrors(ValidationException $exception): array
+    {
+        $errors = [];
+
+        foreach ($exception->errors() as $field => $messages) {
+            foreach ($messages as $message) {
+                $errors[] = [
+                    'status' => (string) $exception->status,
+                    'title' => $this->title($exception->status),
+                    'detail' => $message,
+                    'source' => ['pointer' => '/data/attributes/'.$field],
+                ];
+            }
+        }
+
+        return $errors;
+    }
+
+    private function title(int $status): string
+    {
+        return Response::$statusTexts[$status] ?? 'Error';
+    }
+}

--- a/packages/http/src/HttpServiceProvider.php
+++ b/packages/http/src/HttpServiceProvider.php
@@ -5,17 +5,20 @@ declare(strict_types=1);
 namespace Shopper\Http;
 
 use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\RateLimiter;
 use Shopper\Http\Contracts\ZoneResolver;
 use Shopper\Http\Enum\RateLimit;
+use Shopper\Http\Exceptions\JsonApiErrorRenderer;
 use Shopper\Http\Middleware\EnsureJsonApiResponse;
 use Shopper\Http\Middleware\ResolveCustomer;
 use Shopper\Http\Middleware\ResolveZone;
 use Shopper\Http\Zone\DefaultZoneResolver;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
+use Throwable;
 
 final class HttpServiceProvider extends PackageServiceProvider
 {
@@ -45,6 +48,18 @@ final class HttpServiceProvider extends PackageServiceProvider
 
         $this->registerRateLimiters();
         $this->registerMiddleware();
+        $this->registerExceptionRenderer();
+    }
+
+    private function registerExceptionRenderer(): void
+    {
+        $this->callAfterResolving(ExceptionHandler::class, function (ExceptionHandler $handler): void {
+            $renderer = new JsonApiErrorRenderer;
+
+            $handler->renderable(
+                fn (Throwable $exception, Request $request) => $renderer->render($exception, $request),
+            );
+        });
     }
 
     private function registerRateLimiters(): void

--- a/packages/http/src/HttpServiceProvider.php
+++ b/packages/http/src/HttpServiceProvider.php
@@ -6,6 +6,7 @@ namespace Shopper\Http;
 
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Contracts\Debug\ExceptionHandler;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\RateLimiter;
@@ -57,7 +58,7 @@ final class HttpServiceProvider extends PackageServiceProvider
             $renderer = new JsonApiErrorRenderer;
 
             $handler->renderable(
-                fn (Throwable $exception, Request $request) => $renderer->render($exception, $request),
+                fn (Throwable $exception, Request $request): ?JsonResponse => $renderer->render($exception, $request),
             );
         });
     }

--- a/packages/sdk/.gitignore
+++ b/packages/sdk/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+*.tsbuildinfo

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,0 +1,64 @@
+# @shopperlabs/shopper-sdk
+
+Official JavaScript SDK for the [Shopper](https://shopper.cloud) headless commerce API.
+
+The SDK talks to the Shopper Store API (JSON:API) and returns the plain, nested
+shapes declared by [`@shopperlabs/shopper-types`](https://www.npmjs.com/package/@shopperlabs/shopper-types).
+You work with `product.variants` as an array of full variants — the SDK handles
+the JSON:API normalization (relationships + `included`) for you.
+
+## Installation
+
+```bash
+npm install @shopperlabs/shopper-sdk
+```
+
+## Usage
+
+```ts
+import Shopper from '@shopperlabs/shopper-sdk'
+
+const sdk = new Shopper({ baseUrl: 'https://my-store.com' })
+
+// List products, filtered and paginated
+const { data, meta } = await sdk.store.product.list({
+  filter: { name: 'sony' },
+  sort: ['-published_at'],
+  page: { size: 12 },
+})
+
+// Retrieve a product with its relationships, fully nested
+const product = await sdk.store.product.retrieve('sony-wh-1000xm5', {
+  include: ['brand', 'variants', 'options', 'categories'],
+})
+
+product.variants?.forEach((variant) => console.log(variant.name, variant.prices))
+```
+
+## Custom & addon endpoints
+
+Use `store.fetch()` for any endpoint not yet wrapped, including addon routes
+registered through `shopper/http`. The JSON:API payload is flattened the same way:
+
+```ts
+const { data } = await sdk.store.fetch('/store/best-sellers', { query: { limit: 10 } })
+```
+
+## Errors
+
+Non-2xx responses throw a `ShopperApiError` carrying the HTTP status and the
+JSON:API error objects:
+
+```ts
+import Shopper, { ShopperApiError } from '@shopperlabs/shopper-sdk'
+
+const sdk = new Shopper({ baseUrl: 'https://my-store.com' })
+
+try {
+  await sdk.store.product.retrieve('missing')
+} catch (error) {
+  if (error instanceof ShopperApiError) {
+    console.error(error.status, error.errors)
+  }
+}
+```

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@shopperlabs/shopper-sdk",
+  "version": "3.0.0",
+  "description": "Official JavaScript SDK for the Shopper headless commerce API.",
+  "author": "Arthur Monney <monneylobe@gmail.com> (https://arthurmonney.me)",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/shopperlabs/shopper-sdk.git"
+  },
+  "bugs": {
+    "url": "https://github.com/shopperlabs/shopper-sdk/issues"
+  },
+  "homepage": "https://github.com/shopperlabs/shopper-sdk#readme",
+  "keywords": [
+    "shopper",
+    "ecommerce",
+    "headless",
+    "sdk",
+    "json-api",
+    "storefront"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc --watch",
+    "prepublishOnly": "npm run build"
+  },
+  "dependencies": {
+    "@shopperlabs/shopper-types": "^3.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.2.2"
+  }
+}

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -1,0 +1,51 @@
+import { buildQuery, type FetchOptions, toApiError } from './http'
+import type { JsonApiDocument } from './json-api'
+
+export interface ShopperConfig {
+  /** Base URL of the Shopper application, e.g. https://my-store.com */
+  baseUrl: string
+  /** Store route prefix used by the resource accessors. Defaults to "store". */
+  storePrefix?: string
+  /** Extra headers merged into every request (auth tokens, locale, ...). */
+  headers?: Record<string, string>
+  /** Custom fetch implementation (defaults to the global fetch). */
+  fetch?: typeof globalThis.fetch
+}
+
+/**
+ * Thin transport over fetch: builds the URL, forces the JSON:API Accept header,
+ * and turns non-2xx responses into a ShopperApiError. Returns the raw JSON:API
+ * document; denormalization happens in the resources.
+ */
+export class HttpClient {
+  public readonly storePrefix: string
+
+  private readonly baseUrl: string
+
+  private readonly headers: Record<string, string>
+
+  private readonly fetchImpl: typeof globalThis.fetch
+
+  public constructor(config: ShopperConfig) {
+    this.baseUrl = config.baseUrl.replace(/\/$/, '')
+    this.storePrefix = (config.storePrefix ?? 'store').replace(/^\/|\/$/g, '')
+    this.headers = config.headers ?? {}
+    // Bind to the global so the browser fetch keeps `this === window`
+    this.fetchImpl = (config.fetch ?? globalThis.fetch).bind(globalThis)
+  }
+
+  public async request(path: string, options?: FetchOptions): Promise<JsonApiDocument> {
+    const url = `${this.baseUrl}/${path.replace(/^\//, '')}${buildQuery(options)}`
+
+    const response = await this.fetchImpl(url, {
+      method: 'GET',
+      headers: { Accept: 'application/vnd.api+json', ...this.headers },
+    })
+
+    if (! response.ok) {
+      throw await toApiError(response)
+    }
+
+    return (await response.json()) as JsonApiDocument
+  }
+}

--- a/packages/sdk/src/http.ts
+++ b/packages/sdk/src/http.ts
@@ -1,0 +1,89 @@
+import type { JsonApiErrorDocument } from './json-api'
+
+/**
+ * Structured JSON:API query parameters understood by every list/retrieve call,
+ * mapped to the query family the Shopper API expects (filter[], sort, include,
+ * page[number], page[size], fields[type]).
+ */
+export interface RequestParams {
+  include?: string[]
+  filter?: Record<string, string | number | boolean>
+  sort?: string[]
+  page?: { number?: number; size?: number }
+  fields?: Record<string, string[]>
+}
+
+/** Options for the low-level `store.fetch()` escape hatch: structured params plus arbitrary query values. */
+export interface FetchOptions extends RequestParams {
+  query?: Record<string, string | number | boolean>
+}
+
+export function buildQuery(options?: FetchOptions): string {
+  if (! options) {
+    return ''
+  }
+
+  const search = new URLSearchParams()
+
+  if (options.include?.length) {
+    search.set('include', options.include.join(','))
+  }
+
+  if (options.sort?.length) {
+    search.set('sort', options.sort.join(','))
+  }
+
+  for (const [field, value] of Object.entries(options.filter ?? {})) {
+    search.set(`filter[${field}]`, String(value))
+  }
+
+  if (options.page?.number) {
+    search.set('page[number]', String(options.page.number))
+  }
+
+  if (options.page?.size) {
+    search.set('page[size]', String(options.page.size))
+  }
+
+  for (const [type, list] of Object.entries(options.fields ?? {})) {
+    search.set(`fields[${type}]`, list.join(','))
+  }
+
+  for (const [key, value] of Object.entries(options.query ?? {})) {
+    search.set(key, String(value))
+  }
+
+  const query = search.toString()
+
+  return query ? `?${query}` : ''
+}
+
+/**
+ * Error thrown when the API returns a non-2xx response. Carries the HTTP status
+ * and the parsed JSON:API error objects when available.
+ */
+export class ShopperApiError extends Error {
+  public readonly status: number
+
+  public readonly errors: JsonApiErrorDocument['errors']
+
+  public constructor(status: number, errors: JsonApiErrorDocument['errors']) {
+    super(errors[0]?.detail ?? errors[0]?.title ?? `Request failed with status ${status}`)
+    this.name = 'ShopperApiError'
+    this.status = status
+    this.errors = errors
+  }
+}
+
+export async function toApiError(response: Response): Promise<ShopperApiError> {
+  let errors: JsonApiErrorDocument['errors'] = []
+
+  try {
+    const body = (await response.json()) as Partial<JsonApiErrorDocument>
+    errors = body.errors ?? []
+  } catch {
+    errors = []
+  }
+
+  return new ShopperApiError(response.status, errors)
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,0 +1,33 @@
+import { HttpClient, type ShopperConfig } from './client'
+import { StoreModule } from './store'
+
+/**
+ * Shopper SDK client.
+ *
+ * ```ts
+ * import Shopper from '@shopperlabs/shopper-sdk'
+ *
+ * const sdk = new Shopper({ baseUrl: 'https://my-store.com' })
+ * const { data } = await sdk.store.product.list({ include: ['variants', 'brand'] })
+ * ```
+ */
+export default class Shopper {
+  public readonly store: StoreModule
+
+  public constructor(config: ShopperConfig) {
+    this.store = new StoreModule(new HttpClient(config))
+  }
+}
+
+export type { ShopperConfig } from './client'
+export { StoreModule, type Paginated } from './store'
+export { ShopperApiError, buildQuery } from './http'
+export type { RequestParams, FetchOptions } from './http'
+export { flatten } from './json-api'
+export type {
+  JsonApiDocument,
+  JsonApiResource,
+  JsonApiError,
+  JsonApiErrorDocument,
+  ResourceIdentifier,
+} from './json-api'

--- a/packages/sdk/src/json-api.ts
+++ b/packages/sdk/src/json-api.ts
@@ -1,0 +1,108 @@
+/**
+ * JSON:API document handling.
+ *
+ * The Shopper API serves normalized JSON:API documents: a resource exposes its
+ * own attributes plus relationship linkage ({ type, id }), and the full related
+ * resources live in the top-level `included` array when requested via `include`.
+ *
+ * `flatten()` denormalizes that document back into the plain, nested shapes
+ * declared by `@shopperlabs/shopper-types`, so consumers never deal with the
+ * wire format: `product.variants` is an array of full variants, not pointers.
+ */
+
+export interface ResourceIdentifier {
+  type: string
+  id: string
+}
+
+export interface JsonApiResource extends ResourceIdentifier {
+  attributes?: Record<string, unknown>
+  relationships?: Record<string, { data: ResourceIdentifier | ResourceIdentifier[] | null }>
+}
+
+export interface JsonApiDocument {
+  data: JsonApiResource | JsonApiResource[] | null
+  included?: JsonApiResource[]
+  meta?: Record<string, unknown>
+  links?: Record<string, unknown>
+}
+
+export interface JsonApiError {
+  status?: string
+  title?: string
+  detail?: string
+  source?: { pointer?: string; parameter?: string }
+}
+
+export interface JsonApiErrorDocument {
+  errors: JsonApiError[]
+}
+
+function identifier(resource: ResourceIdentifier): string {
+  return `${resource.type}:${resource.id}`
+}
+
+/**
+ * Denormalize a JSON:API document into flat entities. Returns an array when the
+ * document's primary data is a collection, a single object for a single resource,
+ * or null. Relationships present in `included` are inlined as nested objects;
+ * relationships that are linkage-only resolve to a minimal `{ id }` stub.
+ */
+export function flatten<T = unknown>(document: JsonApiDocument): T | T[] | null {
+  const index = new Map<string, JsonApiResource>()
+
+  for (const resource of document.included ?? []) {
+    index.set(identifier(resource), resource)
+  }
+
+  if (Array.isArray(document.data)) {
+    return document.data.map((resource) => resolve(resource, index, new Map())) as T[]
+  }
+
+  if (document.data == null) {
+    return null
+  }
+
+  return resolve(document.data, index, new Map()) as T
+}
+
+function resolve(
+  resource: JsonApiResource,
+  index: Map<string, JsonApiResource>,
+  seen: Map<string, Record<string, unknown>>,
+): Record<string, unknown> {
+  const key = identifier(resource)
+  const existing = seen.get(key)
+
+  if (existing) {
+    return existing
+  }
+
+  const flat: Record<string, unknown> = { id: resource.id, ...(resource.attributes ?? {}) }
+  seen.set(key, flat)
+
+  for (const [name, relationship] of Object.entries(resource.relationships ?? {})) {
+    const data = relationship.data
+
+    if (data == null) {
+      flat[name] = null
+      continue
+    }
+
+    flat[name] = Array.isArray(data)
+      ? data.map((reference) => resolveReference(reference, index, seen))
+      : resolveReference(data, index, seen)
+  }
+
+  return flat
+}
+
+function resolveReference(
+  reference: ResourceIdentifier,
+  index: Map<string, JsonApiResource>,
+  seen: Map<string, Record<string, unknown>>,
+): Record<string, unknown> {
+  const included = index.get(identifier(reference))
+
+  return included ? resolve(included, index, seen) : { id: reference.id }
+}

--- a/packages/sdk/src/store.ts
+++ b/packages/sdk/src/store.ts
@@ -1,0 +1,69 @@
+import type { Attribute, Brand, Category, Collection, Product } from '@shopperlabs/shopper-types'
+
+import type { HttpClient } from './client'
+import type { FetchOptions, RequestParams } from './http'
+import { flatten } from './json-api'
+
+/** A paginated list result: flattened entities plus JSON:API meta and links. */
+export interface Paginated<T> {
+  data: T[]
+  meta?: Record<string, unknown>
+  links?: Record<string, unknown>
+}
+
+class CollectionResource<T> {
+  public constructor(
+    private readonly client: HttpClient,
+    private readonly path: string,
+  ) {}
+
+  public async list(params?: RequestParams): Promise<Paginated<T>> {
+    const document = await this.client.request(this.path, params)
+
+    return { data: (flatten<T>(document) ?? []) as T[], meta: document.meta, links: document.links }
+  }
+
+  public async retrieve(slug: string, params?: RequestParams): Promise<T> {
+    return flatten<T>(await this.client.request(`${this.path}/${slug}`, params)) as T
+  }
+}
+
+/**
+ * Store API surface, mirroring the catalog endpoints. Resources are singular
+ * (sdk.store.product.list()) like @medusajs/js-sdk. Use `fetch()` for endpoints
+ * not yet wrapped, including addon routes registered through shopper/http.
+ */
+export class StoreModule {
+  public readonly product: CollectionResource<Product>
+
+  public readonly category: CollectionResource<Category>
+
+  public readonly collection: CollectionResource<Collection>
+
+  public readonly brand: CollectionResource<Brand>
+
+  public readonly attribute: Pick<CollectionResource<Attribute>, 'list'>
+
+  public constructor(private readonly client: HttpClient) {
+    const prefix = `/${client.storePrefix}`
+
+    this.product = new CollectionResource<Product>(client, `${prefix}/products`)
+    this.category = new CollectionResource<Category>(client, `${prefix}/categories`)
+    this.collection = new CollectionResource<Collection>(client, `${prefix}/collections`)
+    this.brand = new CollectionResource<Brand>(client, `${prefix}/brands`)
+    this.attribute = new CollectionResource<Attribute>(client, `${prefix}/attributes`)
+  }
+
+  /**
+   * Low-level escape hatch: call any endpoint by path and receive the flattened
+   * payload. `path` is relative to the base URL (e.g. "/store/best-sellers").
+   */
+  public async fetch<T = unknown>(
+    path: string,
+    options?: FetchOptions,
+  ): Promise<{ data: T | T[] | null; meta?: Record<string, unknown>; links?: Record<string, unknown> }> {
+    const document = await this.client.request(path, options)
+
+    return { data: flatten<T>(document), meta: document.meta, links: document.links }
+  }
+}

--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM"],
+    "declaration": true,
+    "outDir": "dist",
+    "declarationDir": "dist",
+    "esModuleInterop": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "strictFunctionTypes": true,
+    "strictNullChecks": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopperlabs/shopper-types",
-  "version": "1.0.0",
+  "version": "3.0.0",
   "description": "TypeScript types for Shopper",
   "author": "Arthur Monney <monneylobe@gmail.com> (https://arthurmonney.me)",
   "main": "dist/index.js",

--- a/packages/types/src/attribute.ts
+++ b/packages/types/src/attribute.ts
@@ -19,17 +19,17 @@ export interface Attribute extends Entity {
   /** The slug of the attribute. */
   slug: string
   /** The type of the attribute field. */
-  type: FieldType
+  type?: FieldType
   /** The icon of the attribute. */
-  icon: string | null
+  icon?: string | null
   /** The description of the attribute. */
-  description: string | null
+  description?: string | null
   /** Whether the attribute is enabled. */
-  is_enabled: boolean
+  is_enabled?: boolean
   /** Whether the attribute is searchable. */
-  is_searchable: boolean
+  is_searchable?: boolean
   /** Whether the attribute is filterable. */
-  is_filterable: boolean
+  is_filterable?: boolean
   /** The computed formatted type. */
   type_formatted?: string
   /** The values of the attribute. */
@@ -40,15 +40,16 @@ export interface Attribute extends Entity {
  * AttributeValue model.
  */
 export interface AttributeValue {
-  id: number
+  /** The internal id (admin contexts only). */
+  id?: number
   /** The display value. */
   value: string
-  /** The key identifier. */
+  /** The key identifier (used as the facet filter value). */
   key: string
   /** The position/order. */
   position: number
-  /** The attribute ID this value belongs to. */
-  attribute_id: number
+  /** The attribute ID this value belongs to (admin contexts only). */
+  attribute_id?: number
   /** The attribute this value belongs to. */
   attribute?: Attribute
 }

--- a/packages/types/src/brand.ts
+++ b/packages/types/src/brand.ts
@@ -19,6 +19,6 @@ export interface Brand extends Entity, SEOFields {
   is_enabled: boolean
   /** The metadata of the brand. */
   metadata: Metadata
-  /** The image of the brand. */
-  image?: Media | null
+  /** The thumbnail of the brand. */
+  thumbnail?: Media | null
 }

--- a/packages/types/src/cart.ts
+++ b/packages/types/src/cart.ts
@@ -1,5 +1,5 @@
 import type { Channel } from './channel'
-import type { DateEntity, Entity, Metadata } from './common'
+import type { Entity, Metadata } from './common'
 import type { Country } from './country'
 import type { Customer } from './customer'
 import type { Discount } from './discount'
@@ -20,7 +20,7 @@ export interface Cart extends Entity {
   /** The coupon code applied to the cart. */
   coupon_code: string | null
   /** The date the cart was completed (converted to order). */
-  completed_at: DateEntity | null
+  completed_at: string | null
   /** The metadata of the cart. */
   metadata: Metadata
   /** The customer ID. */

--- a/packages/types/src/category.ts
+++ b/packages/types/src/category.ts
@@ -20,8 +20,8 @@ export interface Category extends Entity, SEOFields {
   parent_id: number | null
   /** The metadata of the category. */
   metadata: Metadata
-  /** The image of the category. */
-  image?: Media | null
+  /** The thumbnail of the category. */
+  thumbnail?: Media | null
   /** The parent category. */
   parent?: Category
   /** The children categories. */

--- a/packages/types/src/collection.ts
+++ b/packages/types/src/collection.ts
@@ -1,4 +1,4 @@
-import type { DateEntity, Entity, Metadata, SEOFields } from './common'
+import type { Entity, Metadata, SEOFields } from './common'
 import type { Media } from './media'
 import type { Product } from './product'
 import type { Zone } from './zone'
@@ -54,11 +54,11 @@ export interface Collection extends Entity, SEOFields {
   /** The sort order for products. */
   sort: string | null
   /** The published date of the collection. */
-  published_at: DateEntity | null
+  published_at: string | null
   /** The metadata of the collection. */
   metadata: Metadata
-  /** The image of the collection. */
-  image?: Media | null
+  /** The thumbnail of the collection. */
+  thumbnail?: Media | null
   /** The rules for automatic collections. */
   rules?: CollectionRule[]
   /** The zones this collection belongs to. */

--- a/packages/types/src/common.ts
+++ b/packages/types/src/common.ts
@@ -25,30 +25,26 @@ export enum Volume {
  * Global entity for all the models.
  */
 export interface Entity {
-  /** The id of the entity. */
-  id: number
-  /** The created at of the entity. */
-  created_at?: DateEntity
-  /** The updated at of the entity. */
-  updated_at?: DateEntity
-  /** The deleted at of the entity. */
-  deleted_at?: DateEntity | null
-}
-
-/**
- * A date DTO to manage date format.
- */
-export interface DateEntity {
-  /** The date format of the entity. */
-  date: string
-  /** The human-readable date. Eg: 2 hours ago. */
-  human: string
+  /** The internal id of the entity (admin). */
+  id: string | number
+  /** The stable public identifier (ULID) exposed by the API. */
+  public_id?: string
+  /** The ISO 8601 created at timestamp. */
+  created_at?: string
+  /** The ISO 8601 updated at timestamp. */
+  updated_at?: string
+  /** The ISO 8601 deleted at timestamp. */
+  deleted_at?: string | null
 }
 
 /**
  * Price interface for entity.
  */
 export interface Price {
+  /** The internal id of the entity (admin). */
+  id?: string | number
+  /** The stable public identifier (ULID) exposed by the API. */
+  public_id?: string
   /** The original amount for the entity. */
   amount: number | null
   /** The compare_amount amount for the entity. */

--- a/packages/types/src/common.ts
+++ b/packages/types/src/common.ts
@@ -50,13 +50,13 @@ export interface Price {
   /** The compare_amount amount for the entity. */
   compare_amount: number | null
   /** The cost_amount for the entity. */
-  cost_amount: number | null
+  cost_amount?: number | null
   /** The currency_id for the entity. */
-  currency_id: number
+  currency_id?: number
   /** The currency_code for the entity. */
   currency_code: string
   /** The currency for the entity. */
-  currency: Currency
+  currency?: Currency
 }
 
 /**

--- a/packages/types/src/country.ts
+++ b/packages/types/src/country.ts
@@ -5,6 +5,8 @@ import type { Zone } from './zone'
  */
 export interface Country {
   id: number
+  /** The stable public identifier (ULID) exposed by the API. */
+  public_id?: string
   /** The name of the country. */
   name: string
   /** The official name of the country. */

--- a/packages/types/src/currency.ts
+++ b/packages/types/src/currency.ts
@@ -15,6 +15,8 @@ export function isNoDivisionCurrency(currency: string): boolean {
  */
 export interface Currency {
   id: number
+  /** The stable public identifier (ULID) exposed by the API. */
+  public_id?: string
   /** The name of the currency. */
   name: string
   /** The code of the currency (e.g., USD, EUR). */

--- a/packages/types/src/customer.ts
+++ b/packages/types/src/customer.ts
@@ -1,5 +1,5 @@
 import type { Address } from './address'
-import type { DateEntity, Entity } from './common'
+import type { Entity } from './common'
 
 /**
  * The Gender Type for the customer.
@@ -43,7 +43,7 @@ export interface Customer extends Entity {
   /** Whether the customer has opted in to marketing. */
   opt_in: boolean
   /** The last login date. */
-  last_login_at: DateEntity | null
+  last_login_at: string | null
   /** The last login IP address. */
   last_login_ip?: string | null
   /** The customer's addresses. */

--- a/packages/types/src/discount.ts
+++ b/packages/types/src/discount.ts
@@ -1,4 +1,4 @@
-import type { DateEntity, Entity, Metadata } from './common'
+import type { Entity, Metadata } from './common'
 import type { Zone } from './zone'
 
 export enum DiscountType {
@@ -58,9 +58,9 @@ export interface Discount extends Entity {
   /** The metadata of the discount. */
   metadata: Metadata
   /** The start date of the discount. */
-  start_at: DateEntity
+  start_at: string
   /** The end date of the discount. */
-  end_at: DateEntity | null
+  end_at: string | null
   /** The zone of the discount. */
   zone?: Zone
   /** The discount items/details. */

--- a/packages/types/src/order.ts
+++ b/packages/types/src/order.ts
@@ -1,6 +1,6 @@
 import type { CarrierOption } from './carrier'
 import type { Channel } from './channel'
-import type { DateEntity, Entity, Metadata } from './common'
+import type { Entity, Metadata } from './common'
 import type { Customer } from './customer'
 import type { PaymentMethod } from './payment_method'
 import type { OrderTaxLine } from './tax'
@@ -84,9 +84,9 @@ export interface Order extends Entity {
   /** The shipping status. */
   shipping_status: ShippingStatus
   /** The date the order was cancelled. */
-  cancelled_at: DateEntity | null
+  cancelled_at: string | null
   /** The date the order was archived. */
-  archived_at: DateEntity | null
+  archived_at: string | null
   /** The zone ID. */
   zone_id: number | null
   /** The shipping address ID. */
@@ -206,11 +206,11 @@ export interface OrderShipping extends Entity {
   /** The shipment status. */
   status: ShipmentStatus | null
   /** The date the order was shipped. */
-  shipped_at: DateEntity | null
+  shipped_at: string | null
   /** The date the order was received. */
-  received_at: DateEntity | null
+  received_at: string | null
   /** The date the order was returned. */
-  returned_at: DateEntity | null
+  returned_at: string | null
   /** The tracking number. */
   tracking_number: string | null
   /** The tracking URL. */
@@ -251,9 +251,9 @@ export interface OrderShippingEvent {
   /** The metadata of the event. */
   metadata: Metadata
   /** The date the event occurred. */
-  occurred_at: DateEntity
+  occurred_at: string
   /** The creation date. */
-  created_at?: DateEntity
+  created_at?: string
   /** The order shipping ID. */
   order_shipping_id: number
   /** The shipment this event belongs to. */

--- a/packages/types/src/product.ts
+++ b/packages/types/src/product.ts
@@ -4,7 +4,6 @@ import type { Category } from './category'
 import type { Channel } from './channel'
 import type { Collection } from './collection'
 import type {
-  DateEntity,
   Entity,
   Metadata,
   Price,
@@ -51,7 +50,7 @@ export interface Product extends Entity, SEOFields, ShippingFields {
   /** The type of the product. */
   type: ProductType | null
   /** The published at date of the product. */
-  published_at: DateEntity | null
+  published_at: string | null
   /** The external ID of the product. */
   external_id: string | null
   /** The stock quantity of the product. */
@@ -84,6 +83,10 @@ export interface Product extends Entity, SEOFields, ShippingFields {
   relatedProducts?: Product[]
   /** The images of the product. */
   images?: Media[] | null
+  /** The thumbnail of the product. */
+  thumbnail?: Media | null
+  /** The downloadable files of the product. */
+  files?: Media[] | null
   /** The reviews of the product. */
   reviews?: Review[]
   /** The prices of the product. */

--- a/packages/types/src/product.ts
+++ b/packages/types/src/product.ts
@@ -89,6 +89,10 @@ export interface Product extends Entity, SEOFields, ShippingFields {
   files?: Media[] | null
   /** The reviews of the product. */
   reviews?: Review[]
+  /** The average approved rating (null when there are no approved reviews). */
+  rating?: number | null
+  /** The number of approved reviews. */
+  reviews_count?: number
   /** The prices of the product. */
   prices?: Price[]
 }

--- a/packages/types/src/product_variant.ts
+++ b/packages/types/src/product_variant.ts
@@ -33,6 +33,8 @@ export interface ProductVariant extends Entity, ShippingFields {
   values?: AttributeValue[]
   /** The images of the product variant. */
   images?: Media[] | null
+  /** The thumbnail of the product variant. */
+  thumbnail?: Media | null
   /** The prices of the product variant. */
   prices?: Price[]
 }

--- a/packages/types/src/product_variant.ts
+++ b/packages/types/src/product_variant.ts
@@ -1,7 +1,21 @@
-import type { AttributeValue } from './attribute'
 import type { Entity, Metadata, Price, ShippingFields } from './common'
 import type { Media } from './media'
 import type { Product } from './product'
+
+/**
+ * A variant's option value, denormalized for the storefront (e.g. Color = Black).
+ * Used to match a selected option set to a variant and render swatches.
+ */
+export interface VariantOptionValue {
+  /** The display value (e.g. "Black"). */
+  value: string
+  /** The key identifier / swatch value (e.g. "black" or a hex color). */
+  key: string
+  /** The option name this value belongs to (e.g. "Color"). */
+  attribute: string
+  /** The option slug. */
+  attribute_slug: string
+}
 
 /**
  * ProductVariant model.
@@ -23,14 +37,14 @@ export interface ProductVariant extends Entity, ShippingFields {
   allow_backorder: boolean
   /** The product ID this variant belongs to. */
   product_id: number
-  /** The stock quantity of the variant. */
-  stock: number
+  /** The stock quantity of the variant (exposed once batched stock loading lands). */
+  stock?: number
   /** The metadata of the product variant. */
   metadata: Metadata
   /** The product this variant belongs to. */
   product?: Product
-  /** The attribute values of this variant. */
-  values?: AttributeValue[]
+  /** The option values this variant is built from (Color = Black, Storage = 256, ...). */
+  values?: VariantOptionValue[]
   /** The images of the product variant. */
   images?: Media[] | null
   /** The thumbnail of the product variant. */

--- a/tests/Api/Feature/CatalogEndpointsTest.php
+++ b/tests/Api/Feature/CatalogEndpointsTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+use Shopper\Core\Models\Attribute;
+use Shopper\Core\Models\AttributeValue;
+use Shopper\Core\Models\Brand;
+use Shopper\Core\Models\Category;
+use Shopper\Core\Models\Collection;
+use Shopper\Core\Models\Product;
+
+uses(Tests\Api\TestCase::class);
+
+it('shows a category by slug and hides disabled ones', function (): void {
+    $enabled = Category::factory()->create(['name' => 'CatEnabled', 'slug' => 'cat-enabled', 'is_enabled' => true]);
+    $disabled = Category::factory()->create(['name' => 'CatDisabled', 'slug' => 'cat-disabled', 'is_enabled' => false]);
+
+    $this->getJson('/store/categories/'.$enabled->slug)
+        ->assertOk()
+        ->assertJsonPath('data.type', 'categories')
+        ->assertJsonPath('data.id', $enabled->public_id)
+        ->assertJsonPath('data.attributes.name', 'CatEnabled');
+
+    $ids = collect($this->getJson('/store/categories?filter[name]=Cat')->assertOk()->json('data'))->pluck('id');
+    expect($ids)->toContain($enabled->public_id)->and($ids)->not->toContain($disabled->public_id);
+
+    $this->getJson('/store/categories/'.$disabled->slug)->assertNotFound();
+});
+
+it('lists only published collections and shows one by slug', function (): void {
+    $published = Collection::factory()->create(['name' => 'ColPublished', 'slug' => 'col-published', 'published_at' => now()]);
+    $draft = Collection::factory()->create(['name' => 'ColDraft', 'slug' => 'col-draft', 'published_at' => now()->addYear()]);
+
+    $ids = collect($this->getJson('/store/collections?filter[name]=Col')->assertOk()->json('data'))->pluck('id');
+    expect($ids)->toContain($published->public_id)->and($ids)->not->toContain($draft->public_id);
+
+    $this->getJson('/store/collections/'.$published->slug)
+        ->assertOk()
+        ->assertJsonPath('data.type', 'collections')
+        ->assertJsonPath('data.id', $published->public_id);
+});
+
+it('shows a brand and includes its products on demand', function (): void {
+    $brand = Brand::factory()->create(['name' => 'BrandOne', 'slug' => 'brand-one', 'is_enabled' => true]);
+    $product = Product::factory()->publish()->create(['brand_id' => $brand->id]);
+
+    $this->getJson('/store/brands/'.$brand->slug.'?include=products')
+        ->assertOk()
+        ->assertJsonPath('data.type', 'brands')
+        ->assertJsonPath('data.id', $brand->public_id)
+        ->assertJsonPath('included.0.type', 'products')
+        ->assertJsonPath('included.0.id', $product->public_id);
+});
+
+it('hides disabled brands from the listing', function (): void {
+    $enabled = Brand::factory()->create(['name' => 'BrandVisible', 'is_enabled' => true]);
+    $disabled = Brand::factory()->create(['name' => 'BrandHidden', 'is_enabled' => false]);
+
+    $ids = collect($this->getJson('/store/brands?filter[name]=Brand')->assertOk()->json('data'))->pluck('id');
+    expect($ids)->toContain($enabled->public_id)->and($ids)->not->toContain($disabled->public_id);
+});
+
+it('lists enabled attributes with their embedded values', function (): void {
+    $attribute = Attribute::factory()->create(['name' => 'AttrColor', 'is_enabled' => true]);
+    AttributeValue::factory()->create(['attribute_id' => $attribute->id, 'value' => 'Red', 'key' => 'attr-red']);
+
+    Attribute::factory()->create(['name' => 'AttrHidden', 'is_enabled' => false]);
+
+    $response = $this->getJson('/store/attributes?filter[name]=Attr')->assertOk();
+
+    $ids = collect($response->json('data'))->pluck('id');
+    expect($ids)->toContain($attribute->public_id);
+
+    $row = collect($response->json('data'))->firstWhere('id', $attribute->public_id);
+    $value = collect($row['attributes']['values'])->firstWhere('key', 'attr-red');
+    expect($value)->not->toBeNull()
+        ->and($value['value'])->toBe('Red');
+});

--- a/tests/Api/Feature/JsonApiResourceTest.php
+++ b/tests/Api/Feature/JsonApiResourceTest.php
@@ -22,7 +22,7 @@ it('serializes a model as a JSON:API document', function (): void {
     $this->getJson('/__test/products/'.$product->getKey())
         ->assertOk()
         ->assertJsonPath('data.type', 'products')
-        ->assertJsonPath('data.id', (string) $product->getKey())
+        ->assertJsonPath('data.id', $product->public_id)
         ->assertJsonPath('data.attributes.name', 'Tee')
         ->assertJsonStructure(['data' => ['type', 'id', 'attributes' => ['name', 'slug']]]);
 });

--- a/tests/Api/Feature/ProductCatalogTest.php
+++ b/tests/Api/Feature/ProductCatalogTest.php
@@ -11,6 +11,7 @@ use Shopper\Core\Models\Currency;
 use Shopper\Core\Models\Price;
 use Shopper\Core\Models\Product;
 use Shopper\Core\Models\ProductVariant;
+use Shopper\Core\Models\Review;
 
 uses(Tests\Api\TestCase::class);
 
@@ -172,6 +173,28 @@ it('serializes product options as a deduplicated array scoped to the used values
     expect($optionsData)->toBeArray()->toHaveCount(1)
         ->and(array_is_list($optionsData))->toBeTrue()
         ->and($values)->toContain('Red', 'Blue')->not->toContain('Green');
+});
+
+it('exposes the average rating and approved reviews count', function (): void {
+    $product = publishedProduct(['name' => 'Rated']);
+    $reviewable = ['reviewrateable_id' => $product->id, 'reviewrateable_type' => $product->getMorphClass()];
+    Review::factory()->create([...$reviewable, 'rating' => 4, 'approved' => true]);
+    Review::factory()->create([...$reviewable, 'rating' => 5, 'approved' => true]);
+    Review::factory()->create([...$reviewable, 'rating' => 1, 'approved' => false]);
+
+    $attributes = $this->getJson('/store/products/'.$product->slug)->assertOk()->json('data.attributes');
+
+    expect($attributes['reviews_count'])->toBe(2)
+        ->and($attributes['rating'])->toBe(4.5);
+});
+
+it('returns a null rating and zero count without approved reviews', function (): void {
+    $product = publishedProduct(['name' => 'Unrated']);
+
+    $this->getJson('/store/products/'.$product->slug)
+        ->assertOk()
+        ->assertJsonPath('data.attributes.rating', null)
+        ->assertJsonPath('data.attributes.reviews_count', 0);
 });
 
 it('paginates with page[size] and page[number]', function (): void {

--- a/tests/Api/Feature/ProductCatalogTest.php
+++ b/tests/Api/Feature/ProductCatalogTest.php
@@ -3,7 +3,10 @@
 declare(strict_types=1);
 
 use Illuminate\Support\Facades\DB;
+use Shopper\Core\Models\Attribute;
+use Shopper\Core\Models\AttributeValue;
 use Shopper\Core\Models\Brand;
+use Shopper\Core\Models\Category;
 use Shopper\Core\Models\Currency;
 use Shopper\Core\Models\Price;
 use Shopper\Core\Models\Product;
@@ -92,7 +95,9 @@ it('eager-loads variant prices when including variants, avoiding N+1', function 
 
     expect($variants)->toHaveCount(3)
         ->and($variants->first()['attributes']['prices'])->not->toBeEmpty()
-        ->and($queryCount)->toBeLessThanOrEqual(10);
+        // Bounded and constant regardless of variant count: prices.currency and
+        // values.attribute are eager-loaded once, never per variant.
+        ->and($queryCount)->toBeLessThanOrEqual(13);
 });
 
 it('includes the brand relationship on demand', function (): void {
@@ -104,6 +109,69 @@ it('includes the brand relationship on demand', function (): void {
         ->assertJsonPath('data.relationships.brand.data.type', 'brands')
         ->assertJsonPath('data.relationships.brand.data.id', $brand->public_id)
         ->assertJsonPath('included.0.type', 'brands');
+});
+
+it('filters products by category', function (): void {
+    $category = Category::factory()->create(['name' => 'Phones', 'slug' => 'phones']);
+    $inCategory = publishedProduct(['name' => 'Pixel']);
+    $inCategory->categories()->attach($category);
+    publishedProduct(['name' => 'Sneaker']);
+
+    $names = collect($this->getJson('/store/products?filter[category]=phones')->assertOk()->json('data'))
+        ->pluck('attributes.name');
+
+    expect($names)->toContain('Pixel')->and($names)->not->toContain('Sneaker');
+});
+
+it('searches products by term', function (): void {
+    publishedProduct(['name' => 'Wireless Headphones']);
+    publishedProduct(['name' => 'Running Shoes']);
+
+    $names = collect($this->getJson('/store/products?filter[q]=headphone')->assertOk()->json('data'))
+        ->pluck('attributes.name');
+
+    expect($names)->toContain('Wireless Headphones')->and($names)->not->toContain('Running Shoes');
+});
+
+it('exposes variant option values for option matching', function (): void {
+    $product = publishedProduct(['name' => 'Tee']);
+    $attribute = Attribute::factory()->create(['name' => 'Color']);
+    $value = AttributeValue::factory()->create([
+        'attribute_id' => $attribute->id,
+        'value' => 'Red',
+        'key' => 'red',
+    ]);
+    ProductVariant::factory()->create(['product_id' => $product->id])->values()->attach($value);
+
+    $variant = collect($this->getJson('/store/products/'.$product->slug.'?include=variants')->assertOk()->json('included'))
+        ->firstWhere('type', 'variants');
+
+    expect($variant['attributes']['values'])->toHaveCount(1)
+        ->and($variant['attributes']['values'][0])->toMatchArray([
+            'value' => 'Red',
+            'key' => 'red',
+            'attribute' => 'Color',
+        ]);
+});
+
+it('serializes product options as a deduplicated array scoped to the used values', function (): void {
+    $product = publishedProduct(['name' => 'Phone']);
+    $color = Attribute::factory()->create(['name' => 'Color']);
+    $red = AttributeValue::factory()->create(['attribute_id' => $color->id, 'value' => 'Red', 'key' => 'red']);
+    $blue = AttributeValue::factory()->create(['attribute_id' => $color->id, 'value' => 'Blue', 'key' => 'blue']);
+    // A global value the product does NOT use: must be excluded from its options.
+    AttributeValue::factory()->create(['attribute_id' => $color->id, 'value' => 'Green', 'key' => 'green']);
+    $product->options()->attach($color->id, ['attribute_value_id' => $red->id]);
+    $product->options()->attach($color->id, ['attribute_value_id' => $blue->id]);
+
+    $response = $this->getJson('/store/products/'.$product->slug.'?include=options')->assertOk();
+    $optionsData = $response->json('data.relationships.options.data');
+    $colorOption = collect($response->json('included'))->firstWhere('type', 'attributes');
+    $values = collect($colorOption['attributes']['values'])->pluck('value');
+
+    expect($optionsData)->toBeArray()->toHaveCount(1)
+        ->and(array_is_list($optionsData))->toBeTrue()
+        ->and($values)->toContain('Red', 'Blue')->not->toContain('Green');
 });
 
 it('paginates with page[size] and page[number]', function (): void {

--- a/tests/Api/Feature/ProductCatalogTest.php
+++ b/tests/Api/Feature/ProductCatalogTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Shopper\Core\Models\Brand;
+use Shopper\Core\Models\Currency;
+use Shopper\Core\Models\Price;
+use Shopper\Core\Models\Product;
+use Shopper\Core\Models\ProductVariant;
+
+uses(Tests\Api\TestCase::class);
+
+function publishedProduct(array $attributes = []): Product
+{
+    $product = Product::factory()->publish()->create($attributes);
+
+    Price::factory()->create([
+        'priceable_id' => $product->id,
+        'priceable_type' => $product->getMorphClass(),
+        'currency_id' => Currency::query()->value('id'),
+        'amount' => 2999,
+        'compare_amount' => 3999,
+    ]);
+
+    return $product;
+}
+
+it('shows a product by slug as a JSON:API document', function (): void {
+    $product = publishedProduct(['name' => 'Air Max']);
+
+    $this->getJson('/store/products/'.$product->slug)
+        ->assertOk()
+        ->assertHeader('Content-Type', 'application/vnd.api+json')
+        ->assertJsonPath('data.type', 'products')
+        ->assertJsonPath('data.id', $product->public_id)
+        ->assertJsonPath('data.attributes.name', 'Air Max')
+        ->assertJsonPath('data.attributes.slug', $product->slug)
+        ->assertJsonPath('data.attributes.prices.0.amount', 2999)
+        ->assertJsonPath('data.attributes.prices.0.compare_amount', 3999)
+        ->assertJsonPath('data.attributes.prices.0.currency_code', $product->prices()->first()->currency_code);
+});
+
+it('exposes a ULID public id, never the primary key', function (): void {
+    $product = publishedProduct(['name' => 'Opaque']);
+
+    $id = $this->getJson('/store/products/'.$product->slug)->json('data.id');
+
+    expect($id)->toBe($product->public_id)
+        ->and($id)->not->toBe((string) $product->getKey());
+});
+
+it('returns a JSON:API 404 error for an unknown slug', function (): void {
+    $this->getJson('/store/products/does-not-exist')
+        ->assertNotFound()
+        ->assertHeader('Content-Type', 'application/vnd.api+json')
+        ->assertJsonPath('errors.0.status', '404')
+        ->assertJsonPath('errors.0.title', 'Not Found');
+});
+
+it('lists only published products', function (): void {
+    $visible = publishedProduct(['name' => 'CatalogVisible']);
+    $hidden = Product::factory()->create(['name' => 'CatalogHidden', 'is_visible' => false]);
+
+    $ids = collect($this->getJson('/store/products?filter[name]=Catalog')->assertOk()->json('data'))
+        ->pluck('id');
+
+    expect($ids)->toContain($visible->public_id)
+        ->and($ids)->not->toContain($hidden->public_id);
+});
+
+it('eager-loads variant prices when including variants, avoiding N+1', function (): void {
+    $product = publishedProduct(['name' => 'WithVariants']);
+    $currencyId = Currency::query()->value('id');
+
+    foreach (range(1, 3) as $i) {
+        $variant = ProductVariant::factory()->create(['product_id' => $product->id]);
+        Price::factory()->create([
+            'priceable_id' => $variant->id,
+            'priceable_type' => $variant->getMorphClass(),
+            'currency_id' => $currencyId,
+            'amount' => 1000 + $i,
+        ]);
+    }
+
+    DB::enableQueryLog();
+    $response = $this->getJson('/store/products/'.$product->slug.'?include=variants')->assertOk();
+    $queryCount = count(DB::getQueryLog());
+    DB::disableQueryLog();
+
+    $variants = collect($response->json('included'))->where('type', 'variants');
+
+    expect($variants)->toHaveCount(3)
+        ->and($variants->first()['attributes']['prices'])->not->toBeEmpty()
+        ->and($queryCount)->toBeLessThanOrEqual(10);
+});
+
+it('includes the brand relationship on demand', function (): void {
+    $brand = Brand::factory()->create();
+    $product = publishedProduct(['name' => 'Branded', 'brand_id' => $brand->id]);
+
+    $this->getJson('/store/products/'.$product->slug.'?include=brand')
+        ->assertOk()
+        ->assertJsonPath('data.relationships.brand.data.type', 'brands')
+        ->assertJsonPath('data.relationships.brand.data.id', $brand->public_id)
+        ->assertJsonPath('included.0.type', 'brands');
+});
+
+it('paginates with page[size] and page[number]', function (): void {
+    publishedProduct(['name' => 'PageOne']);
+    publishedProduct(['name' => 'PageTwo']);
+    publishedProduct(['name' => 'PageThree']);
+
+    $first = $this->getJson('/store/products?filter[name]=Page&sort=name&page[size]=2')->assertOk();
+    expect($first->json('data'))->toHaveCount(2);
+
+    $second = $this->getJson('/store/products?filter[name]=Page&sort=name&page[size]=2&page[number]=2')->assertOk();
+    expect($second->json('data'))->toHaveCount(1);
+});
+
+it('caps page[size] at the configured maximum', function (): void {
+    config()->set('shopper.api.pagination.max_per_page', 1);
+    publishedProduct(['name' => 'CapA']);
+    publishedProduct(['name' => 'CapB']);
+
+    $response = $this->getJson('/store/products?filter[name]=Cap&page[size]=50')->assertOk();
+    expect($response->json('data'))->toHaveCount(1);
+});
+
+it('filters and sorts the product list through the allowlist', function (): void {
+    publishedProduct(['name' => 'ZzzCatalogBeta']);
+    publishedProduct(['name' => 'ZzzCatalogAlpha']);
+
+    $names = collect(
+        $this->getJson('/store/products?filter[name]=ZzzCatalog&sort=name')->assertOk()->json('data')
+    )->pluck('attributes.name');
+
+    expect($names->toArray())->toBe(['ZzzCatalogAlpha', 'ZzzCatalogBeta']);
+});

--- a/tests/Core/Models/ProductTest.php
+++ b/tests/Core/Models/ProductTest.php
@@ -378,8 +378,8 @@ describe(Product::class, function (): void {
         $product2->channels()->attach($channel2);
         $product3->channels()->attach([$channel1->id, $channel2->id]);
 
-        $resultsChannel1 = Product::forChannel($channel1->id)->get();
-        $resultsChannel2 = Product::forChannel($channel2->id)->get();
+        $resultsChannel1 = Product::channel($channel1->id)->get();
+        $resultsChannel2 = Product::channel($channel2->id)->get();
 
         expect($resultsChannel1->count())->toBe(2)
             ->and($resultsChannel2->count())->toBe(2);

--- a/tests/Http/Feature/StoreGroupTest.php
+++ b/tests/Http/Feature/StoreGroupTest.php
@@ -52,7 +52,10 @@ it('rejects unauthenticated requests on the authenticated group', function (): v
         Route::get('/me', fn () => response()->json(['ok' => true]));
     });
 
-    $this->getJson('/store/me')->assertUnauthorized();
+    $this->getJson('/store/me')
+        ->assertUnauthorized()
+        ->assertHeader('Content-Type', 'application/vnd.api+json')
+        ->assertJsonPath('errors.0.status', '401');
 });
 
 it('binds the authenticated customer onto the request', function (): void {


### PR DESCRIPTION
Introduces the storefront catalog API (`shopper/api`) and the official JavaScript SDK (`@shopperlabs/shopper-sdk`), the first slice of Shopper's headless storefront layer.

## API (`shopper/api`)
JSON:API endpoints under `/store` for products, categories, collections, brands and attributes:

- Products list and retrieve by slug, with `q` search, filters (category, collection, brand, tag, faceted attribute `option`), `page[number]`/`page[size]` pagination, and `include` of brand, variants, categories, collections, options and related products.
- Variants expose their option values (`value`, `key`, `attribute`) so a storefront can match a selected option set to a variant and render colour swatches.
- Product options are deduplicated and scoped to the values the product actually uses, so the PDP renders only the relevant selectors.
- Attributes expose `type`, `is_filterable`/`is_searchable` and value keys for facet sidebars.
- Media exposed as `images`, `thumbnail` and `files`; review aggregates as `rating` and `reviews_count`.
- JSON:API error documents (404, 401, 422, 500) and rate limiting provided by `shopper/http`.

Every API-exposed model gains a stable, non-enumerable `public_id` (ULID) used as the JSON:API `id`, backfilled by idempotent migrations across core and cart.

## SDK (`@shopperlabs/shopper-sdk`)
`new Shopper({ baseUrl }).store.product.list(...)` returns the flat shapes declared by `@shopperlabs/shopper-types`. The SDK denormalizes the JSON:API document (relationships and the `included` array) so consumers never touch the wire format. npm workspaces let it resolve the types package locally during development.

## Core
`HasModelContract` now routes Laravel 12 `#[Scope]` attribute methods through the query builder, so attribute scopes resolve correctly on swappable models.

Closes #457
Closes #458