### PR TITLE
feat(api): patch cart endpoint with currency, email and metadata

### DIFF
--- a/packages/api/resources/lang/en/messages.php
+++ b/packages/api/resources/lang/en/messages.php
@@ -9,6 +9,7 @@ return [
         'nothing_to_collect' => 'The cart has no amount to collect.',
         'no_zone' => 'The cart has no shipping zone, so no shipping option applies to it.',
         'email_required' => 'Provide an email address before completing the cart.',
+        'metadata_too_large' => 'The metadata payload is too large.',
     ],
 
     'purchasable' => [

--- a/packages/api/resources/lang/es/messages.php
+++ b/packages/api/resources/lang/es/messages.php
@@ -9,6 +9,7 @@ return [
         'nothing_to_collect' => 'El carrito no tiene ningún importe que cobrar.',
         'no_zone' => 'El carrito no tiene zona de envío, ninguna opción de envío se le aplica.',
         'email_required' => 'Indica una dirección de correo electrónico antes de finalizar el carrito.',
+        'metadata_too_large' => 'Los metadatos son demasiado grandes.',
     ],
 
     'purchasable' => [

--- a/packages/api/resources/lang/fr/messages.php
+++ b/packages/api/resources/lang/fr/messages.php
@@ -9,6 +9,7 @@ return [
         'nothing_to_collect' => 'Le panier n\'a aucun montant à encaisser.',
         'no_zone' => 'Le panier n\'a pas de zone de livraison, aucune option de livraison ne s\'y applique.',
         'email_required' => 'Renseignez une adresse e-mail avant de finaliser le panier.',
+        'metadata_too_large' => 'Les métadonnées sont trop volumineuses.',
     ],
 
     'purchasable' => [

--- a/packages/api/routes/store/cart.php
+++ b/packages/api/routes/store/cart.php
@@ -16,6 +16,7 @@ use Shopper\Http\Enum\RateLimit;
 
 Route::post('/carts', [CartController::class, 'store']);
 Route::get('/carts/{cartId}', [CartController::class, 'show']);
+Route::patch('/carts/{cartId}', [CartController::class, 'update']);
 Route::post('/carts/{cartId}/lines', [CartLineController::class, 'store']);
 Route::patch('/carts/{cartId}/lines/{lineId}', [CartLineController::class, 'update']);
 Route::delete('/carts/{cartId}/lines/{lineId}', [CartLineController::class, 'destroy']);

--- a/packages/api/src/Actions/ApplyCartPromotionAction.php
+++ b/packages/api/src/Actions/ApplyCartPromotionAction.php
@@ -4,28 +4,30 @@ declare(strict_types=1);
 
 namespace Shopper\Api\Actions;
 
+use Illuminate\Database\DatabaseManager;
 use Illuminate\Validation\ValidationException;
 use Shopper\Cart\CartManager;
-use Shopper\Cart\Discounts\DiscountValidator;
 use Shopper\Cart\Models\Cart;
 use Shopper\Core\Models\Discount;
 
 final readonly class ApplyCartPromotionAction
 {
     public function __construct(
+        private DatabaseManager $database,
         private CartManager $cartManager,
-        private DiscountValidator $validator,
+        private RevalidateCartCouponAction $revalidateCoupon,
     ) {}
 
     /**
-     * Apply a promotion code to the cart. The code is validated against the
-     * cart before it is persisted, so an invalid, expired or non applicable
-     * code is rejected with its reason and leaves the cart untouched.
+     * Apply a promotion code to the cart. The apply-then-verify runs under a
+     * row lock inside a transaction: a concurrent apply cannot interleave, and
+     * a code that does not reduce the cart (unknown reason, currency, zone,
+     * eligibility, expiry, or products not in the cart) rolls back so the cart
+     * is left untouched. The failure reason is never disclosed to the client,
+     * to keep the codes from being enumerated.
      */
     public function execute(Cart $cart, string $code): void
     {
-        $cart->load(['lines.purchasable']);
-
         $discount = Discount::query()->where('code', $code)->first();
 
         if (! $discount instanceof Discount || ! $discount->is_active) {
@@ -34,24 +36,16 @@ final readonly class ApplyCartPromotionAction
             ]);
         }
 
-        $result = $this->validator->validate($discount, $this->cartManager->calculate($cart));
+        $this->database->transaction(function () use ($cart, $code): void {
+            $cart->newQuery()->lockForUpdate()->whereKey($cart->getKey())->first();
 
-        if (! $result->valid) {
-            throw ValidationException::withMessages([
-                'code' => $result->failureReason ?? __('shopper-api::messages.promotion.not_applicable'),
-            ]);
-        }
+            $this->cartManager->applyCoupon($cart, $code);
 
-        $this->cartManager->applyCoupon($cart, $code);
-
-        // The code is valid in itself, but it may target products this cart
-        // does not hold: confirm it actually reduces the total before keeping it.
-        if ($this->cartManager->calculate($cart)->discountTotal <= 0) {
-            $this->cartManager->removeCoupon($cart);
-
-            throw ValidationException::withMessages([
-                'code' => __('shopper-api::messages.promotion.not_applicable'),
-            ]);
-        }
+            if (! $this->revalidateCoupon->execute($cart)) {
+                throw ValidationException::withMessages([
+                    'code' => __('shopper-api::messages.promotion.not_applicable'),
+                ]);
+            }
+        });
     }
 }

--- a/packages/api/src/Actions/CancelPaymentSessionAction.php
+++ b/packages/api/src/Actions/CancelPaymentSessionAction.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Api\Actions;
+
+use Shopper\Payment\PaymentManager;
+use Throwable;
+
+final readonly class CancelPaymentSessionAction
+{
+    public function __construct(
+        private PaymentManager $paymentManager,
+    ) {}
+
+    /**
+     * Cancel the intent behind a cart payment session at the provider,
+     * best-effort: an abandoned session (total changed, currency switched)
+     * leaves an open intent in the provider dashboard otherwise. Failures are
+     * swallowed: the intent may already be cancelled or confirmed, or the
+     * driver may not support cancellation.
+     *
+     * @param  array<string, mixed>|null  $session
+     */
+    public function execute(?array $session): void
+    {
+        if (! $session || ! isset($session['reference'])) {
+            return;
+        }
+
+        try {
+            $this->paymentManager
+                ->driver($session['driver'] ?? 'manual')
+                ->cancelPayment($session['reference']);
+        } catch (Throwable) {
+        }
+    }
+}

--- a/packages/api/src/Actions/CreateCartPaymentSessionAction.php
+++ b/packages/api/src/Actions/CreateCartPaymentSessionAction.php
@@ -11,13 +11,13 @@ use Shopper\Cart\Models\Cart;
 use Shopper\Payment\Contracts\PaymentDriver;
 use Shopper\Payment\Exceptions\PaymentException;
 use Shopper\Payment\PaymentManager;
-use Throwable;
 
 final readonly class CreateCartPaymentSessionAction
 {
     public function __construct(
         private PaymentManager $paymentManager,
         private CartManager $cartManager,
+        private CancelPaymentSessionAction $cancelSession,
     ) {}
 
     /**
@@ -60,7 +60,7 @@ final readonly class CreateCartPaymentSessionAction
             return $existing;
         }
 
-        $this->cancelReplacedSession($cart->payment_session);
+        $this->cancelSession->execute($cart->payment_session);
 
         // The idempotency key is versioned per attempt, never derived from the
         // amount: providers cache responses by key (Stripe: 24h), so an
@@ -88,28 +88,6 @@ final readonly class CreateCartPaymentSessionAction
         ]);
 
         return new PaymentSession($cart, $driverCode, $result);
-    }
-
-    /**
-     * A replaced session leaves an open intent at the provider; cancel it
-     * best-effort so abandoned intents do not pile up in the provider
-     * dashboard. Failures are swallowed: the intent may already be cancelled
-     * or confirmed, or the driver may not support cancellation at all.
-     *
-     * @param  array<string, mixed>|null  $session
-     */
-    private function cancelReplacedSession(?array $session): void
-    {
-        if (! $session || ! isset($session['reference'])) {
-            return;
-        }
-
-        try {
-            $this->paymentManager
-                ->driver($session['driver'] ?? 'manual')
-                ->cancelPayment($session['reference']);
-        } catch (Throwable) {
-        }
     }
 
     /**

--- a/packages/api/src/Actions/RevalidateCartCouponAction.php
+++ b/packages/api/src/Actions/RevalidateCartCouponAction.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Api\Actions;
+
+use Shopper\Cart\CartManager;
+use Shopper\Cart\Models\Cart;
+
+final readonly class RevalidateCartCouponAction
+{
+    public function __construct(
+        private CartManager $cartManager,
+    ) {}
+
+    /**
+     * Drop the cart coupon when it no longer reduces the cart. The discount
+     * pipeline re-validates the code on every calculation (currency, zone,
+     * eligibility, expiry, per-customer limit), so a zero discount means the
+     * coupon stopped applying after a context change (currency switch, cart
+     * transfer to a customer who already redeemed it, ...). Keeping a coupon
+     * that contributes nothing would advertise a stale code to the storefront.
+     *
+     * Returns whether a coupon is still applied.
+     */
+    public function execute(Cart $cart): bool
+    {
+        if (! $cart->coupon_code) {
+            return false;
+        }
+
+        if ($this->cartManager->calculate($cart)->discountTotal <= 0) {
+            $this->cartManager->removeCoupon($cart);
+
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/packages/api/src/Actions/TransferCartAction.php
+++ b/packages/api/src/Actions/TransferCartAction.php
@@ -9,10 +9,16 @@ use Shopper\Cart\Models\Cart;
 
 final readonly class TransferCartAction
 {
+    public function __construct(
+        private RevalidateCartCouponAction $revalidateCoupon,
+    ) {}
+
     /**
      * Attach a guest cart to a customer. Transferring a cart the customer
      * already owns is a no-op, so a retried login never fails; a cart owned
-     * by another customer is refused.
+     * by another customer is refused. Once the cart belongs to the customer,
+     * an applied coupon is re-validated against their redemption history and
+     * dropped if a per-customer limit now rejects it.
      *
      * @throws AuthorizationException
      */
@@ -27,5 +33,7 @@ final readonly class TransferCartAction
         }
 
         $cart->update(['customer_id' => $customerId]);
+
+        $this->revalidateCoupon->execute($cart);
     }
 }

--- a/packages/api/src/Actions/UpdateCartAction.php
+++ b/packages/api/src/Actions/UpdateCartAction.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Api\Actions;
+
+use Illuminate\Validation\ValidationException;
+use Shopper\Cart\CartManager;
+use Shopper\Cart\Models\Cart;
+use Shopper\Core\Contracts\Priceable;
+use Shopper\Core\Models\Price;
+
+final readonly class UpdateCartAction
+{
+    public function __construct(
+        private CartManager $cartManager,
+        private CancelPaymentSessionAction $cancelSession,
+        private RevalidateCartCouponAction $revalidateCoupon,
+    ) {}
+
+    /**
+     * Apply a partial update to the cart. Only the keys present in the payload
+     * are touched. Switching the currency re-prices the lines, so it is
+     * rejected when a line has no price in the target currency; the open
+     * payment intent is cancelled and an applied coupon is dropped when it no
+     * longer reduces the re-priced cart.
+     *
+     * @param  array<string, mixed>  $attributes
+     */
+    public function execute(Cart $cart, array $attributes): void
+    {
+        $currency = $attributes['currency_code'] ?? null;
+
+        if (is_string($currency) && $currency !== $cart->currency_code) {
+            $this->guardLinePrices($cart, $currency);
+
+            $session = $cart->payment_session;
+
+            $this->cartManager->changeCurrency($cart, $currency);
+            $this->cancelSession->execute($session);
+            $this->revalidateCoupon->execute($cart);
+        }
+
+        if (array_key_exists('email', $attributes) && is_string($attributes['email'])) {
+            $this->cartManager->setEmail($cart, $attributes['email']);
+        }
+
+        if (array_key_exists('metadata', $attributes)) {
+            $metadata = $attributes['metadata'];
+
+            $this->cartManager->setMetadata($cart, is_array($metadata) ? $metadata : null);
+        }
+    }
+
+    private function guardLinePrices(Cart $cart, string $currencyCode): void
+    {
+        $cart->loadMissing('lines.purchasable.prices');
+
+        foreach ($cart->lines as $line) {
+            $purchasable = $line->purchasable;
+
+            if (! $purchasable instanceof Priceable || ! $purchasable->getPrice($currencyCode) instanceof Price) {
+                throw ValidationException::withMessages([
+                    'currency_code' => __('shopper-api::messages.purchasable.missing_price', ['currency' => $currencyCode]),
+                ]);
+            }
+        }
+    }
+}

--- a/packages/api/src/Concerns/NormalizesCartInput.php
+++ b/packages/api/src/Concerns/NormalizesCartInput.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Api\Concerns;
+
+use Closure;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Rules\Exists;
+
+trait NormalizesCartInput
+{
+    protected function prepareForValidation(): void
+    {
+        if ($this->filled('currency_code')) {
+            $this->merge(['currency_code' => mb_strtoupper((string) $this->string('currency_code'))]);
+        }
+
+        if ($this->filled('email')) {
+            $this->merge(['email' => mb_strtolower((string) $this->string('email'))]);
+        }
+    }
+
+    /**
+     * The currency must exist, be enabled, and be one of the currencies the
+     * shop is configured to sell in: an enabled-but-not-configured currency
+     * would price a cart the storefront cannot check out.
+     */
+    protected function currencyExistsRule(): Exists
+    {
+        return Rule::exists(shopper_table('currencies'), 'code')
+            ->where('is_enabled', true)
+            ->whereIn('id', (array) shopper_setting('currencies'));
+    }
+
+    /**
+     * @return array<int, string|Closure>
+     */
+    protected function metadataRules(): array
+    {
+        return [
+            'array',
+            'max:50',
+            function (string $attribute, mixed $value, Closure $fail): void {
+                if (mb_strlen((string) json_encode($value)) > 4096) {
+                    $fail(__('shopper-api::messages.cart.metadata_too_large'));
+                }
+            },
+        ];
+    }
+}

--- a/packages/api/src/Http/Controllers/Cart/CartController.php
+++ b/packages/api/src/Http/Controllers/Cart/CartController.php
@@ -6,8 +6,10 @@ namespace Shopper\Api\Http\Controllers\Cart;
 
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Shopper\Api\Actions\UpdateCartAction;
 use Shopper\Api\Concerns\RespondsWithCart;
 use Shopper\Api\Http\Requests\Cart\CreateCartRequest;
+use Shopper\Api\Http\Requests\Cart\PatchCartRequest;
 use Shopper\Cart\Models\Cart;
 use Shopper\Cart\Models\Contracts\Cart as CartContract;
 use Shopper\Core\Models\Zone;
@@ -17,6 +19,10 @@ use TiMacDonald\JsonApi\JsonApiResource;
 final class CartController
 {
     use RespondsWithCart;
+
+    public function __construct(
+        private readonly UpdateCartAction $updateCart,
+    ) {}
 
     /**
      * Create a cart.
@@ -56,5 +62,21 @@ final class CartController
     public function show(Request $request, string $cartId): JsonApiResource
     {
         return $this->cartResource($this->findCart($request, $cartId));
+    }
+
+    /**
+     * Update a cart.
+     *
+     * Patches the currency, contact email or metadata. Switching the currency
+     * re-prices the lines and drops the shipping and payment choices bound to
+     * the old currency; it is rejected when a line has no price in the target.
+     */
+    public function update(PatchCartRequest $request, string $cartId): JsonApiResource
+    {
+        $cart = $this->findCart($request, $cartId);
+
+        $this->mutateCart(fn () => $this->updateCart->execute($cart, $request->validated()));
+
+        return $this->cartResource($cart->refresh());
     }
 }

--- a/packages/api/src/Http/Requests/Cart/PatchCartRequest.php
+++ b/packages/api/src/Http/Requests/Cart/PatchCartRequest.php
@@ -7,7 +7,7 @@ namespace Shopper\Api\Http\Requests\Cart;
 use Illuminate\Foundation\Http\FormRequest;
 use Shopper\Api\Concerns\NormalizesCartInput;
 
-final class CreateCartRequest extends FormRequest
+final class PatchCartRequest extends FormRequest
 {
     use NormalizesCartInput;
 
@@ -22,9 +22,9 @@ final class CreateCartRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'currency_code' => ['nullable', 'string', $this->currencyExistsRule()],
-            'email' => ['nullable', 'email', 'max:255'],
-            'metadata' => ['nullable', ...$this->metadataRules()],
+            'currency_code' => ['sometimes', 'required', 'string', $this->currencyExistsRule()],
+            'email' => ['sometimes', 'nullable', 'email', 'max:255'],
+            'metadata' => ['sometimes', 'nullable', ...$this->metadataRules()],
         ];
     }
 }

