### PR TITLE
feat(api): capture guest email on cart

### DIFF
--- a/packages/api/resources/lang/en/messages.php
+++ b/packages/api/resources/lang/en/messages.php
@@ -8,6 +8,7 @@ return [
         'empty' => 'The cart is empty.',
         'nothing_to_collect' => 'The cart has no amount to collect.',
         'no_zone' => 'The cart has no shipping zone, so no shipping option applies to it.',
+        'email_required' => 'Provide an email address before completing the cart.',
     ],
 
     'purchasable' => [

--- a/packages/api/resources/lang/es/messages.php
+++ b/packages/api/resources/lang/es/messages.php
@@ -8,6 +8,7 @@ return [
         'empty' => 'El carrito está vacío.',
         'nothing_to_collect' => 'El carrito no tiene ningún importe que cobrar.',
         'no_zone' => 'El carrito no tiene zona de envío, ninguna opción de envío se le aplica.',
+        'email_required' => 'Indica una dirección de correo electrónico antes de finalizar el carrito.',
     ],
 
     'purchasable' => [

--- a/packages/api/resources/lang/fr/messages.php
+++ b/packages/api/resources/lang/fr/messages.php
@@ -8,6 +8,7 @@ return [
         'empty' => 'Le panier est vide.',
         'nothing_to_collect' => 'Le panier n\'a aucun montant à encaisser.',
         'no_zone' => 'Le panier n\'a pas de zone de livraison, aucune option de livraison ne s\'y applique.',
+        'email_required' => 'Renseignez une adresse e-mail avant de finaliser le panier.',
     ],
 
     'purchasable' => [

--- a/packages/api/src/Actions/CompleteCartAction.php
+++ b/packages/api/src/Actions/CompleteCartAction.php
@@ -40,7 +40,7 @@ final readonly class CompleteCartAction
             return $order;
         }
 
-        $cart->load(['zone.currency', 'zone.carriers', 'lines.purchasable', 'addresses.country']);
+        $cart->load(['zone.currency', 'zone.carriers', 'lines.purchasable', 'addresses.country', 'customer']);
 
         if ($cart->lines->isEmpty()) {
             throw ValidationException::withMessages([
@@ -53,6 +53,8 @@ final readonly class CompleteCartAction
                 'payment_method' => __('shopper-api::messages.payment.method_required'),
             ]);
         }
+
+        $this->ensureEmail($cart);
 
         $this->refreshShipping($cart);
 
@@ -75,6 +77,28 @@ final readonly class CompleteCartAction
         $this->recordInitiatedPayment($cart, $order);
 
         return $order;
+    }
+
+    /**
+     * Freeze the contact email on the cart so the order can be confirmed and
+     * looked up. A customer cart falls back to the customer's own email; a
+     * guest cart must carry one, set at creation or with the checkout address.
+     */
+    private function ensureEmail(Cart $cart): void
+    {
+        if ($cart->email !== null) {
+            return;
+        }
+
+        $email = $cart->customer?->getAttribute('email');
+
+        if (! is_string($email)) {
+            throw ValidationException::withMessages([
+                'email' => __('shopper-api::messages.cart.email_required'),
+            ]);
+        }
+
+        $this->cartManager->setEmail($cart, $email);
     }
 
     /**

--- a/packages/api/src/Http/Controllers/Cart/CartAddressController.php
+++ b/packages/api/src/Http/Controllers/Cart/CartAddressController.php
@@ -40,7 +40,13 @@ final class CartAddressController
             ->whereIn('cca2', collect($addresses)->filter()->pluck('country_code')->unique())
             ->pluck('id', 'cca2');
 
-        $this->mutateCart(function () use ($cart, $addresses, $countryIds): void {
+        $email = $request->validated('email');
+
+        $this->mutateCart(function () use ($cart, $addresses, $countryIds, $email): void {
+            if ($email !== null) {
+                $this->cartManager->setEmail($cart, $email);
+            }
+
             foreach ($addresses as $type => $address) {
                 if (! $address) {
                     continue;

--- a/packages/api/src/Http/Controllers/Cart/CartController.php
+++ b/packages/api/src/Http/Controllers/Cart/CartController.php
@@ -35,6 +35,7 @@ final class CartController
         $cart = resolve(CartContract::class)::query()->create([
             'currency_code' => $request->validated('currency_code')
                 ?? ($zone?->currency_id ? $zone->currency_code : shopper_currency()),
+            'email' => $request->validated('email'),
             'customer_id' => $request->user('sanctum')?->getAuthIdentifier(),
             'zone_id' => $zone?->id,
             'metadata' => $request->validated('metadata'),

--- a/packages/api/src/Http/Requests/Cart/CreateCartRequest.php
+++ b/packages/api/src/Http/Requests/Cart/CreateCartRequest.php
@@ -25,6 +25,7 @@ final class CreateCartRequest extends FormRequest
                 'string',
                 Rule::exists(shopper_table('currencies'), 'code')->where('is_enabled', true),
             ],
+            'email' => ['nullable', 'email', 'max:255'],
             'metadata' => ['nullable', 'array'],
         ];
     }
@@ -33,6 +34,10 @@ final class CreateCartRequest extends FormRequest
     {
         if ($this->filled('currency_code')) {
             $this->merge(['currency_code' => mb_strtoupper((string) $this->string('currency_code'))]);
+        }
+
+        if ($this->filled('email')) {
+            $this->merge(['email' => mb_strtolower((string) $this->string('email'))]);
         }
     }
 }

--- a/packages/api/src/Http/Requests/Cart/StoreCartAddressesRequest.php
+++ b/packages/api/src/Http/Requests/Cart/StoreCartAddressesRequest.php
@@ -22,6 +22,7 @@ final class StoreCartAddressesRequest extends FormRequest
         return [
             'shipping_address' => ['required_without:billing_address', 'array'],
             'billing_address' => ['required_without:shipping_address', 'array'],
+            'email' => ['nullable', 'email', 'max:255'],
             ...$this->addressRules('shipping_address'),
             ...$this->addressRules('billing_address'),
         ];
@@ -29,6 +30,10 @@ final class StoreCartAddressesRequest extends FormRequest
 
     protected function prepareForValidation(): void
     {
+        if ($this->filled('email')) {
+            $this->merge(['email' => mb_strtolower((string) $this->string('email'))]);
+        }
+
         foreach (['shipping_address', 'billing_address'] as $key) {
             $code = $this->input("{$key}.country_code");
 

--- a/packages/api/src/Http/Resources/CartResource.php
+++ b/packages/api/src/Http/Resources/CartResource.php
@@ -32,6 +32,7 @@ final class CartResource extends JsonApiResource
     {
         return [
             'currency_code' => $this->currency_code,
+            'email' => $this->email,
             'coupon_code' => $this->coupon_code,
             'completed_at' => $this->completed_at?->toIso8601String(),
             'metadata' => $this->metadata,

--- a/packages/api/src/Http/Resources/OrderResource.php
+++ b/packages/api/src/Http/Resources/OrderResource.php
@@ -29,6 +29,7 @@ final class OrderResource extends JsonApiResource
             'shipping_amount' => $this->shipping_amount,
             'price_amount' => $this->price_amount,
             'currency_code' => $this->currency_code,
+            'email' => $this->email,
             'created_at' => $this->created_at->toIso8601String(),
         ];
     }

--- a/packages/cart/database/migrations/2026_06_13_000001_add_email_to_carts_table.php
+++ b/packages/cart/database/migrations/2026_06_13_000001_add_email_to_carts_table.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Shopper\Core\Helpers\Migration;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table($this->getTableName('carts'), function (Blueprint $table): void {
+            $table->string('email')->nullable()->after('currency_code');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table($this->getTableName('carts'), function (Blueprint $table): void {
+            $table->dropColumn('email');
+        });
+    }
+};

--- a/packages/cart/src/Actions/CreateOrderFromCartAction.php
+++ b/packages/cart/src/Actions/CreateOrderFromCartAction.php
@@ -62,6 +62,7 @@ final readonly class CreateOrderFromCartAction
                 'tax_amount' => $context->taxTotal,
                 'shipping_amount' => $cart->shipping_amount,
                 'currency_code' => $cart->currency_code,
+                'email' => $cart->email,
                 'customer_id' => $cart->customer_id,
                 'channel_id' => $cart->channel_id,
                 'zone_id' => $cart->zone_id,

--- a/packages/cart/src/CartManager.php
+++ b/packages/cart/src/CartManager.php
@@ -147,6 +147,13 @@ final readonly class CartManager
         $cart->update(['payment_method_id' => $paymentMethodId]);
     }
 
+    public function setEmail(Cart $cart, string $email): void
+    {
+        $this->guardCompleted($cart);
+
+        $cart->update(['email' => $email]);
+    }
+
     public function applyCoupon(Cart $cart, string $code): void
     {
         $this->guardCompleted($cart);

--- a/packages/cart/src/Models/Cart.php
+++ b/packages/cart/src/Models/Cart.php
@@ -22,6 +22,7 @@ use Shopper\Core\Traits\HasModelContract;
  * @property-read int $id
  * @property-read ?string $public_id
  * @property-read string $currency_code
+ * @property-read ?string $email
  * @property-read ?string $coupon_code
  * @property-read ?CarbonInterface $completed_at
  * @property-read ?array<string, mixed> $metadata

--- a/packages/core/database/migrations/2026_06_13_000001_add_email_to_orders_table.php
+++ b/packages/core/database/migrations/2026_06_13_000001_add_email_to_orders_table.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Shopper\Core\Helpers\Migration;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table($this->getTableName('orders'), function (Blueprint $table): void {
+            $table->string('email')->nullable()->after('currency_code');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table($this->getTableName('orders'), function (Blueprint $table): void {
+            $table->dropColumn('email');
+        });
+    }
+};

--- a/packages/core/src/Models/Order.php
+++ b/packages/core/src/Models/Order.php
@@ -31,6 +31,7 @@ use Shopper\Core\Traits\HasModelContract;
  * @property-read ?int $shipping_amount
  * @property-read string $notes
  * @property-read string $currency_code
+ * @property-read ?string $email
  * @property-read ?int $zone_id
  * @property-read ?int $shipping_address_id
  * @property-read ?int $shipping_option_id

--- a/packages/sdk/src/store/cart.ts
+++ b/packages/sdk/src/store/cart.ts
@@ -7,6 +7,8 @@ import { flatten } from '../json-api'
 export type CreateCartPayload = {
   /** ISO currency code the cart prices in. Defaults to the zone or shop currency. */
   currency_code?: string
+  /** Contact email frozen on the order at completion. Required for a guest cart, set here or with the checkout addresses. */
+  email?: string
   metadata?: Record<string, unknown> | null
 }
 
