### PR TITLE
fix(admin): show derived discount status in the listing

### DIFF
--- a/packages/admin/resources/views/livewire/tables/cells/discounts/date.blade.php
+++ b/packages/admin/resources/views/livewire/tables/cells/discounts/date.blade.php
@@ -3,13 +3,6 @@
 @endphp
 
 <div class="flex shrink-0 items-center gap-3">
-    <x-filament::badge :color="$discount->start_at <= now() ? 'success' : 'warning'">
-        @if ($discount->start_at <= now())
-            {{ __('shopper::words.active_for_users') }}
-        @else
-            {{ __('shopper::words.scheduled') }}
-        @endif
-    </x-filament::badge>
     <p class="text-sm leading-6 text-sh-fg-muted">
         @if ($discount->end_at)
             <span>{{ $discount->start_at->format('d M, Y') }}</span>

--- a/packages/admin/src/Livewire/Pages/Discount/Index.php
+++ b/packages/admin/src/Livewire/Pages/Discount/Index.php
@@ -12,7 +12,6 @@ use Filament\Forms\Components\DatePicker;
 use Filament\Notifications\Notification;
 use Filament\Schemas\Concerns\InteractsWithSchemas;
 use Filament\Schemas\Contracts\HasSchemas;
-use Filament\Tables\Columns\IconColumn;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Columns\ViewColumn;
 use Filament\Tables\Concerns\InteractsWithTable;
@@ -29,6 +28,7 @@ use Mckenziearts\Icons\Untitledui\Enums\Untitledui;
 use Shopper\Actions\Store\DuplicateDiscountAction;
 use Shopper\Core\Enum\DiscountApplyTo;
 use Shopper\Core\Enum\DiscountEligibility;
+use Shopper\Core\Enum\DiscountStatus;
 use Shopper\Core\Models\Discount;
 use Shopper\Livewire\Pages\AbstractPageComponent;
 use Shopper\Traits\HandlesAuthorizationExceptions;
@@ -76,10 +76,12 @@ class Index extends AbstractPageComponent implements HasActions, HasSchemas, Has
                     ->toggledHiddenByDefault()
                     ->color('gray')
                     ->badge(),
-                IconColumn::make('is_active')
+                TextColumn::make('status')
                     ->label(__('shopper::forms.label.status'))
-                    ->boolean()
-                    ->sortable(),
+                    ->badge()
+                    ->icon(fn (DiscountStatus $state): string => $state->getIcon())
+                    ->color(fn (DiscountStatus $state): string => $state->getColor())
+                    ->formatStateUsing(fn (DiscountStatus $state): string => $state->getLabel()),
                 ViewColumn::make('start_at')
                     ->label(__('shopper::words.date'))
                     ->toggleable()

--- a/tests/Admin/Livewire/Pages/Discount/IndexTest.php
+++ b/tests/Admin/Livewire/Pages/Discount/IndexTest.php
@@ -3,6 +3,8 @@
 declare(strict_types=1);
 
 use Livewire\Livewire;
+use Shopper\Core\Enum\DiscountApplyTo;
+use Shopper\Core\Enum\DiscountStatus;
 use Shopper\Core\Models\Discount;
 use Shopper\Livewire\Pages\Discount\Index;
 use Tests\Core\Stubs\User;
@@ -38,5 +40,33 @@ describe(Index::class, function (): void {
         Livewire::test(Index::class)
             ->filterTable('is_active', true)
             ->assertCountTableRecords(2);
+    });
+
+    it('shows the derived `Expired` status for an enabled discount past its end date', function (): void {
+        $discount = Discount::factory()->create([
+            'is_active' => true,
+            'apply_to' => DiscountApplyTo::Order(),
+            'start_at' => now()->subMonth(),
+            'end_at' => now()->subDay(),
+        ]);
+
+        Livewire::test(Index::class)
+            ->loadTable()
+            ->assertTableColumnStateSet('status', DiscountStatus::Expired, $discount);
+    });
+
+    it('shows the derived `LimitReached` status when usage has hit its limit', function (): void {
+        $discount = Discount::factory()->create([
+            'is_active' => true,
+            'apply_to' => DiscountApplyTo::Order(),
+            'start_at' => now()->subDay(),
+            'end_at' => now()->addMonth(),
+            'usage_limit' => 100,
+            'total_use' => 100,
+        ]);
+
+        Livewire::test(Index::class)
+            ->loadTable()
+            ->assertTableColumnStateSet('status', DiscountStatus::LimitReached, $discount);
     });
 })->group('livewire', 'discounts');


### PR DESCRIPTION
The discount listing rendered the raw `is_active` boolean as its status icon, so an enabled discount past its end date (or at its usage limit) showed a green check while the edit page and the cart correctly treated it as expired. Three surfaces, one truth, and the listing was the one ignoring it.

The listing now reads the derived `Discount::status()` accessor as a badge column, the same single source of truth the edit page and `DiscountValidator` already use. It renders every lifecycle state (`Expired`, `LimitReached`, `Scheduled`, `Disabled`, `Inapplicable`, `Active`) with its own color and icon.

The date cell also dropped its `start_at`-only badge, which labelled expired discounts "Active for users". The status column now carries that meaning, so the date cell is left to show the date range alone.