--- a/packages/api/src/Http/Resources/OrderResource.php
+++ b/packages/api/src/Http/Resources/OrderResource.php
@@ -29,7 +29,8 @@ final class OrderResource extends JsonApiResource
             'shipping_amount' => $this->shipping_amount,
             'price_amount' => $this->price_amount,
             'currency_code' => $this->currency_code,
-            'email' => $this->email,
+            // the buyer email is only exposed to the authenticated owner.
+            'email' => $request->user('sanctum') ? $this->email : null,
             'created_at' => $this->created_at->toIso8601String(),
         ];
     }

--- a/packages/cart/src/CartManager.php
+++ b/packages/cart/src/CartManager.php
@@ -15,6 +15,7 @@ use Shopper\Cart\Exceptions\InsufficientStockException;
 use Shopper\Cart\Exceptions\InvalidDiscountException;
 use Shopper\Cart\Models\Cart;
 use Shopper\Cart\Models\CartLine;
+use Shopper\Cart\Models\CartLineAdjustment;
 use Shopper\Cart\Pipelines\CartPipelineContext;
 use Shopper\Cart\Pipelines\CartPipelineRunner;
 use Shopper\Core\Contracts\Priceable;
@@ -154,6 +155,45 @@ final readonly class CartManager
         $cart->update(['email' => $email]);
     }
 
