### PR TITLE
Catalog stock exposure and product type shaped resources

### DIFF
--- a/packages/api/config/api.php
+++ b/packages/api/config/api.php
@@ -41,7 +41,15 @@ return [
                 'option' => ['scope', 'option'],
             ],
             'sorts' => ['name', 'created_at', 'published_at'],
-            'includes' => ['brand', 'variants', 'categories', 'collections', 'options', 'relatedProducts'],
+            'includes' => [
+                'brand',
+                'variants',
+                'categories',
+                'collections',
+                'options',
+                'relatedProducts',
+                'rating' => Shopper\Api\Http\Includes\RatingAggregate::class,
+            ],
             'include_loads' => [
                 'variants' => ['variants.prices.currency', 'variants.values.attribute'],
                 'options' => ['options.values'],

--- a/packages/api/src/Concerns/BuildsApiQueries.php
+++ b/packages/api/src/Concerns/BuildsApiQueries.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Shopper\Api\Concerns;
 
-use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Collection;
 use Spatie\QueryBuilder\AllowedFilter;
+use Spatie\QueryBuilder\AllowedInclude;
+use Spatie\QueryBuilder\Includes\IncludeInterface;
 use Spatie\QueryBuilder\QueryBuilder;
 use Spatie\QueryBuilder\QueryBuilderRequest;
 
@@ -30,7 +33,7 @@ trait BuildsApiQueries
         $builder = QueryBuilder::for($query, $request)
             ->allowedFilters(...$this->allowedFilters((array) ($allowlist['filters'] ?? [])))
             ->allowedSorts(...($allowlist['sorts'] ?? []))
-            ->allowedIncludes(...($allowlist['includes'] ?? []));
+            ->allowedIncludes(...$this->allowedIncludes((array) ($allowlist['includes'] ?? [])));
 
         $loads = $this->requestedIncludeLoads($resource);
 
@@ -68,6 +71,17 @@ trait BuildsApiQueries
     }
 
     /**
+     * The include names requested on the current request, for endpoints that
+     * apply opt-in behavior (e.g. aggregates) outside the spatie query builder.
+     *
+     * @return Collection<int, string>
+     */
+    protected function requestedIncludes(): Collection
+    {
+        return QueryBuilderRequest::fromRequest(request())->includes();
+    }
+
+    /**
      * @template TModel of Model
      *
      * @param  Builder<TModel>  $query
@@ -100,6 +114,35 @@ trait BuildsApiQueries
         return $this->apiQuery($resource, $query)
             ->paginate(perPage: $size, pageName: 'page[number]', page: $page)
             ->withQueryString();
+    }
+
+    /**
+     * Build the spatie include list from a config descriptor map. A plain
+     * string entry is a relationship include; a `name => class-string` entry
+     * is a custom include (IncludeInterface) applied to the query on demand,
+     * e.g. the opt-in rating aggregates.
+     *
+     * @param  array<int|string, string>  $includes
+     * @return array<int, string|AllowedInclude>
+     */
+    private function allowedIncludes(array $includes): array
+    {
+        $allowed = [];
+
+        foreach ($includes as $key => $value) {
+            if (is_int($key)) {
+                $allowed[] = $value;
+
+                continue;
+            }
+
+            /** @var IncludeInterface $include */
+            $include = resolve($value);
+
+            $allowed[] = AllowedInclude::custom($key, $include);
+        }
+
+        return $allowed;
     }
 
     /**

--- a/packages/api/src/Concerns/LoadsStock.php
+++ b/packages/api/src/Concerns/LoadsStock.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Api\Concerns;
+
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Query\JoinClause;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
+use Shopper\Core\Enum\ProductType;
+use Shopper\Core\Models\Contracts\ProductVariant;
+use Shopper\Core\Models\Product as CoreProduct;
+use Shopper\Core\Models\ProductVariant as CoreProductVariant;
+
+trait LoadsStock
+{
+    /**
+     * Batch-load stock for the products of a response before serialization,
+     * shaped by the product type: standard and virtual products carry their
+     * own stock, variant products a per-product variant aggregate (correct on
+     * listings that do not include variants), and external products none. The
+     * per-variant stock of any loaded `variants` relation is batched too.
+     * Query count is constant regardless of page size or variant count.
+     *
+     * @param  Collection<int, Model>  $products
+     */
+    protected function loadStockForProducts(Collection $products): void
+    {
+        $products = $products
+            ->merge($products->flatMap(fn (Model $product): Collection => $this->loadedRelation($product, 'relatedProducts')))
+            ->unique(fn (Model $product) => $product->getKey())
+            ->values();
+
+        $ownStockProducts = $products->filter(
+            fn (Model $product): bool => ! in_array($product->getAttribute('type'), [ProductType::Variant, ProductType::External], true)
+        );
+
+        if ($ownStockProducts->isNotEmpty()) {
+            CoreProduct::loadCurrentStock(EloquentCollection::make($ownStockProducts->all()));
+        }
+
+        $variants = $products->flatMap(fn (Model $product): Collection => $this->loadedRelation($product, 'variants'));
+
+        if ($variants->isNotEmpty()) {
+            CoreProductVariant::loadCurrentStock(EloquentCollection::make($variants->all()));
+        }
+
+        $variantProducts = $products->filter(
+            fn (Model $product): bool => $product->getAttribute('type') === ProductType::Variant
+        );
+
+        if ($variantProducts->isNotEmpty()) {
+            $this->loadVariantsAggregate($variantProducts);
+        }
+    }
+
+    /**
+     * Batch-load stock for the products rendered through a loaded relation
+     * (e.g. categories or brands serialized with `include=products`).
+     *
+     * @param  Collection<int, Model>  $models
+     */
+    protected function loadStockThroughRelation(Collection $models, string $relation = 'products'): void
+    {
+        $products = $models->flatMap(fn (Model $model): Collection => $this->loadedRelation($model, $relation));
+
+        if ($products->isNotEmpty()) {
+            $this->loadStockForProducts($products);
+        }
+    }
+
+    /**
+     * One aggregate query: per product, the summed variant stock and whether
+     * any variant allows backorders. Posed as raw attributes read back through
+     * `getAttributes()` by the resources, because the product model already
+     * has a `variants_stock` accessor that would shadow a plain attribute and
+     * lazily iterate the variants relation.
+     *
+     * @param  Collection<int, Model>  $products
+     */
+    private function loadVariantsAggregate(Collection $products): void
+    {
+        /** @var Model $variant */
+        $variant = resolve(ProductVariant::class);
+        $variantsTable = $variant->getTable();
+        $historiesTable = shopper_table('inventory_histories');
+
+        $aggregates = $variant->newQuery()
+            ->toBase()
+            ->leftJoin($historiesTable, function (JoinClause $join) use ($historiesTable, $variantsTable, $variant): void {
+                $join->on($historiesTable.'.stockable_id', '=', $variantsTable.'.id')
+                    ->where($historiesTable.'.stockable_type', $variant->getMorphClass())
+                    ->where($historiesTable.'.created_at', '<=', Carbon::now());
+            })
+            ->whereIn($variantsTable.'.product_id', $products->map(fn (Model $product) => $product->getKey()))
+            ->groupBy($variantsTable.'.product_id')
+            ->selectRaw($variantsTable.'.product_id as product_id')
+            ->selectRaw('COALESCE(SUM('.$historiesTable.'.quantity), 0) as variants_stock')
+            ->selectRaw('MAX(CASE WHEN '.$variantsTable.'.allow_backorder THEN 1 ELSE 0 END) as variants_allow_backorder')
+            ->get()
+            ->keyBy('product_id');
+
+        $products->each(function (Model $product) use ($aggregates): void {
+            $row = $aggregates->get($product->getKey());
+
+            $product->setAttribute('variants_real_stock', (int) ($row->variants_stock ?? 0));
+            $product->setAttribute('variants_allow_backorder', (bool) ($row->variants_allow_backorder ?? false));
+        });
+    }
+
+    /**
+     * @return Collection<int, Model>
+     */
+    private function loadedRelation(Model $model, string $relation): Collection
+    {
+        $related = $model->relationLoaded($relation) ? $model->getRelation($relation) : null;
+
+        return $related instanceof EloquentCollection ? $related->toBase() : new Collection;
+    }
+}

