### PR TITLE
feat(api): guest and customer cart endpoints

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -1,8 +1,8 @@
 # Shopper API
 
-The headless Store API for [Shopper](https://shopper.cloud). It exposes the catalog, geo data,
-customer authentication and account endpoints as a [JSON:API](https://jsonapi.org) under the
-`/store` prefix, ready to be consumed by any storefront or by the official
+The headless Store API for [Shopper](https://laravelshopper.me). It exposes the catalog, geo data,
+cart, customer authentication and account endpoints as a [JSON:API](https://jsonapi.org) under
+the `/store` prefix, ready to be consumed by any storefront or by the official
 [`@shopperlabs/shopper-sdk`](https://www.npmjs.com/package/@shopperlabs/shopper-sdk) JavaScript client.
 
 ## Requirements
@@ -68,6 +68,7 @@ and answer in `application/vnd.api+json`.
 |---|---|
 | Catalog | `GET /store/products[/{slug}]`, `categories`, `collections`, `brands`, `attributes` |
 | Geo | `GET /store/countries[/{code}]`, `zones[/{code}]`, `currencies[/{code}]` |
+| Cart | `POST /store/carts`, `GET /store/carts/{id}`, `POST /store/carts/{id}/lines`, `PATCH/DELETE /store/carts/{id}/lines/{lineId}` |
 | Auth | `POST /store/auth/register`, `login`, `logout`, `forgot-password`, `reset-password` |
 | Account | `GET/PATCH /store/customers/me`, `POST/DELETE /store/customers/me/avatar`, addresses CRUD, `GET /store/customers/me/orders` |
 
@@ -95,6 +96,85 @@ X-Shopper-Zone: eu
 
 The resolver is swappable through `shopper.http.zone.resolver` if you prefer resolving the
 zone from a country, a geo-ip lookup, or any custom strategy.
+
+## Cart
+
+The cart works for guests and authenticated customers with the same endpoints. Create one,
+persist its id on the client (cookie, localStorage), then drive it through the line endpoints:
+
+```
+POST   /store/carts                        → 201, the new cart
+GET    /store/carts/{id}                   → 200, summary + totals
+POST   /store/carts/{id}/lines             → 200, add a purchasable
+PATCH  /store/carts/{id}/lines/{lineId}    → 200, change quantity / metadata
+DELETE /store/carts/{id}/lines/{lineId}    → 200, remove the line
+```
+
+Every response is the full cart document, recalculated by the `shopper/cart` pipelines
+(lines, coupon discounts, taxes), so the storefront never needs a follow-up call to refresh
+totals. All amounts are integers in cents.
+
+```json
+{
+  "data": {
+    "type": "carts",
+    "id": "01jxd9se2cd6kr925vqgve46rb",
+    "attributes": {
+      "currency_code": "USD",
+      "coupon_code": "SAVE20",
+      "lines_count": 1,
+      "lines_quantity": 2,
+      "subtotal": 5000,
+      "discount_total": 1000,
+      "tax_total": 400,
+      "total": 4400,
+      "tax_inclusive": false
+    }
+  }
+}
+```
+
+### Includes
+
+The cart document is partitioned: the attributes above are the cheap summary (enough for a
+header badge), everything heavier is an opt-in [JSON:API include](https://jsonapi.org/format/#fetching-includes):
+
+| Include | Expands |
+|---|---|
+| `lines` | The cart lines with their computed amounts (`subtotal`, `discount_total`, `tax_total`), applied `adjustments` and `tax_lines` |
+| `lines.purchasable` | The full product or variant behind each line, typed by the line's `purchasable_type` |
+| `addresses` | The shipping and billing addresses attached to the cart |
+
+```
+GET /store/carts/{id}?include=lines.purchasable,addresses
+```
+
+The `include` parameter works on the line endpoints too, so a `POST .../lines?include=lines`
+answers with the updated lines in the same round trip.
+
+### Adding to the cart
+
+Lines target a purchasable through its public id and a type discriminator:
+
+```json
+{
+  "purchasable_type": "variant",
+  "purchasable_id": "01jxd9se2cd6kr925vqgve46rb",
+  "quantity": 2,
+  "metadata": { "engraving": "MC" }
+}
+```
+
+Line operations are idempotent on the purchasable: adding the same product or variant again
+increments the existing line instead of creating a duplicate. The API refuses anything a
+storefront cannot sell, draft products, external products, products that sell through their
+variants, or a purchasable without a price in the cart currency, with a `422` validation error.
+
+### Ownership
+
+A guest cart is a capability URL: whoever holds the ULID can read and mutate it. A cart
+created with a Bearer token belongs to that customer, and any other caller gets a `404`
+indistinguishable from a missing cart. Mutating a completed cart answers `409 Conflict`.
 
 ## Authentication flow
 
@@ -129,6 +209,26 @@ const me = await sdk.store.customer.me()
 const { data } = await sdk.store.product.list({ include: ['variants', 'brand'] })
 ```
 
+The cart module mirrors the cart endpoints and asks for the `lines` include by default, so
+`cart.lines` is always populated. Pass your own `include` to slim it down or expand more:
+
+```ts
+let cart = await sdk.store.cart.create({ currency_code: 'USD' })
+
+cart = await sdk.store.cart.createLineItem(cart.id, {
+  purchasable_type: 'variant',
+  purchasable_id: variant.public_id,
+  quantity: 2,
+})
+
+cart = await sdk.store.cart.updateLineItem(cart.id, cart.lines[0].id, { quantity: 3 })
+cart = await sdk.store.cart.deleteLineItem(cart.id, cart.lines[0].id)
+
+// Header badge: skip the lines entirely
+const summary = await sdk.store.cart.retrieve(cart.id, { include: [] })
+console.log(summary.lines_quantity, summary.total)
+```
+
 ## License
 
-Shopper API is open-sourced software licensed under the [MIT license](https://github.com/shopperlabs/shopper/blob/2.x/LICENSE.md).
+Shopper API is open-sourced software licensed under the [MIT license](https://github.com/shopperlabs/shopper/blob/3.x/LICENSE.md).

--- a/packages/api/composer.json
+++ b/packages/api/composer.json
@@ -11,6 +11,8 @@
   "require": {
     "php": "^8.3",
     "dedoc/scramble": "^0.13",
+    "laravel/prompts": "^0.3.16",
+    "shopper/cart": "*",
     "shopper/core": "*",
     "shopper/http": "*",
     "spatie/laravel-medialibrary": "^11.5",

--- a/packages/api/routes/store.php
+++ b/packages/api/routes/store.php
@@ -8,6 +8,7 @@ ShopperApi::store(function (): void {
     require __DIR__.'/store/catalog.php';
     require __DIR__.'/store/geo.php';
     require __DIR__.'/store/auth.php';
+    require __DIR__.'/store/cart.php';
 });
 
 ShopperApi::authenticated(function (): void {

--- a/packages/api/routes/store/cart.php
+++ b/packages/api/routes/store/cart.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Route;
+use Shopper\Api\Http\Controllers\Cart\CartController;
+use Shopper\Api\Http\Controllers\Cart\CartLineController;
+
+Route::post('/carts', [CartController::class, 'store']);
+Route::get('/carts/{cartId}', [CartController::class, 'show']);
+Route::post('/carts/{cartId}/lines', [CartLineController::class, 'store']);
+Route::patch('/carts/{cartId}/lines/{lineId}', [CartLineController::class, 'update']);
+Route::delete('/carts/{cartId}/lines/{lineId}', [CartLineController::class, 'destroy']);

--- a/packages/api/src/Actions/ResolvePurchasableAction.php
+++ b/packages/api/src/Actions/ResolvePurchasableAction.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Api\Actions;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Validation\ValidationException;
+use Shopper\Core\Contracts\Priceable;
+use Shopper\Core\Enum\ProductType;
+use Shopper\Core\Models\Contracts\Product;
+use Shopper\Core\Models\Contracts\ProductVariant;
+use Shopper\Core\Models\Price;
+
+final class ResolvePurchasableAction
+{
+    public function execute(string $type, string $publicId, string $currencyCode): Priceable&Model
+    {
+        $purchasable = $type === 'variant'
+            ? $this->findVariant($publicId)
+            : $this->findProduct($publicId);
+
+        if (! $purchasable instanceof Priceable) {
+            throw ValidationException::withMessages([
+                'purchasable_id' => __('This product is not available for purchase.'),
+            ]);
+        }
+
+        if ($purchasable instanceof Product && $purchasable->canUseVariants()) {
+            throw ValidationException::withMessages([
+                'purchasable_id' => __('This product is sold through its variants, add one of them instead.'),
+            ]);
+        }
+
+        if (! $purchasable->getPrice($currencyCode) instanceof Price) {
+            throw ValidationException::withMessages([
+                'purchasable_id' => __('This product has no price for the :currency currency.', ['currency' => $currencyCode]),
+            ]);
+        }
+
+        return $purchasable;
+    }
+
+    /**
+     * @return (Priceable&Model)|null
+     */
+    private function findProduct(string $publicId): ?Model
+    {
+        return resolve(Product::class)::query()
+            ->publish()
+            ->where('type', '<>', ProductType::External->value)
+            ->wherePublicId($publicId)
+            ->first();
+    }
+
+    /**
+     * @return (Priceable&Model)|null
+     */
+    private function findVariant(string $publicId): ?Model
+    {
+        $variant = resolve(ProductVariant::class)::query()
+            ->wherePublicId($publicId)
+            ->first();
+
+        if (! $variant instanceof Model || ! $variant instanceof Priceable) {
+            return null;
+        }
+
+        $parentIsPublished = resolve(Product::class)::query()
+            ->publish()
+            ->whereKey($variant->getAttribute('product_id'))
+            ->exists();
+
+        return $parentIsPublished ? $variant : null;
+    }
+}

--- a/packages/api/src/Concerns/RespondsWithCart.php
+++ b/packages/api/src/Concerns/RespondsWithCart.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Api\Concerns;
+
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Http\Request;
+use Shopper\Api\Http\Resources\CartResource;
+use Shopper\Cart\CartManager;
+use Shopper\Cart\Models\Cart;
+use Shopper\Core\Models\Contracts\Cart as CartContract;
+
+trait RespondsWithCart
+{
+    protected function findCart(Request $request, string $publicId): Cart
+    {
+        /** @var Cart|null $cart */
+        $cart = resolve(CartContract::class)::query()->wherePublicId($publicId)->first();
+
+        if (
+            ! $cart
+            || ($cart->customer_id !== null && $cart->customer_id !== $request->user('sanctum')?->getAuthIdentifier())
+        ) {
+            throw (new ModelNotFoundException)->setModel(Cart::class, [$publicId]);
+        }
+
+        return $cart;
+    }
+
+    /**
+     * Every cart response carries the totals computed by the cart pipelines,
+     * so a single GET is enough to render the cart. Relations are reloaded
+     * after the run because the pipelines rewrite adjustments and tax lines;
+     * whether they are serialized is up to the client through `include`.
+     */
+    protected function cartResource(Cart $cart): CartResource
+    {
+        $context = resolve(CartManager::class)->calculate($cart);
+
+        $cart->load(['lines.purchasable', 'lines.adjustments', 'lines.taxLines', 'addresses.country']);
+
+        return CartResource::make($cart)->withTotals($context);
+    }
+}

--- a/packages/api/src/Http/Controllers/Cart/CartController.php
+++ b/packages/api/src/Http/Controllers/Cart/CartController.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Api\Http\Controllers\Cart;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Shopper\Api\Concerns\RespondsWithCart;
+use Shopper\Api\Http\Requests\Cart\CreateCartRequest;
+use Shopper\Cart\Models\Cart;
+use Shopper\Core\Models\Contracts\Cart as CartContract;
+use Shopper\Core\Models\Zone;
+use Symfony\Component\HttpFoundation\Response;
+use TiMacDonald\JsonApi\JsonApiResource;
+
+final class CartController
+{
+    use RespondsWithCart;
+
+    /**
+     * Create a cart.
+     *
+     * Starts a guest cart, or a customer cart when the request carries a
+     * Sanctum token. The currency falls back to the resolved zone, then to
+     * the shop default. Persist the returned id on the client: it is the only
+     * way back to a guest cart.
+     */
+    public function store(CreateCartRequest $request): JsonResponse
+    {
+        /** @var Zone|null $zone */
+        $zone = $request->attributes->get('shopper_zone');
+
+        /** @var Cart $cart */
+        $cart = resolve(CartContract::class)::query()->create([
+            'currency_code' => $request->validated('currency_code')
+                ?? ($zone?->currency_id ? $zone->currency_code : shopper_currency()),
+            'customer_id' => $request->user('sanctum')?->getAuthIdentifier(),
+            'zone_id' => $zone?->id,
+            'metadata' => $request->validated('metadata'),
+        ]);
+
+        $response = $this->cartResource($cart)->toResponse($request);
+
+        return $response->setStatusCode(Response::HTTP_CREATED);
+    }
+
+    /**
+     * Retrieve a cart.
+     *
+     * Returns the cart summary with its pipeline-computed totals. Expand the
+     * heavy parts on demand: `include=lines`, `include=lines.purchasable`,
+     * `include=addresses`.
+     */
+    public function show(Request $request, string $cartId): JsonApiResource
+    {
+        return $this->cartResource($this->findCart($request, $cartId));
+    }
+}

--- a/packages/api/src/Http/Controllers/Cart/CartLineController.php
+++ b/packages/api/src/Http/Controllers/Cart/CartLineController.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Api\Http\Controllers\Cart;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Validation\ValidationException;
+use Shopper\Api\Actions\ResolvePurchasableAction;
+use Shopper\Api\Concerns\RespondsWithCart;
+use Shopper\Api\Http\Requests\Cart\StoreCartLineRequest;
+use Shopper\Api\Http\Requests\Cart\UpdateCartLineRequest;
+use Shopper\Cart\CartManager;
+use Shopper\Cart\Exceptions\CartCompletedException;
+use Shopper\Cart\Exceptions\InsufficientStockException;
+use Shopper\Cart\Models\Cart;
+use Shopper\Cart\Models\CartLine;
+use Symfony\Component\HttpFoundation\Response;
+use TiMacDonald\JsonApi\JsonApiResource;
+
+final class CartLineController
+{
+    use RespondsWithCart;
+
+    public function __construct(
+        private readonly CartManager $cartManager,
+    ) {}
+
+    /**
+     * Add a line to the cart.
+     *
+     * Idempotent on the purchasable: adding the same product or variant again
+     * increments the existing line instead of duplicating it. Responds with
+     * the updated cart; pass `include=lines` to get the lines back.
+     */
+    public function store(StoreCartLineRequest $request, ResolvePurchasableAction $action, string $cartId): JsonApiResource
+    {
+        $cart = $this->findCart($request, $cartId);
+
+        $purchasable = $action->execute(
+            type: (string) $request->validated('purchasable_type'),
+            publicId: (string) $request->validated('purchasable_id'),
+            currencyCode: $cart->currency_code,
+        );
+
+        $this->mutateCart(fn (): CartLine => $this->cartManager->add(
+            cart: $cart,
+            purchasable: $purchasable,
+            quantity: (int) ($request->validated('quantity') ?? 1),
+            metadata: $request->validated('metadata'),
+        ));
+
+        return $this->cartResource($cart);
+    }
+
+    /**
+     * Update a cart line.
+     *
+     * Changes the quantity or the metadata of a line, then responds with the
+     * recalculated cart.
+     */
+    public function update(UpdateCartLineRequest $request, string $cartId, string $lineId): JsonApiResource
+    {
+        $cart = $this->findCart($request, $cartId);
+        $line = $this->findLine($cart, $lineId);
+
+        $this->mutateCart(fn (): CartLine => $this->cartManager->update($cart, $line->id, $request->validated()));
+
+        return $this->cartResource($cart);
+    }
+
+    /**
+     * Remove a cart line.
+     *
+     * Deletes the line and responds with the recalculated cart rather than a
+     * 204, so the storefront can refresh totals without a second call.
+     */
+    public function destroy(Request $request, string $cartId, string $lineId): JsonApiResource
+    {
+        $cart = $this->findCart($request, $cartId);
+        $line = $this->findLine($cart, $lineId);
+
+        $this->mutateCart(fn () => $this->cartManager->remove($cart, $line->id));
+
+        return $this->cartResource($cart);
+    }
+
+    private function findLine(Cart $cart, string $publicId): CartLine
+    {
+        /** @var CartLine */
+        return $cart->lines()->wherePublicId($publicId)->firstOrFail();
+    }
+
+    /**
+     * Domain failures from the cart manager become HTTP semantics: a stock
+     * shortage is a validation error on the quantity, touching a completed
+     * cart is a conflict.
+     */
+    private function mutateCart(Closure $operation): void
+    {
+        try {
+            $operation();
+        } catch (InsufficientStockException $exception) {
+            throw ValidationException::withMessages(['quantity' => $exception->getMessage()]);
+        } catch (CartCompletedException $exception) {
+            abort(Response::HTTP_CONFLICT, $exception->getMessage());
+        }
+    }
+}

--- a/packages/api/src/Http/Requests/Cart/CreateCartRequest.php
+++ b/packages/api/src/Http/Requests/Cart/CreateCartRequest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Api\Http\Requests\Cart;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+final class CreateCartRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, array<int, mixed>>
+     */
+    public function rules(): array
+    {
+        return [
+            'currency_code' => [
+                'nullable',
+                'string',
+                Rule::exists(shopper_table('currencies'), 'code')->where('is_enabled', true),
+            ],
+            'metadata' => ['nullable', 'array'],
+        ];
+    }
+
+    protected function prepareForValidation(): void
+    {
+        if ($this->filled('currency_code')) {
+            $this->merge(['currency_code' => mb_strtoupper((string) $this->string('currency_code'))]);
+        }
+    }
+}

--- a/packages/api/src/Http/Requests/Cart/StoreCartLineRequest.php
+++ b/packages/api/src/Http/Requests/Cart/StoreCartLineRequest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Api\Http\Requests\Cart;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+final class StoreCartLineRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, array<int, mixed>>
+     */
+    public function rules(): array
+    {
+        return [
+            'purchasable_type' => ['required', 'string', Rule::in(['product', 'variant'])],
+            'purchasable_id' => ['required', 'string'],
+            'quantity' => ['nullable', 'integer', 'min:1'],
+            'metadata' => ['nullable', 'array'],
+        ];
+    }
+}

--- a/packages/api/src/Http/Requests/Cart/UpdateCartLineRequest.php
+++ b/packages/api/src/Http/Requests/Cart/UpdateCartLineRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Api\Http\Requests\Cart;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+final class UpdateCartLineRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, array<int, mixed>>
+     */
+    public function rules(): array
+    {
+        return [
+            'quantity' => ['sometimes', 'integer', 'min:1'],
+            'metadata' => ['sometimes', 'nullable', 'array'],
+        ];
+    }
+}

--- a/packages/api/src/Http/Resources/CartAddressResource.php
+++ b/packages/api/src/Http/Resources/CartAddressResource.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Api\Http\Resources;
+
+use Illuminate\Http\Request;
+use Shopper\Cart\Models\CartAddress;
+
+/**
+ * @mixin CartAddress
+ */
+final class CartAddressResource extends JsonApiResource
+{
+    public function toType(Request $request): string
+    {
+        return 'cart-addresses';
+    }
+
+    public function toAttributes(Request $request): array
+    {
+        return [
+            'type' => $this->type->value,
+            'first_name' => $this->first_name,
+            'last_name' => $this->last_name,
+            'full_name' => $this->full_name,
+            'company' => $this->company,
+            'address_1' => $this->address_1,
+            'address_2' => $this->address_2,
+            'city' => $this->city,
+            'state' => $this->state,
+            'postal_code' => $this->postal_code,
+            'country_code' => $this->country?->cca2,
+            'phone' => $this->phone,
+        ];
+    }
+}

--- a/packages/api/src/Http/Resources/CartLineResource.php
+++ b/packages/api/src/Http/Resources/CartLineResource.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Api\Http\Resources;
+
+use Illuminate\Http\Request;
+use Shopper\Cart\Models\CartLine;
+use Shopper\Cart\Models\CartLineAdjustment;
+use Shopper\Cart\Models\CartLineTaxLine;
+use Shopper\Core\Models\Contracts\ProductVariant;
+use TiMacDonald\JsonApi\JsonApiResource as BaseJsonApiResource;
+
+/**
+ * @mixin CartLine
+ */
+final class CartLineResource extends JsonApiResource
+{
+    public function toType(Request $request): string
+    {
+        return 'cart-lines';
+    }
+
+    public function toAttributes(Request $request): array
+    {
+        $subtotal = $this->unit_price_amount * $this->quantity;
+
+        return [
+            'purchasable_type' => $this->purchasable instanceof ProductVariant ? 'variant' : 'product',
+            'quantity' => $this->quantity,
+            'unit_price_amount' => $this->unit_price_amount,
+            'subtotal' => $subtotal,
+            'discount_total' => (int) $this->adjustments->sum('amount'),
+            'tax_total' => (int) $this->taxLines->sum('amount'),
+            'adjustments' => $this->adjustmentsPayload(),
+            'tax_lines' => $this->taxLinesPayload(),
+            'metadata' => $this->metadata,
+            'created_at' => $this->created_at->toIso8601String(),
+            'updated_at' => $this->updated_at->toIso8601String(),
+        ];
+    }
+
+    public function toRelationships(Request $request): array
+    {
+        return [
+            'purchasable' => fn (): BaseJsonApiResource => $this->purchasable instanceof ProductVariant
+                ? ProductVariantResource::make($this->purchasable)
+                : ProductResource::make($this->purchasable),
+        ];
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function adjustmentsPayload(): array
+    {
+        return $this->adjustments->map(fn (CartLineAdjustment $adjustment): array => [
+            'amount' => (int) $adjustment->amount,
+            'code' => $adjustment->code,
+        ])->values()->all();
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function taxLinesPayload(): array
+    {
+        return $this->taxLines->map(fn (CartLineTaxLine $taxLine): array => [
+            'code' => $taxLine->code,
+            'name' => $taxLine->name,
+            'rate' => (float) $taxLine->rate,
+            'amount' => (int) $taxLine->amount,
+        ])->values()->all();
+    }
+}

--- a/packages/api/src/Http/Resources/CartResource.php
+++ b/packages/api/src/Http/Resources/CartResource.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Api\Http\Resources;
+
+use Illuminate\Http\Request;
+use Shopper\Cart\Models\Cart;
+use Shopper\Cart\Pipelines\CartPipelineContext;
+use TiMacDonald\JsonApi\JsonApiResourceCollection;
+
+/**
+ * @mixin Cart
+ */
+final class CartResource extends JsonApiResource
+{
+    private ?CartPipelineContext $totals = null;
+
+    public function withTotals(CartPipelineContext $context): self
+    {
+        $this->totals = $context;
+
+        return $this;
+    }
+
+    public function toType(Request $request): string
+    {
+        return 'carts';
+    }
+
+    public function toAttributes(Request $request): array
+    {
+        return [
+            'currency_code' => $this->currency_code,
+            'coupon_code' => $this->coupon_code,
+            'completed_at' => $this->completed_at?->toIso8601String(),
+            'metadata' => $this->metadata,
+            'lines_count' => $this->lines->count(),
+            'lines_quantity' => (int) $this->lines->sum('quantity'),
+            'subtotal' => $this->totals->subtotal ?? 0,
+            'discount_total' => $this->totals->discountTotal ?? 0,
+            'tax_total' => $this->totals->taxTotal ?? 0,
+            'total' => $this->totals->total ?? 0,
+            'tax_inclusive' => $this->totals->taxInclusive ?? false,
+            'created_at' => $this->created_at->toIso8601String(),
+            'updated_at' => $this->updated_at->toIso8601String(),
+        ];
+    }
+
+    public function toRelationships(Request $request): array
+    {
+        return [
+            'lines' => fn (): JsonApiResourceCollection => CartLineResource::collection($this->lines),
+            'addresses' => fn (): JsonApiResourceCollection => CartAddressResource::collection($this->addresses),
+        ];
+    }
+}

--- a/packages/cart/src/Discounts/DiscountCalculator.php
+++ b/packages/cart/src/Discounts/DiscountCalculator.php
@@ -42,6 +42,11 @@ final readonly class DiscountCalculator
             ->whereIn('cart_line_id', $context->cart->lines->pluck('id'))
             ->delete();
 
+        // The runner eager-loads `lines.adjustments` before the pipeline runs:
+        // without dropping the cached relation, later pipes (tax) would compute
+        // on the adjustments as they were before this rewrite.
+        $context->cart->lines->each(fn (CartLine $line) => $line->unsetRelation('adjustments'));
+
         $applicableLines = $this->getApplicableLines($discount, $context);
 
         if ($applicableLines->isEmpty()) {

--- a/packages/cart/src/Models/CartLine.php
+++ b/packages/cart/src/Models/CartLine.php
@@ -26,7 +26,7 @@ use Shopper\Core\Traits\HasModelContract;
  * @property-read CarbonInterface $created_at
  * @property-read CarbonInterface $updated_at
  * @property-read Cart $cart
- * @property-read Model $purchasable
+ * @property-read ?Model $purchasable
  * @property-read Collection<int, CartLineAdjustment> $adjustments
  * @property-read Collection<int, CartLineTaxLine> $taxLines
  */

--- a/packages/sdk/src/store.ts
+++ b/packages/sdk/src/store.ts
@@ -2,6 +2,7 @@ import type {
   Address,
   Attribute,
   Brand,
+  Cart,
   Category,
   Collection,
   Country,
@@ -65,6 +66,94 @@ class CustomerAddressResource {
 
   public async delete(id: string): Promise<void> {
     await this.client.send('DELETE', `${this.path}/${id}`)
+  }
+}
+
+export type CreateCartPayload = {
+  /** ISO currency code the cart prices in. Defaults to the zone or shop currency. */
+  currency_code?: string
+  metadata?: Record<string, unknown> | null
+}
+
+export type CreateCartLinePayload = {
+  /** Public id of the product or variant to add. */
+  purchasable_id: string
+  purchasable_type: 'product' | 'variant'
+  /** Defaults to 1. Adding the same purchasable again increments the existing line. */
+  quantity?: number
+  metadata?: Record<string, unknown> | null
+}
+
+export type UpdateCartLinePayload = {
+  quantity?: number
+  metadata?: Record<string, unknown> | null
+}
+
+/**
+ * Guest and customer carts. A cart is addressed by its public id: persist it
+ * (cookie, localStorage) to reuse the cart across visits. When a customer
+ * token is set, carts created through create() belong to that customer and
+ * are hidden from anyone else.
+ *
+ * Every call answers with the cart summary and its pipeline-computed totals.
+ * The API keeps lines and addresses behind JSON:API includes; the SDK asks
+ * for `lines` by default so `cart.lines` is always populated. Pass your own
+ * `include` to change that: `[]` for the bare summary (header badge),
+ * `['lines.purchasable']` to also expand products and variants,
+ * `['addresses']` for the checkout addresses.
+ */
+export class CartModule {
+  private readonly path: string
+
+  public constructor(private readonly client: HttpClient) {
+    this.path = `/${client.storePrefix}/carts`
+  }
+
+  public async create(payload: CreateCartPayload = {}, params?: RequestParams): Promise<Cart> {
+    const document = await this.client.send('POST', this.path, payload, this.params(params))
+
+    return flatten<Cart>(document as NonNullable<typeof document>) as Cart
+  }
+
+  public async retrieve(id: string, params?: RequestParams): Promise<Cart> {
+    return flatten<Cart>(await this.client.request(`${this.path}/${id}`, this.params(params))) as Cart
+  }
+
+  public async createLineItem(cartId: string, payload: CreateCartLinePayload, params?: RequestParams): Promise<Cart> {
+    const document = await this.client.send('POST', `${this.path}/${cartId}/lines`, payload, this.params(params))
+
+    return flatten<Cart>(document as NonNullable<typeof document>) as Cart
+  }
+
+  public async updateLineItem(
+    cartId: string,
+    lineId: string,
+    payload: UpdateCartLinePayload,
+    params?: RequestParams,
+  ): Promise<Cart> {
+    const document = await this.client.send(
+      'PATCH',
+      `${this.path}/${cartId}/lines/${lineId}`,
+      payload,
+      this.params(params),
+    )
+
+    return flatten<Cart>(document as NonNullable<typeof document>) as Cart
+  }
+
+  public async deleteLineItem(cartId: string, lineId: string, params?: RequestParams): Promise<Cart> {
+    const document = await this.client.send(
+      'DELETE',
+      `${this.path}/${cartId}/lines/${lineId}`,
+      undefined,
+      this.params(params),
+    )
+
+    return flatten<Cart>(document as NonNullable<typeof document>) as Cart
+  }
+
+  private params(params?: RequestParams): RequestParams {
+    return { include: ['lines'], ...params }
   }
 }
 
@@ -139,6 +228,8 @@ export class StoreModule {
 
   public readonly customer: CustomerModule
 
+  public readonly cart: CartModule
+
   public constructor(private readonly client: HttpClient) {
     const prefix = `/${client.storePrefix}`
 
@@ -151,6 +242,7 @@ export class StoreModule {
     this.zone = new CollectionResource<Zone>(client, `${prefix}/zones`)
     this.currency = new CollectionResource<Currency>(client, `${prefix}/currencies`)
     this.customer = new CustomerModule(client)
+    this.cart = new CartModule(client)
   }
 
   /**

--- a/packages/types/src/cart.ts
+++ b/packages/types/src/cart.ts
@@ -3,6 +3,8 @@ import type { Entity, Metadata } from './common'
 import type { Country } from './country'
 import type { Customer } from './customer'
 import type { Discount } from './discount'
+import type { Product } from './product'
+import type { ProductVariant } from './product_variant'
 import type { TaxRate } from './tax'
 import type { Zone } from './zone'
 
@@ -23,6 +25,20 @@ export interface Cart extends Entity {
   completed_at: string | null
   /** The metadata of the cart. */
   metadata: Metadata
+  /** The number of lines in the cart (store API). */
+  lines_count?: number
+  /** The sum of the line quantities (store API). */
+  lines_quantity?: number
+  /** The sum of the line subtotals in cents, computed by the cart pipelines (store API). */
+  subtotal?: number
+  /** The discount total in cents, computed by the cart pipelines (store API). */
+  discount_total?: number
+  /** The tax total in cents, computed by the cart pipelines (store API). */
+  tax_total?: number
+  /** The cart total in cents, computed by the cart pipelines (store API). */
+  total?: number
+  /** Whether taxes are already included in the prices (store API). */
+  tax_inclusive?: boolean
   /** The customer ID. */
   customer_id: number | null
   /** The channel ID. */
@@ -42,29 +58,37 @@ export interface Cart extends Entity {
 }
 
 /**
- * CartLine model.
+ * CartLine model. The store API serializes a line with its computed amounts
+ * and exposes the purchasable as an expandable relationship
+ * (`include=lines.purchasable`), typed by `purchasable_type`.
  */
 export interface CartLine extends Entity {
   /** The cart ID. */
-  cart_id: number
-  /** The morph type of the purchasable entity. */
-  purchasable_type: string
+  cart_id?: number
+  /** Whether the line holds a product or one of its variants. */
+  purchasable_type?: 'product' | 'variant' | string
   /** The morph ID of the purchasable entity. */
-  purchasable_id: number
+  purchasable_id?: number
   /** The quantity of the cart line. */
   quantity: number
   /** The unit price amount (in cents). */
   unit_price_amount: number
+  /** The line subtotal in cents (unit price times quantity, store API). */
+  subtotal?: number
+  /** The discount amount applied to this line in cents (store API). */
+  discount_total?: number
+  /** The tax amount applied to this line in cents (store API). */
+  tax_total?: number
   /** The metadata of the cart line. */
   metadata: Metadata
   /** The cart this line belongs to. */
   cart?: Cart
-  /** The purchasable entity (product or variant). */
-  purchasable?: Record<string, unknown>
+  /** The purchasable entity, when expanded through `include=lines.purchasable`. */
+  purchasable?: Product | ProductVariant | null
   /** The price adjustments applied to this line. */
   adjustments?: CartLineAdjustment[]
   /** The tax lines applied to this line. */
-  taxLines?: CartLineTaxLine[]
+  tax_lines?: CartLineTaxLine[]
 }
 
 /**
@@ -76,7 +100,9 @@ export interface CartAddress extends Entity {
   /** The address type (billing or shipping). */
   type: CartAddressType
   /** The country ID. */
-  country_id: number | null
+  country_id?: number | null
+  /** The ISO 3166-1 alpha-2 country code (store API). */
+  country_code?: string | null
   /** The first name. */
   first_name: string | null
   /** The last name. */
@@ -105,28 +131,34 @@ export interface CartAddress extends Entity {
 
 /**
  * CartLineAdjustment model — price adjustments (discounts) applied to a cart line.
+ * The store API only carries the amount and the code on each line.
  */
-export interface CartLineAdjustment extends Entity {
+export interface CartLineAdjustment {
+  /** The internal id of the entity (admin). */
+  id?: string | number
   /** The cart line ID. */
-  cart_line_id: number
+  cart_line_id?: number
   /** The adjustment amount (in cents). */
   amount: number
   /** The coupon/discount code. */
   code: string | null
   /** The discount ID (if applied from a discount). */
-  discount_id: number | null
+  discount_id?: number | null
   /** The cart line this adjustment belongs to. */
-  cartLine?: CartLine
+  cart_line?: CartLine
   /** The discount this adjustment comes from. */
   discount?: Discount | null
 }
 
 /**
  * CartLineTaxLine model — tax applied to a cart line.
+ * The store API only carries the code, name, rate and amount on each line.
  */
-export interface CartLineTaxLine extends Entity {
+export interface CartLineTaxLine {
+  /** The internal id of the entity (admin). */
+  id?: string | number
   /** The cart line ID. */
-  cart_line_id: number
+  cart_line_id?: number
   /** The tax code (e.g., "VAT", "GST"). */
   code: string
   /** The tax name (e.g., "TVA 20%"). */
@@ -136,9 +168,9 @@ export interface CartLineTaxLine extends Entity {
   /** The calculated tax amount (in cents). */
   amount: number
   /** The source tax rate ID. */
-  tax_rate_id: number | null
+  tax_rate_id?: number | null
   /** The cart line this tax line belongs to. */
-  cartLine?: CartLine
+  cart_line?: CartLine
   /** The source tax rate. */
-  taxRate?: TaxRate | null
+  tax_rate?: TaxRate | null
 }

--- a/tests/Api/Feature/CartEndpointsTest.php
+++ b/tests/Api/Feature/CartEndpointsTest.php
@@ -1,0 +1,332 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Collection;
+use Illuminate\Testing\TestResponse;
+use Laravel\Sanctum\Sanctum;
+use Shopper\Cart\Models\Cart;
+use Shopper\Core\Enum\AddressType;
+use Shopper\Core\Enum\DiscountApplyTo;
+use Shopper\Core\Enum\DiscountEligibility;
+use Shopper\Core\Enum\DiscountRequirement;
+use Shopper\Core\Enum\DiscountType;
+use Shopper\Core\Enum\ProductType;
+use Shopper\Core\Models\Country;
+use Shopper\Core\Models\Currency;
+use Shopper\Core\Models\Discount;
+use Shopper\Core\Models\Inventory;
+use Shopper\Core\Models\Product;
+use Shopper\Core\Models\ProductVariant;
+use Shopper\Core\Models\TaxRate;
+use Shopper\Core\Models\TaxZone;
+use Tests\Core\Stubs\User;
+
+uses(Tests\Api\TestCase::class);
+
+function includedCartLines(TestResponse $response): Collection
+{
+    return collect($response->json('included'))->where('type', 'cart-lines')->values();
+}
+
+beforeEach(function (): void {
+    setupCurrencies();
+
+    $this->currency = Currency::query()->where('code', 'USD')->first();
+    $this->inventory = Inventory::factory()->create();
+
+    $this->product = Product::factory()->standard()->publish()->create();
+    $this->product->prices()->create([
+        'amount' => 2500,
+        'currency_id' => $this->currency->id,
+    ]);
+    $this->product->mutateStock($this->inventory->id, 50);
+});
+
+it('creates a guest cart with the default currency', function (): void {
+    $response = $this->postJson('/store/carts')
+        ->assertCreated()
+        ->assertJsonPath('data.type', 'carts')
+        ->assertJsonPath('data.attributes.currency_code', 'USD')
+        ->assertJsonPath('data.attributes.total', 0)
+        ->assertJsonPath('data.attributes.lines_count', 0);
+
+    $cart = Cart::query()->where('public_id', $response->json('data.id'))->first();
+
+    expect($cart)->not->toBeNull()
+        ->and($cart->customer_id)->toBeNull();
+});
+
+it('attaches the cart to the authenticated customer', function (): void {
+    $customer = User::factory()->create();
+    Sanctum::actingAs($customer, ['store']);
+
+    $cartId = $this->postJson('/store/carts', ['metadata' => ['source' => 'mobile']])
+        ->assertCreated()
+        ->assertJsonPath('data.attributes.metadata.source', 'mobile')
+        ->json('data.id');
+
+    expect(Cart::query()->where('public_id', $cartId)->value('customer_id'))->toBe($customer->id);
+});
+
+it('rejects a currency the shop does not sell in', function (): void {
+    $this->postJson('/store/carts', ['currency_code' => 'XXX'])->assertUnprocessable();
+});
+
+it('retrieves a cart by its public id', function (): void {
+    $cart = Cart::query()->create(['currency_code' => 'USD']);
+
+    $this->getJson('/store/carts/'.$cart->public_id)
+        ->assertOk()
+        ->assertJsonPath('data.id', $cart->public_id)
+        ->assertJsonPath('data.attributes.currency_code', 'USD');
+
+    $this->getJson('/store/carts/01JUNKNOWNCARTIDENTIFIER00')->assertNotFound();
+});
+
+it('hides a customer cart from guests and other customers', function (): void {
+    $owner = User::factory()->create();
+    $cart = Cart::query()->create(['currency_code' => 'USD', 'customer_id' => $owner->id]);
+
+    $this->getJson('/store/carts/'.$cart->public_id)->assertNotFound();
+
+    Sanctum::actingAs(User::factory()->create(), ['store']);
+    $this->getJson('/store/carts/'.$cart->public_id)->assertNotFound();
+
+    Sanctum::actingAs($owner, ['store']);
+    $this->getJson('/store/carts/'.$cart->public_id)->assertOk();
+});
+
+it('keeps lines out of the payload until the client includes them', function (): void {
+    $cartId = $this->postJson('/store/carts')->json('data.id');
+
+    $this->postJson("/store/carts/{$cartId}/lines", [
+        'purchasable_type' => 'product',
+        'purchasable_id' => $this->product->public_id,
+    ])->assertOk();
+
+    $summary = $this->getJson("/store/carts/{$cartId}")
+        ->assertOk()
+        ->assertJsonPath('data.attributes.lines_count', 1)
+        ->assertJsonPath('data.attributes.subtotal', 2500);
+
+    expect($summary->json('included'))->toBeNull()
+        ->and($summary->json('data.relationships'))->toBeNull();
+});
+
+it('adds a product to the cart and computes totals', function (): void {
+    $cartId = $this->postJson('/store/carts')->json('data.id');
+
+    $response = $this->postJson("/store/carts/{$cartId}/lines?include=lines", [
+        'purchasable_type' => 'product',
+        'purchasable_id' => $this->product->public_id,
+        'quantity' => 2,
+    ])->assertOk()
+        ->assertJsonPath('data.attributes.subtotal', 5000)
+        ->assertJsonPath('data.attributes.total', 5000)
+        ->assertJsonPath('data.attributes.lines_count', 1)
+        ->assertJsonPath('data.attributes.lines_quantity', 2);
+
+    $line = includedCartLines($response)->sole();
+
+    expect($line['attributes']['quantity'])->toBe(2)
+        ->and($line['attributes']['unit_price_amount'])->toBe(2500)
+        ->and($line['attributes']['subtotal'])->toBe(5000)
+        ->and($line['attributes']['purchasable_type'])->toBe('product');
+});
+
+it('expands the purchasable of each line on demand', function (): void {
+    $cartId = $this->postJson('/store/carts')->json('data.id');
+
+    $response = $this->postJson("/store/carts/{$cartId}/lines?include=lines.purchasable", [
+        'purchasable_type' => 'product',
+        'purchasable_id' => $this->product->public_id,
+    ])->assertOk();
+
+    $products = collect($response->json('included'))->where('type', 'products')->values();
+
+    expect($products->sole()['id'])->toBe($this->product->public_id);
+});
+
+it('merges duplicate purchasables into a single line', function (): void {
+    $cartId = $this->postJson('/store/carts')->json('data.id');
+    $payload = ['purchasable_type' => 'product', 'purchasable_id' => $this->product->public_id];
+
+    $this->postJson("/store/carts/{$cartId}/lines", [...$payload, 'quantity' => 1])->assertOk();
+
+    $response = $this->postJson("/store/carts/{$cartId}/lines?include=lines", [...$payload, 'quantity' => 2])
+        ->assertOk()
+        ->assertJsonPath('data.attributes.lines_count', 1)
+        ->assertJsonPath('data.attributes.lines_quantity', 3);
+
+    expect(includedCartLines($response)->sole()['attributes']['quantity'])->toBe(3);
+});
+
+it('adds a variant to the cart', function (): void {
+    $variant = ProductVariant::factory()->create(['product_id' => $this->product->id]);
+    $variant->prices()->create([
+        'amount' => 3000,
+        'currency_id' => $this->currency->id,
+    ]);
+    $variant->mutateStock($this->inventory->id, 20);
+
+    $cartId = $this->postJson('/store/carts')->json('data.id');
+
+    $response = $this->postJson("/store/carts/{$cartId}/lines?include=lines.purchasable", [
+        'purchasable_type' => 'variant',
+        'purchasable_id' => $variant->public_id,
+    ])->assertOk();
+
+    $line = includedCartLines($response)->sole();
+    $variants = collect($response->json('included'))->where('type', 'variants')->values();
+
+    expect($line['attributes']['unit_price_amount'])->toBe(3000)
+        ->and($line['attributes']['purchasable_type'])->toBe('variant')
+        ->and($variants->sole()['id'])->toBe($variant->public_id);
+});
+
+it('rejects purchasables a storefront cannot sell', function (): void {
+    $cartId = $this->postJson('/store/carts')->json('data.id');
+
+    $draft = Product::factory()->standard()->create(['is_visible' => false]);
+    $external = Product::factory()->external()->publish()->create();
+    $parent = Product::factory()->publish()->create(['type' => ProductType::Variant]);
+    $unpriced = Product::factory()->standard()->publish()->create();
+
+    foreach ([
+        '01JUNKNOWNPURCHASABLEID000',
+        $draft->public_id,
+        $external->public_id,
+        $parent->public_id,
+        $unpriced->public_id,
+    ] as $publicId) {
+        $this->postJson("/store/carts/{$cartId}/lines", [
+            'purchasable_type' => 'product',
+            'purchasable_id' => $publicId,
+        ])->assertUnprocessable();
+    }
+});
+
+it('returns a validation error when stock is insufficient', function (): void {
+    $cartId = $this->postJson('/store/carts')->json('data.id');
+
+    $this->postJson("/store/carts/{$cartId}/lines", [
+        'purchasable_type' => 'product',
+        'purchasable_id' => $this->product->public_id,
+        'quantity' => 100,
+    ])->assertUnprocessable();
+});
+
+it('updates the quantity of a line and removes it', function (): void {
+    $cartId = $this->postJson('/store/carts')->json('data.id');
+
+    $response = $this->postJson("/store/carts/{$cartId}/lines?include=lines", [
+        'purchasable_type' => 'product',
+        'purchasable_id' => $this->product->public_id,
+    ]);
+
+    $lineId = includedCartLines($response)->sole()['id'];
+
+    $updated = $this->patchJson("/store/carts/{$cartId}/lines/{$lineId}?include=lines", ['quantity' => 3])
+        ->assertOk()
+        ->assertJsonPath('data.attributes.subtotal', 7500);
+
+    expect(includedCartLines($updated)->sole()['attributes']['quantity'])->toBe(3);
+
+    $this->deleteJson("/store/carts/{$cartId}/lines/{$lineId}")
+        ->assertOk()
+        ->assertJsonPath('data.attributes.lines_count', 0)
+        ->assertJsonPath('data.attributes.subtotal', 0);
+
+    $this->patchJson("/store/carts/{$cartId}/lines/{$lineId}", ['quantity' => 1])->assertNotFound();
+});
+
+it('returns a conflict when mutating a completed cart', function (): void {
+    $cart = Cart::query()->create(['currency_code' => 'USD', 'completed_at' => now()]);
+
+    $this->postJson("/store/carts/{$cart->public_id}/lines", [
+        'purchasable_type' => 'product',
+        'purchasable_id' => $this->product->public_id,
+    ])->assertConflict();
+});
+
+it('exposes the cart addresses as an include', function (): void {
+    $country = Country::query()->where('cca2', 'US')->first()
+        ?? Country::factory()->create(['cca2' => 'US', 'name' => 'United States']);
+
+    $cart = Cart::query()->create(['currency_code' => 'USD']);
+    $cart->addresses()->create([
+        'type' => AddressType::Shipping,
+        'first_name' => 'John',
+        'last_name' => 'Doe',
+        'address_1' => '123 Main St',
+        'city' => 'New York',
+        'postal_code' => '10001',
+        'country_id' => $country->id,
+    ]);
+
+    $response = $this->getJson("/store/carts/{$cart->public_id}?include=addresses")->assertOk();
+
+    $address = collect($response->json('included'))->where('type', 'cart-addresses')->sole();
+
+    expect($address['attributes']['type'])->toBe('shipping')
+        ->and($address['attributes']['country_code'])->toBe('US')
+        ->and($address['attributes']['full_name'])->toBe('John Doe');
+});
+
+it('exposes discounts and taxes computed by the cart pipelines', function (): void {
+    Discount::factory()->create([
+        'code' => 'SAVE20',
+        'is_active' => true,
+        'type' => DiscountType::Percentage,
+        'value' => 20,
+        'apply_to' => DiscountApplyTo::Order,
+        'eligibility' => DiscountEligibility::Everyone,
+        'min_required' => DiscountRequirement::None,
+        'start_at' => now()->subDay(),
+        'end_at' => now()->addMonth(),
+    ]);
+
+    $country = Country::query()->where('cca2', 'US')->first()
+        ?? Country::factory()->create(['cca2' => 'US', 'name' => 'United States']);
+
+    $taxZone = TaxZone::factory()->create([
+        'country_id' => $country->id,
+        'is_tax_inclusive' => false,
+    ]);
+
+    TaxRate::factory()->create([
+        'tax_zone_id' => $taxZone->id,
+        'rate' => 10.00,
+        'is_default' => true,
+    ]);
+
+    $cart = Cart::query()->create(['currency_code' => 'USD', 'coupon_code' => 'SAVE20']);
+    $cart->addresses()->create([
+        'type' => AddressType::Shipping,
+        'first_name' => 'John',
+        'last_name' => 'Doe',
+        'address_1' => '123 Main St',
+        'city' => 'New York',
+        'postal_code' => '10001',
+        'country_id' => $country->id,
+    ]);
+
+    $response = $this->postJson("/store/carts/{$cart->public_id}/lines?include=lines", [
+        'purchasable_type' => 'product',
+        'purchasable_id' => $this->product->public_id,
+        'quantity' => 2,
+    ])->assertOk()
+        ->assertJsonPath('data.attributes.subtotal', 5000)
+        ->assertJsonPath('data.attributes.discount_total', 1000)
+        ->assertJsonPath('data.attributes.tax_total', 400)
+        ->assertJsonPath('data.attributes.total', 4400);
+
+    $line = includedCartLines($response)->sole();
+
+    expect($line['attributes']['discount_total'])->toBe(1000)
+        ->and($line['attributes']['tax_total'])->toBe(400)
+        ->and($line['attributes']['adjustments'])->toBe([['amount' => 1000, 'code' => 'SAVE20']])
+        ->and($line['attributes']['tax_lines'][0]['rate'])->toEqual(10)
+        ->and($line['attributes']['tax_lines'][0]['amount'])->toBe(400);
+});

--- a/tests/Api/TestCase.php
+++ b/tests/Api/TestCase.php
@@ -8,6 +8,7 @@ use Dedoc\Scramble\ScrambleServiceProvider;
 use Laravel\Sanctum\SanctumServiceProvider;
 use Livewire\LivewireServiceProvider;
 use Shopper\Api\ApiServiceProvider;
+use Shopper\Cart\CartServiceProvider;
 use Shopper\Core\CoreServiceProvider;
 use Shopper\Http\HttpServiceProvider;
 use Shopper\Payment\PaymentServiceProvider;
@@ -38,6 +39,7 @@ abstract class TestCase extends \Tests\TestCase
             CoreServiceProvider::class,
             ShopperServiceProvider::class,
             SidebarServiceProvider::class,
+            CartServiceProvider::class,
             PaymentServiceProvider::class,
             MediaLibraryServiceProvider::class,
             PermissionServiceProvider::class,

--- a/tests/Cart/Feature/CartCalculationTest.php
+++ b/tests/Cart/Feature/CartCalculationTest.php
@@ -170,6 +170,52 @@ describe(CalculateLines::class, function (): void {
             ->and($context->total)->toBe(2750);
     });
 
+    it('taxes the discounted amount when a coupon is applied in the same run', function (): void {
+        $country = Country::query()->where('cca2', 'US')->first()
+            ?? Country::factory()->create(['cca2' => 'US', 'name' => 'United States']);
+
+        $taxZone = TaxZone::factory()->create([
+            'country_id' => $country->id,
+            'is_tax_inclusive' => false,
+        ]);
+
+        TaxRate::factory()->create([
+            'tax_zone_id' => $taxZone->id,
+            'rate' => 10.00,
+            'is_default' => true,
+        ]);
+
+        Discount::factory()->create([
+            'code' => 'SAVE20',
+            'is_active' => true,
+            'type' => DiscountType::Percentage,
+            'value' => 20,
+            'apply_to' => DiscountApplyTo::Order,
+            'eligibility' => DiscountEligibility::Everyone,
+            'min_required' => DiscountRequirement::None,
+            'start_at' => now()->subDay(),
+            'end_at' => now()->addMonth(),
+        ]);
+
+        $this->cartManager->add($this->cart, $this->product, quantity: 2);
+        $this->cartManager->applyCoupon($this->cart, 'SAVE20');
+        $this->cartManager->addAddress($this->cart, AddressType::Shipping, [
+            'first_name' => 'John',
+            'last_name' => 'Doe',
+            'address_1' => '123 Main St',
+            'city' => 'New York',
+            'postal_code' => '10001',
+            'country_id' => $country->id,
+        ]);
+
+        $context = $this->cartManager->calculate($this->cart->refresh());
+
+        expect($context->subtotal)->toBe(5000)
+            ->and($context->discountTotal)->toBe(1000)
+            ->and($context->taxTotal)->toBe(400)
+            ->and($context->total)->toBe(4400);
+    });
+
     it('handles tax inclusive mode', function (): void {
         $country = Country::query()->where('cca2', 'FR')->first()
             ?? Country::factory()->create(['cca2' => 'FR', 'name' => 'France']);


### PR DESCRIPTION
Closes #541

## What's new

Guest and customer carts on the Store API, following the patterns from #538, #545 and #546. The cart answers with the totals computed by the `shopper/cart` pipelines (lines, coupon discounts, taxes), everything ships with the matching SDK surface and types.

### Cart (`/store/carts`)

| Endpoint | Behaviour |
|---|---|
| `POST /store/carts` | Creates a cart, 201. Currency from the payload, the resolved zone, then the shop default. With a Bearer token the cart belongs to that customer |
| `GET /store/carts/{id}` | Cart summary by `public_id` with pipeline-computed totals |
| `POST /store/carts/{id}/lines` | Adds a product or variant. Idempotent on the purchasable: adding it again increments the existing line |
| `PATCH /store/carts/{id}/lines/{lineId}` | Updates quantity or metadata |
| `DELETE /store/carts/{id}/lines/{lineId}` | Removes the line, answers with the recalculated cart instead of a 204 |

Every response is the full cart document, recalculated on each call. Amounts are integers in cents: `subtotal`, `discount_total`, `tax_total`, `total`, `tax_inclusive`, plus `lines_count` and `lines_quantity` for header badges.

### Partitioned document

The attributes carry the cheap summary, the heavy parts are opt-in JSON:API includes, on the line endpoints too (`POST .../lines?include=lines` refreshes the lines in the same round trip):

- `include=lines`: `cart-lines` resources with per-line `subtotal`, `discount_total`, `tax_total`, applied `adjustments` and `tax_lines`
- `include=lines.purchasable`: the full `ProductResource` or `ProductVariantResource` behind each line, typed by `purchasable_type`
- `include=addresses`: `cart-addresses` with `country_code` and `full_name`

### Domain guards

- `ResolvePurchasableAction` refuses what a storefront cannot sell with a 422: draft products, external products, products that sell through their variants, purchasables without a price in the cart currency
- Insufficient stock answers 422 on `quantity`, mutating a completed cart answers 409
- A guest cart is a capability URL (the ULID is the key). A customer cart is only visible to its owner, anyone else gets a 404 indistinguishable from a missing cart

### Cart package fix

`CartPipelineRunner` eager-loads `lines.adjustments` before the pipeline runs, and `ApplyDiscounts` bulk-inserts the adjustments. `CalculateTax` then summed the stale empty relation and taxed the pre-discount amount on any coupon + tax cart. `DiscountCalculator` now drops the cached relation after rewriting the adjustments, with a regression test on the combined run (20% coupon + 10% tax: subtotal 5000, discount 1000, tax 400, total 4400).

### SDK and types

- `sdk.store.cart.create/retrieve/createLineItem/updateLineItem/deleteLineItem`, every call accepts `RequestParams` and asks for `include=lines` by default so `cart.lines` is always populated; pass `{ include: [] }` for the bare summary
- Typed payloads (`CreateCartPayload`, `CreateCartLinePayload`, `UpdateCartLinePayload`)
- Types: cart totals and counters on `Cart`, per-line amounts on `CartLine`, `purchasable` typed `Product | ProductVariant`, wire-accurate `tax_lines` keys

### Docs

`packages/api/README.md` gains a full Cart section: lifecycle, response example, includes table, add-to-cart payload, ownership rules and SDK usage. Controllers carry Scramble summaries and descriptions for the OpenAPI document.