### PR TITLE
feat(api): transfer a guest cart to a customer on login

### DIFF
--- a/packages/api/routes/store/account.php
+++ b/packages/api/routes/store/account.php
@@ -8,8 +8,10 @@ use Shopper\Api\Http\Controllers\Account\AvatarController;
 use Shopper\Api\Http\Controllers\Account\CustomerController;
 use Shopper\Api\Http\Controllers\Account\OrderController;
 use Shopper\Api\Http\Controllers\Auth\AuthenticationController;
+use Shopper\Api\Http\Controllers\Cart\CartTransferController;
 
 Route::post('/auth/logout', [AuthenticationController::class, 'logout']);
+Route::post('/carts/{cartId}/transfer', CartTransferController::class);
 
 Route::prefix('customers/me')->group(function (): void {
     Route::get('/', [CustomerController::class, 'show']);

--- a/packages/api/src/Actions/TransferCartAction.php
+++ b/packages/api/src/Actions/TransferCartAction.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Api\Actions;
+
+use Illuminate\Auth\Access\AuthorizationException;
+use Shopper\Cart\Models\Cart;
+
+final readonly class TransferCartAction
+{
+    /**
+     * Attach a guest cart to a customer. Transferring a cart the customer
+     * already owns is a no-op, so a retried login never fails; a cart owned
+     * by another customer is refused.
+     *
+     * @throws AuthorizationException
+     */
+    public function execute(Cart $cart, int $customerId): void
+    {
+        if ($cart->customer_id === $customerId) {
+            return;
+        }
+
+        if ($cart->customer_id !== null) {
+            throw new AuthorizationException;
+        }
+
+        $cart->update(['customer_id' => $customerId]);
+    }
+}

--- a/packages/api/src/Concerns/RespondsWithCart.php
+++ b/packages/api/src/Concerns/RespondsWithCart.php
@@ -34,6 +34,23 @@ trait RespondsWithCart
     }
 
     /**
+     * Resolve a cart by its public id without enforcing ownership, so the
+     * caller decides how a foreign owner is handled (a guest cart transfer
+     * answers 403, not 404, when the cart belongs to another customer).
+     */
+    protected function findCartOrFail(string $publicId): Cart
+    {
+        /** @var Cart|null $cart */
+        $cart = resolve(CartContract::class)::query()->wherePublicId($publicId)->first();
+
+        if (! $cart) {
+            throw (new ModelNotFoundException)->setModel(Cart::class, [$publicId]);
+        }
+
+        return $cart;
+    }
+
+    /**
      * Every cart response carries the totals computed by the cart pipelines,
      * so a single GET is enough to render the cart. Relations are reloaded
      * after the run because the pipelines rewrite adjustments and tax lines;

--- a/packages/api/src/Http/Controllers/Cart/CartTransferController.php
+++ b/packages/api/src/Http/Controllers/Cart/CartTransferController.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Api\Http\Controllers\Cart;
+
+use Illuminate\Http\Request;
+use Shopper\Api\Actions\TransferCartAction;
+use Shopper\Api\Concerns\RespondsWithCart;
+use TiMacDonald\JsonApi\JsonApiResource;
+
+final class CartTransferController
+{
+    use RespondsWithCart;
+
+    public function __construct(
+        private readonly TransferCartAction $action,
+    ) {}
+
+    /**
+     * Transfer a guest cart to the authenticated customer.
+     *
+     * Used when a guest signs in mid checkout: the cart they built is attached
+     * to their account. Idempotent for a cart they already own, refused for a
+     * cart that belongs to another customer.
+     */
+    public function __invoke(Request $request, string $cartId): JsonApiResource
+    {
+        $cart = $this->findCartOrFail($cartId);
+
+        $this->action->execute(
+            cart: $cart,
+            customerId: (int) $request->user()->getAuthIdentifier(),
+        );
+
+        return $this->cartResource($cart->refresh());
+    }
+}