--- a/packages/api/src/Http/Controllers/Catalog/BrandController.php
+++ b/packages/api/src/Http/Controllers/Catalog/BrandController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Shopper\Api\Http\Controllers\Catalog;
 
 use Shopper\Api\Concerns\BuildsApiQueries;
+use Shopper\Api\Concerns\LoadsStock;
 use Shopper\Api\Http\Resources\BrandResource;
 use Shopper\Core\Models\Contracts\Brand;
 use TiMacDonald\JsonApi\JsonApiResource;
@@ -13,12 +14,17 @@ use TiMacDonald\JsonApi\JsonApiResourceCollection;
 final class BrandController
 {
     use BuildsApiQueries;
+    use LoadsStock;
 
     public function index(): JsonApiResourceCollection
     {
         $query = $this->withMediaIfSupported(resolve(Brand::class)::query()->enabled());
 
-        return BrandResource::collection($this->paginated('brand', $query));
+        $brands = $this->paginated('brand', $query);
+
+        $this->loadStockThroughRelation($brands->getCollection());
+
+        return BrandResource::collection($brands);
     }
 
     public function show(string $slug): JsonApiResource
@@ -27,6 +33,8 @@ final class BrandController
             ->with($this->requestedIncludeLoads('brand'))
             ->where('slug', $slug)
             ->firstOrFail();
+
+        $this->loadStockThroughRelation(collect([$brand]));
 
         return BrandResource::make($brand);
     }