+    /**
+     * @param  array<string, mixed>|null  $metadata
+     */
+    public function setMetadata(Cart $cart, ?array $metadata): void
+    {
+        $this->guardCompleted($cart);
+
+        $cart->update(['metadata' => $metadata]);
+    }
+
+    /**
+     * Re-price the cart in another currency. Each line's unit price is resolved
+     * again from its purchasable, and the frozen checkout choices that are
+     * bound to the old currency (shipping price, payment session) are dropped
+     * so they are quoted again against the new total.
+     */
+    public function changeCurrency(Cart $cart, string $currencyCode): void
+    {
+        $this->guardCompleted($cart);
+
+        DB::transaction(function () use ($cart, $currencyCode): void {
+            $cart->loadMissing('lines.purchasable.prices');
+
+            foreach ($cart->lines as $line) {
+                $purchasable = $line->purchasable;
+                $price = $purchasable instanceof Priceable ? $purchasable->getPrice($currencyCode) : null;
+
+                $line->update(['unit_price_amount' => $price ? $price->amount : 0]);
+            }
+
+            $cart->update([
+                'currency_code' => $currencyCode,
+                'shipping_option_id' => null,
+                'shipping_amount' => null,
+                'payment_session' => null,
+            ]);
+        });
+    }
+
     public function applyCoupon(Cart $cart, string $code): void
     {
         $this->guardCompleted($cart);
@@ -175,9 +215,9 @@ final readonly class CartManager
 
         $cart->update(['coupon_code' => null]);
 
-        foreach ($cart->lines as $line) {
-            $line->adjustments()->delete();
-        }
+        CartLineAdjustment::query()
+            ->whereIn('cart_line_id', $cart->lines()->select('id'))
+            ->delete();
 
         CouponRemoved::dispatch($cart);
     }

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -47,6 +47,7 @@ export type {
   CreateCartPayload,
   CreateCartLinePayload,
   UpdateCartLinePayload,
+  UpdateCartPayload,
   ShippingOptionList,
 } from './store'
 export { ShopperApiError, buildQuery } from './http'