--- a/packages/sdk/src/store/cart.ts
+++ b/packages/sdk/src/store/cart.ts
@@ -84,6 +84,17 @@ export class CartModule {
     return flatten<Cart>(await this.client.request(`${this.path}/${id}`, this.params(params))) as Cart
   }
 
+  /**
+   * Attach a guest cart to the authenticated customer, used when a guest signs
+   * in mid-checkout. Requires a customer token. Idempotent for a cart they
+   * already own; rejected for a cart that belongs to another customer.
+   */
+  public async transfer(cartId: string, params?: RequestParams): Promise<Cart> {
+    const document = await this.client.send('POST', `${this.path}/${cartId}/transfer`, undefined, this.params(params))
+
+    return flatten<Cart>(document as NonNullable<typeof document>) as Cart
+  }
+
   public async createLineItem(cartId: string, payload: CreateCartLinePayload, params?: RequestParams): Promise<Cart> {
     const document = await this.client.send('POST', `${this.path}/${cartId}/lines`, payload, this.params(params))
 

--- a/tests/Api/Feature/CartEndpointsTest.php
+++ b/tests/Api/Feature/CartEndpointsTest.php
@@ -343,3 +343,50 @@ it('exposes discounts and taxes computed by the cart pipelines', function (): vo
         ->and($line['attributes']['tax_lines'][0]['rate'])->toEqual(10)
         ->and($line['attributes']['tax_lines'][0]['amount'])->toBe(400);
 });
+
+it('transfers a guest cart to the authenticated customer', function (): void {
+    $cart = Cart::query()->create(['currency_code' => 'USD']);
+    $customer = User::factory()->create();
+
+    Sanctum::actingAs($customer, ['store']);
+
+    $this->postJson("/store/carts/{$cart->public_id}/transfer")
+        ->assertOk()
+        ->assertJsonPath('data.id', (string) $cart->public_id);
+
+    expect($cart->refresh()->customer_id)->toBe($customer->id);
+});
+
+it('is idempotent when transferring an already owned cart', function (): void {
+    $customer = User::factory()->create();
+    $cart = Cart::query()->create(['currency_code' => 'USD', 'customer_id' => $customer->id]);
+
+    Sanctum::actingAs($customer, ['store']);
+
+    $this->postJson("/store/carts/{$cart->public_id}/transfer")->assertOk();
+
+    expect($cart->refresh()->customer_id)->toBe($customer->id);
+});
+
+it('refuses to transfer a cart owned by another customer', function (): void {
+    $owner = User::factory()->create();
+    $cart = Cart::query()->create(['currency_code' => 'USD', 'customer_id' => $owner->id]);
+
+    Sanctum::actingAs(User::factory()->create(), ['store']);
+
+    $this->postJson("/store/carts/{$cart->public_id}/transfer")->assertForbidden();
+
+    expect($cart->refresh()->customer_id)->toBe($owner->id);
+});
+
+it('requires authentication to transfer a cart', function (): void {
+    $cart = Cart::query()->create(['currency_code' => 'USD']);
+
+    $this->postJson("/store/carts/{$cart->public_id}/transfer")->assertUnauthorized();
+});
+
+it('returns 404 when transferring an unknown cart', function (): void {
+    Sanctum::actingAs(User::factory()->create(), ['store']);
+
+    $this->postJson('/store/carts/01JUNKNOWNCARTIDENTIFIER00/transfer')->assertNotFound();
+});


### PR DESCRIPTION
Closes #553.

When a guest signs in during checkout, the cart they built could not be attached to their account: the cart was lost or duplicated. This adds an authenticated endpoint to claim a guest cart.

## Endpoints (`/store`)
- `POST /store/carts/{id}/transfer` (auth) attaches a guest cart to the authenticated customer

## Behavior
- A guest cart is attached to the authenticated customer.
- Transferring a cart the customer already owns is a no-op success (idempotent), so a retried login never fails.
- A cart owned by another customer is refused with a 403.
- An unauthenticated request returns 401; an unknown cart returns 404.
- Adds the SDK `cart.transfer()` method.