--- a/packages/api/src/Http/Controllers/Catalog/CategoryController.php
+++ b/packages/api/src/Http/Controllers/Catalog/CategoryController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Shopper\Api\Http\Controllers\Catalog;
 
 use Shopper\Api\Concerns\BuildsApiQueries;
+use Shopper\Api\Concerns\LoadsStock;
 use Shopper\Api\Http\Resources\CategoryResource;
 use Shopper\Core\Models\Contracts\Category;
 use TiMacDonald\JsonApi\JsonApiResource;
@@ -13,12 +14,17 @@ use TiMacDonald\JsonApi\JsonApiResourceCollection;
 final class CategoryController
 {
     use BuildsApiQueries;
+    use LoadsStock;
 
     public function index(): JsonApiResourceCollection
     {
         $query = $this->withMediaIfSupported(resolve(Category::class)::query()->enabled());
 
-        return CategoryResource::collection($this->paginated('category', $query));
+        $categories = $this->paginated('category', $query);
+
+        $this->loadStockThroughRelation($categories->getCollection());
+
+        return CategoryResource::collection($categories);
     }
 
     public function show(string $slug): JsonApiResource
@@ -27,6 +33,8 @@ final class CategoryController
             ->with($this->requestedIncludeLoads('category'))
             ->where('slug', $slug)
             ->firstOrFail();
+
+        $this->loadStockThroughRelation(collect([$category]));
 
         return CategoryResource::make($category);
     }

--- a/packages/api/src/Http/Controllers/Catalog/ProductController.php
+++ b/packages/api/src/Http/Controllers/Catalog/ProductController.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Shopper\Api\Http\Controllers\Catalog;
 
-use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Model;
 use Shopper\Api\Concerns\BuildsApiQueries;
+use Shopper\Api\Concerns\LoadsStock;
+use Shopper\Api\Http\Includes\RatingAggregate;
 use Shopper\Api\Http\Resources\ProductResource;
 use Shopper\Core\Models\Contracts\Product;
 use TiMacDonald\JsonApi\JsonApiResource;