--- a/packages/sdk/src/store/cart.ts
+++ b/packages/sdk/src/store/cart.ts
@@ -12,6 +12,14 @@ export type CreateCartPayload = {
   metadata?: Record<string, unknown> | null
 }
 
+export type UpdateCartPayload = {
+  /** Re-price the cart in another currency. Drops the shipping and payment choices bound to the old one. */
+  currency_code?: string
+  /** Contact email frozen on the order at completion. */
+  email?: string | null
+  metadata?: Record<string, unknown> | null
+}
+
 export type CreateCartLinePayload = {
   /** Public id of the product or variant to add. */
   purchasable_id: string
@@ -82,6 +90,17 @@ export class CartModule {
 
   public async retrieve(id: string, params?: RequestParams): Promise<Cart> {
     return flatten<Cart>(await this.client.request(`${this.path}/${id}`, this.params(params))) as Cart
+  }
+
+  /**
+   * Patch the cart currency, contact email or metadata. Switching the currency
+   * re-prices the lines and drops the shipping and payment choices bound to the
+   * old currency; it is rejected when a line has no price in the target.
+   */
+  public async update(id: string, payload: UpdateCartPayload, params?: RequestParams): Promise<Cart> {
+    const document = await this.client.send('PATCH', `${this.path}/${id}`, payload, this.params(params))
+
+    return flatten<Cart>(document as NonNullable<typeof document>) as Cart
   }
 
   /**

--- a/packages/sdk/src/store/index.ts
+++ b/packages/sdk/src/store/index.ts
@@ -25,6 +25,7 @@ export type {
   SetCartAddressesPayload,
   ShippingOptionList,
   UpdateCartLinePayload,
+  UpdateCartPayload,
 } from './cart'
 export { CollectionResource } from './collection'
 export type { Paginated } from './collection'

--- a/tests/Api/Feature/CartEndpointsTest.php
+++ b/tests/Api/Feature/CartEndpointsTest.php
@@ -344,6 +344,184 @@ it('exposes discounts and taxes computed by the cart pipelines', function (): vo
         ->and($line['attributes']['tax_lines'][0]['amount'])->toBe(400);
 });
 
+it('updates the cart metadata', function (): void {
+    $cart = Cart::query()->create(['currency_code' => 'USD']);
+
+    $this->patchJson("/store/carts/{$cart->public_id}", ['metadata' => ['note' => 'gift']])
+        ->assertOk()
+        ->assertJsonPath('data.attributes.metadata.note', 'gift');
+
+    expect($cart->refresh()->metadata)->toBe(['note' => 'gift']);
+});
+
+it('updates the cart contact email', function (): void {
+    $cart = Cart::query()->create(['currency_code' => 'USD']);
+
+    $this->patchJson("/store/carts/{$cart->public_id}", ['email' => 'Buyer@Example.com'])
+        ->assertOk()
+        ->assertJsonPath('data.attributes.email', 'buyer@example.com');
+
+    expect($cart->refresh()->email)->toBe('buyer@example.com');
+});
+
+it('changes the cart currency and re-prices the lines', function (): void {
+    setupCurrencies(['USD', 'EUR']);
+    Currency::query()->where('code', 'EUR')->update(['is_enabled' => true]);
+
+    $eur = Currency::query()->where('code', 'EUR')->first();
+    $this->product->prices()->create(['amount' => 3000, 'currency_id' => $eur->id]);
+
+    $cart = Cart::query()->create([
+        'currency_code' => 'USD',
+        'shipping_option_id' => 'main-carrier:standard',
+        'shipping_amount' => 700,
+    ]);
+    $cart->lines()->create([
+        'purchasable_type' => $this->product->getMorphClass(),
+        'purchasable_id' => $this->product->id,
+        'quantity' => 2,
+        'unit_price_amount' => 2500,
+    ]);
+
+    $this->patchJson("/store/carts/{$cart->public_id}", ['currency_code' => 'eur'])
+        ->assertOk()
+        ->assertJsonPath('data.attributes.currency_code', 'EUR')
+        ->assertJsonPath('data.attributes.subtotal', 6000);
+
+    $cart->refresh();
+
+    expect($cart->lines()->first()->unit_price_amount)->toBe(3000)
+        ->and($cart->shipping_option_id)->toBeNull()
+        ->and($cart->shipping_amount)->toBeNull();
+});
+
+it('rejects a currency the shop does not sell in on update', function (): void {
+    $cart = Cart::query()->create(['currency_code' => 'USD']);
+
+    $this->patchJson("/store/carts/{$cart->public_id}", ['currency_code' => 'XXX'])
+        ->assertUnprocessable()
+        ->assertJsonPath('errors.0.source.pointer', '/data/attributes/currency_code');
+});
+
+it('rejects a currency that is enabled but not configured for the shop', function (): void {
+    // The shop sells in USD only (beforeEach). EUR exists and is enabled, but it
+    // is not among the configured currencies, so it must not be accepted.
+    $cart = Cart::query()->create(['currency_code' => 'USD']);
+
+    $this->patchJson("/store/carts/{$cart->public_id}", ['currency_code' => 'EUR'])
+        ->assertUnprocessable()
+        ->assertJsonPath('errors.0.source.pointer', '/data/attributes/currency_code');
+
+    expect($cart->refresh()->currency_code)->toBe('USD');
+});
+
+it('rejects a currency change when a line has no price in it', function (): void {
+    setupCurrencies(['USD', 'EUR']);
+    Currency::query()->where('code', 'EUR')->update(['is_enabled' => true]);
+
+    $cart = Cart::query()->create(['currency_code' => 'USD']);
+    $cart->lines()->create([
+        'purchasable_type' => $this->product->getMorphClass(),
+        'purchasable_id' => $this->product->id,
+        'quantity' => 1,
+        'unit_price_amount' => 2500,
+    ]);
+
+    $this->patchJson("/store/carts/{$cart->public_id}", ['currency_code' => 'EUR'])
+        ->assertUnprocessable()
+        ->assertJsonPath('errors.0.source.pointer', '/data/attributes/currency_code');
+
+    expect($cart->refresh()->currency_code)->toBe('USD');
+});
+
+it('rejects an update on a completed cart', function (): void {
+    $cart = Cart::query()->create(['currency_code' => 'USD', 'completed_at' => now()]);
+
+    $this->patchJson("/store/carts/{$cart->public_id}", ['metadata' => ['note' => 'late']])
+        ->assertConflict();
+});
+
+it('clears the payment session when the currency changes', function (): void {
+    setupCurrencies(['USD', 'EUR']);
+
+    $eur = Currency::query()->where('code', 'EUR')->first();
+    $this->product->prices()->create(['amount' => 3000, 'currency_id' => $eur->id]);
+
+    $cart = Cart::query()->create([
+        'currency_code' => 'USD',
+        'payment_session' => ['driver' => 'manual', 'reference' => 'ref_1', 'amount' => 2500, 'currency' => 'USD'],
+    ]);
+    $cart->lines()->create([
+        'purchasable_type' => $this->product->getMorphClass(),
+        'purchasable_id' => $this->product->id,
+        'quantity' => 1,
+        'unit_price_amount' => 2500,
+    ]);
+
+    $this->patchJson("/store/carts/{$cart->public_id}", ['currency_code' => 'EUR'])->assertOk();
+
+    expect($cart->refresh()->payment_session)->toBeNull();
+});
+
+it('drops a coupon that no longer applies after a currency change', function (): void {
+    setupCurrencies(['USD', 'EUR']);
+
+    $eur = Currency::query()->where('code', 'EUR')->first();
+    $this->product->prices()->create(['amount' => 3000, 'currency_id' => $eur->id]);
+
+    Discount::factory()->create([
+        'code' => 'FLAT5',
+        'is_active' => true,
+        'type' => DiscountType::FixedAmount,
+        'value' => 500,
+        'apply_to' => DiscountApplyTo::Order,
+        'eligibility' => DiscountEligibility::Everyone,
+        'min_required' => DiscountRequirement::None,
+        'start_at' => now()->subDay(),
+        'end_at' => now()->addMonth(),
+    ]);
+
+    $cart = Cart::query()->create(['currency_code' => 'USD', 'coupon_code' => 'FLAT5']);
+    $cart->lines()->create([
+        'purchasable_type' => $this->product->getMorphClass(),
+        'purchasable_id' => $this->product->id,
+        'quantity' => 1,
+        'unit_price_amount' => 2500,
+    ]);
+
+    $this->patchJson("/store/carts/{$cart->public_id}", ['currency_code' => 'EUR'])
+        ->assertOk()
+        ->assertJsonPath('data.attributes.coupon_code', null);
+
+    expect($cart->refresh()->coupon_code)->toBeNull();
+});
+
+it('rejects metadata that exceeds the size limit', function (): void {
+    $cart = Cart::query()->create(['currency_code' => 'USD']);
+
+    $this->patchJson("/store/carts/{$cart->public_id}", ['metadata' => ['blob' => str_repeat('x', 5000)]])
+        ->assertUnprocessable()
+        ->assertJsonPath('errors.0.source.pointer', '/data/attributes/metadata');
+});
+
+it('clears the metadata when null is sent', function (): void {
+    $cart = Cart::query()->create(['currency_code' => 'USD', 'metadata' => ['note' => 'gift']]);
+
+    $this->patchJson("/store/carts/{$cart->public_id}", ['metadata' => null])
+        ->assertOk()
+        ->assertJsonPath('data.attributes.metadata', null);
+
+    expect($cart->refresh()->metadata)->toBeNull();
+});
+
+it('keeps the existing email when null is sent', function (): void {
+    $cart = Cart::query()->create(['currency_code' => 'USD', 'email' => 'keep@example.com']);
+
+    $this->patchJson("/store/carts/{$cart->public_id}", ['email' => null])->assertOk();
+
+    expect($cart->refresh()->email)->toBe('keep@example.com');
+});
+
 it('transfers a guest cart to the authenticated customer', function (): void {
     $cart = Cart::query()->create(['currency_code' => 'USD']);
     $customer = User::factory()->create();

--- a/tests/Api/Feature/CheckoutEndpointsTest.php
+++ b/tests/Api/Feature/CheckoutEndpointsTest.php
@@ -738,3 +738,43 @@ it('rejects a promotion change on a completed cart', function (): void {
     $this->postJson("/store/carts/{$this->cart->public_id}/promotion", ['code' => 'SAVE20'])
         ->assertConflict();
 });
+
+it('rejects an expired promotion code', function (): void {
+    orderDiscount(['end_at' => now()->subDay()]);
+
+    $this->postJson("/store/carts/{$this->cart->public_id}/promotion", ['code' => 'SAVE20'])
+        ->assertUnprocessable()
+        ->assertJsonPath('errors.0.source.pointer', '/data/attributes/code');
+
+    expect($this->cart->refresh()->coupon_code)->toBeNull();
+});
+
+it('removing a promotion from a cart without a coupon is a no-op', function (): void {
+    $this->deleteJson("/store/carts/{$this->cart->public_id}/promotion")
+        ->assertOk()
+        ->assertJsonPath('data.attributes.coupon_code', null);
+});
+
+it('hides the order email from the unauthenticated lookup', function (): void {
+    readyCart($this->cart, $this->option, $this->paymentMethod);
+
+    $orderId = $this->postJson("/store/carts/{$this->cart->public_id}/complete")->json('data.id');
+
+    $this->getJson("/store/orders/{$orderId}")
+        ->assertOk()
+        ->assertJsonPath('data.attributes.email', null);
+});
+
+it('exposes the order email to the authenticated owner', function (): void {
+    $customer = User::factory()->create(['email' => 'owner@example.com']);
+    $this->cart->update(['customer_id' => $customer->id, 'email' => null]);
+    readyCart($this->cart, $this->option, $this->paymentMethod);
+
+    Sanctum::actingAs($customer, ['store']);
+
+    $orderId = $this->postJson("/store/carts/{$this->cart->public_id}/complete")->json('data.id');
+
+    $this->getJson("/store/customers/me/orders/{$orderId}")
+        ->assertOk()
+        ->assertJsonPath('data.attributes.email', 'owner@example.com');
+});


### PR DESCRIPTION
Adds a partial cart update endpoint so the storefront can change the currency, contact email or metadata after creation. Switching the currency re-prices the lines. This PR also hardens the cart/checkout flow with fixes surfaced while reviewing the API epic (#556, #557, #558).

## Endpoints (`/store`)
- `PATCH /store/carts/{id}` accepts `currency_code`, `email` and `metadata` (only the keys present are touched)

## Behavior
- A customer cart falls back to the authenticated customer email; a guest cart switching currency re-prices each line and is rejected when a line has no price in the target currency.
- Switching the currency cancels the open payment intent at the provider, and drops an applied coupon that no longer reduces the re-priced cart.
- Currency validation is restricted to the currencies the shop is configured to sell in (`shopper.settings.currencies`), not just any enabled currency.

## Hardening of the merged epic
- `ApplyCartPromotionAction` now runs apply-then-verify under a row lock in a transaction (no interleaving, automatic rollback) and no longer discloses the discount failure reason to the client.
- The buyer email is exposed only to the authenticated owner on the order lookup, never on the unauthenticated guest lookup.
- Coupon re-validation after a context change (currency switch, cart transfer) is centralised in a single action.
- `metadata` is bounded (max 50 keys, 4 KB).

## SDK
- `cart.update()` and the `UpdateCartPayload` type.

Closes #554 