@@ -41,6 +43,8 @@ export type CartAddressPayload = {
 export type SetCartAddressesPayload = {
   shipping_address?: CartAddressPayload
   billing_address?: CartAddressPayload
+  /** Contact email frozen on the order at completion. Required for a guest cart when not set at creation. */
+  email?: string
 }
 
 /** Delivery choices for a cart plus the non-fatal notices raised while quoting. */

--- a/packages/types/src/cart.ts
+++ b/packages/types/src/cart.ts
@@ -20,6 +20,8 @@ export enum CartAddressType {
 export interface Cart extends Entity {
   /** The currency code for the cart. */
   currency_code: string
+  /** The contact email frozen on the order at completion (store API). */
+  email?: string | null
   /** The coupon code applied to the cart. */
   coupon_code: string | null
   /** The date the cart was completed (converted to order). */

--- a/packages/types/src/order.ts
+++ b/packages/types/src/order.ts
@@ -81,6 +81,8 @@ export interface Order extends Entity {
   notes: string | null
   /** The currency code for the order. */
   currency_code: string
+  /** The contact email of the order (store API). */
+  email?: string | null
   /** The order status. */
   status: OrderStatus
   /** The payment status. */

--- a/tests/Api/Feature/CartEndpointsTest.php
+++ b/tests/Api/Feature/CartEndpointsTest.php
@@ -73,6 +73,19 @@ it('rejects a currency the shop does not sell in', function (): void {
     $this->postJson('/store/carts', ['currency_code' => 'XXX'])->assertUnprocessable();
 });
 
+it('stores the contact email given at creation', function (): void {
+    $cartId = $this->postJson('/store/carts', ['email' => 'Guest@Example.com'])
+        ->assertCreated()
+        ->assertJsonPath('data.attributes.email', 'guest@example.com')
+        ->json('data.id');
+
+    expect(Cart::query()->where('public_id', $cartId)->value('email'))->toBe('guest@example.com');
+});
+
+it('rejects a malformed email at creation', function (): void {
+    $this->postJson('/store/carts', ['email' => 'not-an-email'])->assertUnprocessable();
+});
+
 it('retrieves a cart by its public id', function (): void {
     $cart = Cart::query()->create(['currency_code' => 'USD']);
 

--- a/tests/Api/Feature/CheckoutEndpointsTest.php
+++ b/tests/Api/Feature/CheckoutEndpointsTest.php
@@ -29,6 +29,7 @@ function checkoutCart(Zone $zone, Product $product, int $quantity = 1): Cart
 {
     $cart = Cart::query()->create([
         'currency_code' => 'USD',
+        'email' => 'john@example.com',
         'zone_id' => $zone->id,
     ]);
 
@@ -591,4 +592,52 @@ it('opens a fresh session when the provider reports the stored one unusable', fu
 
     expect($driver->retrievals)->toBe(1)
         ->and($driver->initiations)->toBe(2);
+});
+
+it('sets the contact email with the checkout addresses', function (): void {
+    $this->postJson("/store/carts/{$this->cart->public_id}/addresses", [
+        'email' => 'Buyer@Example.com',
+        'shipping_address' => checkoutAddressPayload(),
+    ])
+        ->assertOk()
+        ->assertJsonPath('data.attributes.email', 'buyer@example.com');
+
+    expect($this->cart->refresh()->email)->toBe('buyer@example.com');
+});
+
+it('requires an email to complete a guest cart', function (): void {
+    readyCart($this->cart, $this->option, $this->paymentMethod);
+    $this->cart->update(['email' => null]);
+
+    $this->postJson("/store/carts/{$this->cart->public_id}/complete")
+        ->assertUnprocessable()
+        ->assertJsonPath('errors.0.source.pointer', '/data/attributes/email');
+
+    expect($this->cart->refresh()->isCompleted())->toBeFalse();
+});
+
+it('freezes the cart email on the order', function (): void {
+    readyCart($this->cart, $this->option, $this->paymentMethod);
+    $this->cart->update(['email' => 'guest@example.com']);
+
+    $orderId = $this->postJson("/store/carts/{$this->cart->public_id}/complete")
+        ->assertCreated()
+        ->json('data.id');
+
+    expect(Order::query()->where('public_id', $orderId)->value('email'))->toBe('guest@example.com');
+});
+
+it('falls back to the customer email when the cart has none', function (): void {
+    $customer = User::factory()->create(['email' => 'member@example.com']);
+    $this->cart->update(['customer_id' => $customer->id, 'email' => null]);
+    readyCart($this->cart, $this->option, $this->paymentMethod);
+
+    Sanctum::actingAs($customer, ['store']);
+
+    $orderId = $this->postJson("/store/carts/{$this->cart->public_id}/complete")
+        ->assertCreated()
+        ->json('data.id');
+
+    expect(Order::query()->where('public_id', $orderId)->value('email'))->toBe('member@example.com')
+        ->and($this->cart->refresh()->email)->toBe('member@example.com');
 });


### PR DESCRIPTION
Closes #551.

A guest cart could not carry an email, so a guest order was placed without one: no confirmation, no guest order lookup. This adds the contact email to the cart and freezes it on the order at completion.

## Endpoints (`/store`)
- `POST /store/carts` accepts an optional `email`
- `POST /store/carts/{id}/addresses` accepts an optional `email`, set alongside the checkout addresses
- `POST /store/carts/{id}/complete` freezes the email on the order

## Behavior
- A customer cart falls back to the authenticated customer email.
- A guest cart without an email fails completion with a 422 on `email`.
- The cart and order resources expose `email`; the SDK payloads and `@shopperlabs/shopper-types` carry it.