@@ -15,41 +15,37 @@ use TiMacDonald\JsonApi\JsonApiResourceCollection;
 final class ProductController
 {
     use BuildsApiQueries;
+    use LoadsStock;
 
     public function index(): JsonApiResourceCollection
     {
         $query = $this->withMediaIfSupported(
-            $this->withRatingSummary(resolve(Product::class)::query()->publish()->with('prices.currency'))
+            resolve(Product::class)::query()->publish()->with('prices.currency')
         );
 
-        return ProductResource::collection($this->paginated('product', $query));
+        $products = $this->paginated('product', $query);
+
+        $this->loadStockForProducts($products->getCollection());
+
+        return ProductResource::collection($products);
     }
 
     public function show(string $slug): JsonApiResource
     {
-        $product = $this->withMediaIfSupported(
-            $this->withRatingSummary(resolve(Product::class)::query()->publish()->with('prices.currency'))
+        $query = $this->withMediaIfSupported(
+            resolve(Product::class)::query()->publish()->with('prices.currency')
         )
             ->with($this->requestedIncludeLoads('product'))
-            ->where('slug', $slug)
-            ->firstOrFail();
+            ->where('slug', $slug);
+
+        if ($this->requestedIncludes()->contains('rating')) {
+            (new RatingAggregate)($query, 'rating');
+        }
+
+        $product = $query->firstOrFail();
+
+        $this->loadStockForProducts(collect([$product]));
 
         return ProductResource::make($product);
-    }
-
-    /**
-     * Aggregate the approved-review count and average rating without an N+1,
-     * exposed as `reviews_count` and `average_rating` on each product row.
-     *
-     * @template TModel of Model
-     *
-     * @param  Builder<TModel>  $query
-     * @return Builder<TModel>
-     */
-    private function withRatingSummary(Builder $query): Builder
-    {
-        return $query
-            ->withCount(['ratings as reviews_count' => fn (Builder $query) => $query->where('approved', true)])
-            ->withAvg(['ratings as average_rating' => fn (Builder $query) => $query->where('approved', true)], 'rating');
     }
 }

--- a/packages/api/src/Http/Includes/RatingAggregate.php
+++ b/packages/api/src/Http/Includes/RatingAggregate.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Api\Http\Includes;
+
+use Illuminate\Database\Eloquent\Builder;
+use Spatie\QueryBuilder\Includes\IncludeInterface;
+
+final class RatingAggregate implements IncludeInterface
+{
+    public function __invoke(Builder $query, string $include): void
+    {
+        $query
+            ->withCount(['ratings as reviews_count' => fn (Builder $query) => $query->where('approved', true)])
+            ->withAvg(['ratings as average_rating' => fn (Builder $query) => $query->where('approved', true)], 'rating');
+    }
+}

--- a/packages/api/src/Http/Resources/ProductResource.php
+++ b/packages/api/src/Http/Resources/ProductResource.php
@@ -39,12 +39,13 @@ final class ProductResource extends JsonApiResource
             'seo_title' => $this->seo_title,
             'seo_description' => $this->seo_description,
             'metadata' => $this->metadata,
+            ...($this->isExternal() ? ['external_id' => $this->external_id] : []),
+            ...$this->stockPayload(),
             'prices' => $this->pricesPayload(),
             'images' => $this->imagesPayload(),
             'thumbnail' => $this->thumbnailPayload(),
-            'files' => $this->filesPayload(),
-            'rating' => $this->ratingValue(),
-            'reviews_count' => (int) $this->resource->getAttribute('reviews_count'),
+            ...($this->isVirtual() ? ['files' => $this->filesPayload()] : []),
+            ...$this->ratingPayload(),
             'created_at' => $this->created_at->toIso8601String(),
             'updated_at' => $this->updated_at->toIso8601String(),
         ];
@@ -52,25 +53,78 @@ final class ProductResource extends JsonApiResource
 
     public function toRelationships(Request $request): array
     {
-        return [
+        $relationships = [
             'brand' => fn () => BrandResource::make($this->brand),
-            'variants' => fn () => ProductVariantResource::collection($this->variants),
             'categories' => fn () => CategoryResource::collection($this->categories),
             'collections' => fn () => CollectionResource::collection($this->collections),
-            'options' => fn () => AttributeResource::collection($this->scopedOptions()),
             'relatedProducts' => fn () => ProductResource::collection($this->relatedProducts),
+        ];
+
+        if ($this->canUseVariants()) {
+            $relationships['variants'] = fn () => ProductVariantResource::collection($this->variants);
+        }
+
+        if ($this->canUseAttributes()) {
+            $relationships['options'] = fn () => AttributeResource::collection($this->scopedOptions());
+        }
+
+        return $relationships;
+    }
+
+    /**
+     * @return array<string, int|bool>
+     */
+    private function stockPayload(): array
+    {
+        if ($this->isExternal()) {
+            return [];
+        }
+
+        $raw = $this->resource->getAttributes();
+
+        if ($this->canUseVariants()) {
+            if (! array_key_exists('variants_real_stock', $raw)) {
+                return [];
+            }
+
+            return [
+                'in_stock' => (int) $raw['variants_real_stock'] > 0 || ($raw['variants_allow_backorder'] ?? false),
+            ];
+        }
+
+        if (! array_key_exists('real_stock', $raw)) {
+            return [];
+        }
+
+        $stock = $this->stock;
+
+        return [
+            'stock' => $stock,
+            'in_stock' => $stock > 0 || $this->allow_backorder,
         ];
     }
 
     /**
-     * The average approved rating, rounded to one decimal, or null when the
-     * product has no approved reviews. Read from the withAvg aggregate alias.
+     * Review aggregates only when the client opted in through
+     * `include=rating` (RatingAggregate), never by default. The average is
+     * rounded to one decimal and null without approved reviews.
+     *
+     * @return array<string, int|float|null>
      */
-    private function ratingValue(): ?float
+    private function ratingPayload(): array
     {
-        $average = $this->resource->getAttribute('average_rating');
+        $raw = $this->resource->getAttributes();
 
-        return $average !== null ? round((float) $average, 1) : null;
+        if (! array_key_exists('reviews_count', $raw)) {
+            return [];
+        }
+
+        $average = $raw['average_rating'] ?? null;
+
+        return [
+            'rating' => $average !== null ? round((float) $average, 1) : null,
+            'reviews_count' => (int) $raw['reviews_count'],
+        ];
     }
 
     /**

--- a/packages/api/src/Http/Resources/ProductVariantResource.php
+++ b/packages/api/src/Http/Resources/ProductVariantResource.php
@@ -33,6 +33,7 @@ final class ProductVariantResource extends JsonApiResource
             'upc' => $this->upc,
             'position' => $this->position,
             'allow_backorder' => $this->allow_backorder,
+            ...$this->stockPayload(),
             'metadata' => $this->metadata,
             'prices' => $this->pricesPayload(),
             'values' => $this->optionValuesPayload(),
@@ -47,6 +48,26 @@ final class ProductVariantResource extends JsonApiResource
     {
         return [
             'product' => fn () => ProductResource::make($this->product),
+        ];
+    }
+
+    /**
+     * Stock fields only when batch-loaded by the controller (LoadsStock):
+     * serializing them lazily would run one stock sum query per variant.
+     *
+     * @return array<string, int|bool>
+     */
+    private function stockPayload(): array
+    {
+        if (! array_key_exists('real_stock', $this->resource->getAttributes())) {
+            return [];
+        }
+
+        $stock = $this->stock;
+
+        return [
+            'stock' => $stock,
+            'in_stock' => $stock > 0 || $this->allow_backorder,
         ];
     }
 

--- a/packages/types/src/product.ts
+++ b/packages/types/src/product.ts
@@ -53,10 +53,10 @@ export interface Product extends Entity, SEOFields, ShippingFields {
   published_at: string | null
   /** The external ID of the product. */
   external_id: string | null
-  /** The stock quantity of the product. */
-  stock: number
-  /** The combined stock of all variants. */
-  variants_stock?: number
+  /** The stock quantity of the product (standard and virtual products). */
+  stock?: number
+  /** Whether the product is available for purchase (own or variant stock, or backorderable). */
+  in_stock?: boolean
   /** The supplier ID of the product. */
   supplier_id?: number | null
   /** The brand ID of the product. */

--- a/packages/types/src/product_variant.ts
+++ b/packages/types/src/product_variant.ts
@@ -37,8 +37,10 @@ export interface ProductVariant extends Entity, ShippingFields {
   allow_backorder: boolean
   /** The product ID this variant belongs to. */
   product_id: number
-  /** The stock quantity of the variant (exposed once batched stock loading lands). */
+  /** The stock quantity of the variant. */
   stock?: number
+  /** Whether the variant is available for purchase (in stock or backorderable). */
+  in_stock?: boolean
   /** The metadata of the product variant. */
   metadata: Metadata
   /** The product this variant belongs to. */

--- a/tests/Api/Feature/ProductCatalogTest.php
+++ b/tests/Api/Feature/ProductCatalogTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Illuminate\Support\Facades\DB;
+use Shopper\Core\Enum\ProductType;
 use Shopper\Core\Models\Attribute;
 use Shopper\Core\Models\AttributeValue;
 use Shopper\Core\Models\Brand;
@@ -74,7 +75,7 @@ it('lists only published products', function (): void {
 });
 
 it('eager-loads variant prices when including variants, avoiding N+1', function (): void {
-    $product = publishedProduct(['name' => 'WithVariants']);
+    $product = publishedProduct(['name' => 'WithVariants', 'type' => ProductType::Variant]);
     $currencyId = Currency::query()->value('id');
 
     foreach (range(1, 3) as $i) {
@@ -97,8 +98,9 @@ it('eager-loads variant prices when including variants, avoiding N+1', function 
     expect($variants)->toHaveCount(3)
         ->and($variants->first()['attributes']['prices'])->not->toBeEmpty()
         // Bounded and constant regardless of variant count: prices.currency and
-        // values.attribute are eager-loaded once, never per variant.
-        ->and($queryCount)->toBeLessThanOrEqual(13);
+        // values.attribute are eager-loaded once, never per variant, and stock
+        // is batch-loaded in three queries.
+        ->and($queryCount)->toBeLessThanOrEqual(16);
 });
 
 it('includes the brand relationship on demand', function (): void {
@@ -135,7 +137,7 @@ it('searches products by term', function (): void {
 });
 
 it('exposes variant option values for option matching', function (): void {
-    $product = publishedProduct(['name' => 'Tee']);
+    $product = publishedProduct(['name' => 'Tee', 'type' => ProductType::Variant]);
     $attribute = Attribute::factory()->create(['name' => 'Color']);
     $value = AttributeValue::factory()->create([
         'attribute_id' => $attribute->id,
@@ -156,7 +158,7 @@ it('exposes variant option values for option matching', function (): void {
 });
 
 it('serializes product options as a deduplicated array scoped to the used values', function (): void {
-    $product = publishedProduct(['name' => 'Phone']);
+    $product = publishedProduct(['name' => 'Phone', 'type' => ProductType::Standard]);
     $color = Attribute::factory()->create(['name' => 'Color']);
     $red = AttributeValue::factory()->create(['attribute_id' => $color->id, 'value' => 'Red', 'key' => 'red']);
     $blue = AttributeValue::factory()->create(['attribute_id' => $color->id, 'value' => 'Blue', 'key' => 'blue']);
@@ -175,26 +177,74 @@ it('serializes product options as a deduplicated array scoped to the used values
         ->and($values)->toContain('Red', 'Blue')->not->toContain('Green');
 });
 
-it('exposes the average rating and approved reviews count', function (): void {
+it('exposes the review aggregates only when the rating include is requested', function (): void {
     $product = publishedProduct(['name' => 'Rated']);
     $reviewable = ['reviewrateable_id' => $product->id, 'reviewrateable_type' => $product->getMorphClass()];
     Review::factory()->create([...$reviewable, 'rating' => 4, 'approved' => true]);
     Review::factory()->create([...$reviewable, 'rating' => 5, 'approved' => true]);
     Review::factory()->create([...$reviewable, 'rating' => 1, 'approved' => false]);
 
-    $attributes = $this->getJson('/store/products/'.$product->slug)->assertOk()->json('data.attributes');
+    $default = $this->getJson('/store/products/'.$product->slug)->assertOk()->json('data.attributes');
+    $rated = $this->getJson('/store/products/'.$product->slug.'?include=rating')->assertOk()->json('data.attributes');
 
-    expect($attributes['reviews_count'])->toBe(2)
-        ->and($attributes['rating'])->toBe(4.5);
+    expect($default)->not->toHaveKeys(['rating', 'reviews_count'])
+        ->and($rated['reviews_count'])->toBe(2)
+        ->and($rated['rating'])->toBe(4.5);
 });
 
 it('returns a null rating and zero count without approved reviews', function (): void {
     $product = publishedProduct(['name' => 'Unrated']);
 
-    $this->getJson('/store/products/'.$product->slug)
+    $this->getJson('/store/products/'.$product->slug.'?include=rating')
         ->assertOk()
         ->assertJsonPath('data.attributes.rating', null)
         ->assertJsonPath('data.attributes.reviews_count', 0);
+});
+
+it('includes the review aggregates on the product listing', function (): void {
+    $product = publishedProduct(['name' => 'RatedList']);
+    $reviewable = ['reviewrateable_id' => $product->id, 'reviewrateable_type' => $product->getMorphClass()];
+    Review::factory()->create([...$reviewable, 'rating' => 3, 'approved' => true]);
+    Review::factory()->create([...$reviewable, 'rating' => 4, 'approved' => true]);
+
+    $attributes = collect(
+        $this->getJson('/store/products?filter[name]=RatedList&include=rating')->assertOk()->json('data')
+    )->first()['attributes'];
+
+    expect($attributes['rating'])->toBe(3.5)
+        ->and($attributes['reviews_count'])->toBe(2);
+});
+
+it('shapes the payload by product type', function (): void {
+    publishedProduct(['name' => 'ShapeStandard', 'type' => ProductType::Standard]);
+    publishedProduct(['name' => 'ShapeVariant', 'type' => ProductType::Variant]);
+    publishedProduct(['name' => 'ShapeVirtual', 'type' => ProductType::Virtual]);
+    publishedProduct(['name' => 'ShapeExternal', 'type' => ProductType::External, 'external_id' => 'ext-42']);
+
+    $products = collect($this->getJson('/store/products?filter[name]=Shape')->assertOk()->json('data'))
+        ->keyBy('attributes.name')
+        ->map(fn (array $product): array => $product['attributes']);
+
+    expect($products->get('ShapeStandard'))->toHaveKeys(['stock', 'in_stock'])
+        ->not->toHaveKeys(['files', 'variants_stock', 'external_id'])
+        ->and($products->get('ShapeVariant'))->toHaveKey('in_stock')
+        ->not->toHaveKeys(['stock', 'variants_stock', 'files'])
+        ->and($products->get('ShapeVirtual'))->toHaveKeys(['files', 'stock', 'in_stock'])
+        ->and($products->get('ShapeExternal'))->toMatchArray(['external_id' => 'ext-42'])
+        ->not->toHaveKeys(['stock', 'variants_stock', 'in_stock', 'files']);
+});
+
+it('only exposes the variants and options relationships for capable product types', function (): void {
+    publishedProduct(['name' => 'RelVariant', 'type' => ProductType::Variant]);
+    publishedProduct(['name' => 'RelExternal', 'type' => ProductType::External, 'external_id' => 'ext-1']);
+
+    $products = collect(
+        $this->getJson('/store/products?filter[name]=Rel&include=variants,options')->assertOk()->json('data')
+    )->keyBy('attributes.name');
+
+    expect($products->get('RelVariant')['relationships'])->toHaveKey('variants')
+        ->and($products->get('RelExternal')['relationships'] ?? [])->not->toHaveKey('variants')
+        ->not->toHaveKey('options');
 });
 
 it('paginates with page[size] and page[number]', function (): void {

--- a/tests/Api/Feature/ProductStockTest.php
+++ b/tests/Api/Feature/ProductStockTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Shopper\Core\Models\Category;
+use Shopper\Core\Models\Currency;
+use Shopper\Core\Models\Inventory;
+use Shopper\Core\Models\Price;
+use Shopper\Core\Models\Product;
+use Shopper\Core\Models\ProductVariant;
+
+uses(Tests\Api\TestCase::class);
+
+beforeEach(function (): void {
+    $this->inventory = Inventory::factory()->create([
+        'is_default' => true,
+        'priority' => 0,
+    ]);
+});
+
+function stockedProduct(string $type, array $attributes = []): Product
+{
+    $product = Product::factory()->{$type}()->create($attributes);
+
+    Price::factory()->create([
+        'priceable_id' => $product->id,
+        'priceable_type' => $product->getMorphClass(),
+        'currency_id' => Currency::query()->value('id'),
+        'amount' => 1999,
+    ]);
+
+    return $product;
+}
+
+it('exposes the stock of a standard product', function (): void {
+    $product = stockedProduct('standard', ['name' => 'OwnStock', 'allow_backorder' => false]);
+    $product->mutateStock($this->inventory->id, 7, event: 'Initial');
+
+    $attributes = $this->getJson('/store/products/'.$product->slug)
+        ->assertOk()
+        ->assertJsonPath('data.attributes.stock', 7)
+        ->assertJsonPath('data.attributes.in_stock', true)
+        ->json('data.attributes');
+
+    expect($attributes)->not->toHaveKey('variants_stock');
+});
+
+it('marks a standard product without stock as out of stock', function (): void {
+    $product = stockedProduct('standard', ['name' => 'Depleted', 'allow_backorder' => false]);
+
+    $this->getJson('/store/products/'.$product->slug)
+        ->assertOk()
+        ->assertJsonPath('data.attributes.stock', 0)
+        ->assertJsonPath('data.attributes.in_stock', false);
+});
+
+it('exposes the stock of each included variant', function (): void {
+    $product = stockedProduct('variant', ['name' => 'VariantStock']);
+    $stocked = ProductVariant::factory()->create(['product_id' => $product->id, 'allow_backorder' => false]);
+    $stocked->mutateStock($this->inventory->id, 3, event: 'Initial');
+    $depleted = ProductVariant::factory()->create(['product_id' => $product->id, 'allow_backorder' => false]);
+
+    $variants = collect($this->getJson('/store/products/'.$product->slug.'?include=variants')->assertOk()->json('included'))
+        ->where('type', 'variants')
+        ->keyBy('id');
+
+    expect($variants->get($stocked->public_id)['attributes'])->toMatchArray(['stock' => 3, 'in_stock' => true])
+        ->and($variants->get($depleted->public_id)['attributes'])->toMatchArray(['stock' => 0, 'in_stock' => false]);
+});
+
+it('keeps a zero-stock variant purchasable through backorders', function (): void {
+    $product = stockedProduct('variant', ['name' => 'Backorderable']);
+    ProductVariant::factory()->create(['product_id' => $product->id, 'allow_backorder' => true]);
+
+    $included = collect($this->getJson('/store/products/'.$product->slug.'?include=variants')->assertOk()->json('included'))
+        ->firstWhere('type', 'variants');
+
+    expect($included['attributes']['stock'])->toBe(0)
+        ->and($included['attributes']['in_stock'])->toBeTrue();
+});
+
+it('exposes the variant product availability through its variants on the listing', function (): void {
+    $product = stockedProduct('variant', ['name' => 'StockedByVariants']);
+    $variant = ProductVariant::factory()->create(['product_id' => $product->id, 'allow_backorder' => false]);
+    $variant->mutateStock($this->inventory->id, 5, event: 'Initial');
+
+    $attributes = collect($this->getJson('/store/products?filter[name]=StockedByVariants')->assertOk()->json('data'))
+        ->first()['attributes'];
+
+    expect($attributes)->not->toHaveKeys(['stock', 'variants_stock'])
+        ->and($attributes['in_stock'])->toBeTrue();
+});
+
+it('exposes stock on products included in a category', function (): void {
+    $category = Category::factory()->create(['name' => 'Stocked Gear', 'is_enabled' => true]);
+    $product = stockedProduct('standard', ['name' => 'CategorizedStock', 'allow_backorder' => false]);
+    $product->mutateStock($this->inventory->id, 4, event: 'Initial');
+    $product->categories()->attach($category);
+
+    $included = collect(
+        $this->getJson('/store/categories/'.$category->slug.'?include=products')->assertOk()->json('included')
+    )->firstWhere('type', 'products');
+
+    expect($included['attributes']['stock'])->toBe(4)
+        ->and($included['attributes']['in_stock'])->toBeTrue();
+});
+
+it('batch-loads stock without lazy queries and with a constant query count', function (): void {
+    Product::preventLazyStockLoading();
+    ProductVariant::preventLazyStockLoading();
+
+    try {
+        foreach (range(1, 2) as $i) {
+            stockedProduct('standard', ['name' => 'BulkStock standard '.$i, 'allow_backorder' => false])
+                ->mutateStock($this->inventory->id, $i, event: 'Initial');
+
+            $product = stockedProduct('variant', ['name' => 'BulkStock variant '.$i]);
+            $variant = ProductVariant::factory()->create(['product_id' => $product->id, 'allow_backorder' => false]);
+            $variant->mutateStock($this->inventory->id, $i, event: 'Initial');
+        }
+
+        DB::enableQueryLog();
+        $response = $this->getJson('/store/products?filter[name]=BulkStock&include=variants')->assertOk();
+        $queryCount = count(DB::getQueryLog());
+        DB::disableQueryLog();
+
+        expect($response->json('data'))->toHaveCount(4)
+            // Bounded and constant regardless of product or variant count: the
+            // products', variants', and aggregate stock are three batch queries.
+            ->and($queryCount)->toBeLessThanOrEqual(16);
+    } finally {
+        Product::preventLazyStockLoading(false);
+        ProductVariant::preventLazyStockLoading(false);
+    }
+});


### PR DESCRIPTION
## What

Continues the storefront API work from #538 with the deferred stock exposure, and reshapes the product payloads around the product type constraints.

### Stock

New `LoadsStock` concern batch-loads stock for store endpoints before serialization, in a constant number of queries regardless of page size or variant count:

- products own stock through `HasStock::loadCurrentStock()`
- per-variant stock for included variants
- a per-product variant aggregate (one `LEFT JOIN` on inventory histories) so a variant product stays correct on listings that do not include variants

Variants expose `stock` and `in_stock` (stock or backorder). Wired into the product, category, and brand controllers, including `include=products`.

### Resources shaped by product type

Product payloads now mirror the admin constraints instead of returning the same shape for every type:

| Field | Standard | Variant | Virtual | External |
|---|---|---|---|---|
| `stock` / `in_stock` | own stock | `in_stock` only, derived from variants | own stock | none |
| `files` | no | no | yes | no |
| `external_id` | no | no | no | yes |
| `variants` relationship | no | yes | no | no |
| `options` relationship | yes | yes | yes | no |

A variant product does not expose an aggregated stock count: each included variant carries its own stock, and the scoped `options` plus each variant `values` give a storefront everything needed to resolve a selected option combination to a variant.

### Rating opt-in

`rating` and `reviews_count` move behind `include=rating`, handled by a custom spatie include (`RatingAggregate`). The aggregates are no longer computed on every request, and the `includes` config now accepts `name => class-string` descriptors for custom includes.

### Types

`@shopperlabs/shopper-types`: `Product.stock` becomes optional, `in_stock` added on `Product` and `ProductVariant`, `variants_stock` removed.