### PR TITLE
feat(upgrade): permissions dot-notation migration command

### DIFF
--- a/packages/upgrade/resources/boost/skills/shopper-upgrade-two-factor-auth/SKILL.blade.php
+++ b/packages/upgrade/resources/boost/skills/shopper-upgrade-two-factor-auth/SKILL.blade.php
@@ -95,6 +95,23 @@ Search for these patterns:
 grep -rn "ShopperUser.*2fa\|TwoFactorAuthenticatable\|two_factor_secret\|two_factor_recovery" app/ --include="*.php"
 ```
 
-### Step 3: Verify database columns
+### Step 3: Database columns are renamed
 
-The database columns remain the same (`two_factor_secret`, `two_factor_recovery_codes`, `two_factor_confirmed_at`). No migration needed.
+The `two_factor_secret` and `two_factor_recovery_codes` columns are renamed to avoid colliding with Laravel Fortify, which uses the unprefixed names:
+
+| 2.x column | 3.x column |
+|---|---|
+| `two_factor_secret` | `store_two_factor_secret` |
+| `two_factor_recovery_codes` | `store_two_factor_recovery_codes` |
+
+`two_factor_confirmed_at` is unchanged.
+
+The rename is handled automatically by the migration `2026_03_10_000000_rename_two_factor_columns_on_users_table.php` when you run `php artisan migrate`. The migration is idempotent — it is a no-op once the columns already use the `store_` prefix.
+
+Any code that reads or writes the old column names directly must be updated:
+
+```bash
+grep -rn "two_factor_secret\|two_factor_recovery_codes" app/ --include="*.php"
+```
+
+Replace `$user->two_factor_secret` with `$user->store_two_factor_secret` (and the recovery codes equivalent). Code going through the `InteractsWithStoreAuthentication` trait methods needs no change.

--- a/packages/upgrade/src/Console/MigratePermissions.php
+++ b/packages/upgrade/src/Console/MigratePermissions.php
@@ -1,0 +1,208 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Upgrade\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+use function Laravel\Prompts\confirm;
+use function Laravel\Prompts\info;
+use function Laravel\Prompts\spin;
+use function Laravel\Prompts\table;
+use function Laravel\Prompts\warning;
+
+#[AsCommand('shopper:upgrade:permissions')]
+final class MigratePermissions extends Command
+{
+    /**
+     * 2.x action prefix => 3.x action suffix.
+     */
+    private const array ACTIONS = [
+        'browse' => 'browse',
+        'read' => 'read',
+        'edit' => 'edit',
+        'add' => 'create',
+        'delete' => 'delete',
+    ];
+
+    /**
+     * [2.x underscore item, 3.x dotted base, 3.x group].
+     *
+     * @var array<int, array{string, string, string}>
+     */
+    private const array RESOURCES = [
+        ['brands', 'brands', 'catalog'],
+        ['categories', 'categories', 'catalog'],
+        ['collections', 'collections', 'catalog'],
+        ['products', 'products', 'products'],
+        ['product_variants', 'products.variants', 'products'],
+        ['attributes', 'attributes', 'products'],
+        ['suppliers', 'suppliers', 'products'],
+        ['tags', 'tags', 'products'],
+        ['reviews', 'reviews', 'products'],
+        ['orders', 'orders', 'sales'],
+        ['discounts', 'discounts', 'sales'],
+        ['customers', 'customers', 'customers'],
+        ['inventories', 'inventories', 'inventory'],
+    ];
+
+    /**
+     * Fixed 2.x name => 3.x dotted name (all in the `system` group).
+     */
+    private const array SYSTEM = [
+        'access_dashboard' => 'system.dashboard',
+        'access_setting' => 'system.settings',
+        'view_users' => 'system.users',
+    ];
+
+    protected $signature = 'shopper:upgrade:permissions
+        {--dry-run : Show what would be renamed without modifying data}
+        {--force : Skip confirmation prompt}';
+
+    protected $description = 'Rename admin permissions from underscore format (read_orders) to dot notation (orders.read) and regroup them';
+
+    public function handle(): int
+    {
+        if ($this->hasAlreadyRun() && ! $this->option('force')) {
+            warning('Permissions have already been migrated to dot notation. Use --force to run it again.');
+
+            return self::SUCCESS;
+        }
+
+        $present = $this->presentMappings();
+
+        if ($present === []) {
+            info('No underscore-format permissions found. Nothing to migrate.');
+
+            return self::SUCCESS;
+        }
+
+        table(
+            headers: ['2.x name', '3.x name', 'Group'],
+            rows: array_map(
+                fn (array $mapping): array => [$mapping['old'], $mapping['new'], $mapping['group']],
+                $present,
+            ),
+        );
+
+        if ($this->option('dry-run')) {
+            warning('Dry run — no data was modified. Run without --dry-run to apply.');
+
+            return self::SUCCESS;
+        }
+
+        if (! $this->option('force') && ! confirm('Rename these permissions to dot notation?', default: false)) {
+            warning('Upgrade cancelled.');
+
+            return self::SUCCESS;
+        }
+
+        [$renamed, $skipped] = spin(
+            callback: fn (): array => $this->apply($present),
+            message: 'Renaming permissions...',
+        );
+
+        info("{$renamed} permission(s) renamed to dot notation.");
+
+        if ($skipped > 0) {
+            warning("{$skipped} permission(s) skipped because the dot-notation name already existed.");
+        }
+
+        $this->markAsRun();
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * The full 2.x => 3.x mapping, regardless of what exists in the database.
+     *
+     * @return array<int, array{old: string, new: string, group: string}>
+     */
+    private function map(): array
+    {
+        $map = [];
+
+        foreach (self::SYSTEM as $old => $new) {
+            $map[] = ['old' => $old, 'new' => $new, 'group' => 'system'];
+        }
+
+        foreach (self::RESOURCES as [$item, $base, $group]) {
+            foreach (self::ACTIONS as $oldAction => $newAction) {
+                $map[] = [
+                    'old' => $oldAction.'_'.$item,
+                    'new' => $base.'.'.$newAction,
+                    'group' => $group,
+                ];
+            }
+        }
+
+        return $map;
+    }
+
+    /**
+     * Only the mappings whose 2.x permission actually exists in the database.
+     *
+     * @return array<int, array{old: string, new: string, group: string}>
+     */
+    private function presentMappings(): array
+    {
+        $existing = DB::table($this->permissionsTable())->pluck('name')->all();
+
+        return array_values(array_filter(
+            $this->map(),
+            fn (array $mapping): bool => in_array($mapping['old'], $existing, true),
+        ));
+    }
+
+    /**
+     * @param  array<int, array{old: string, new: string, group: string}>  $mappings
+     * @return array{0: int, 1: int} renamed and skipped counts
+     */
+    private function apply(array $mappings): array
+    {
+        return DB::transaction(function () use ($mappings): array {
+            $renamed = 0;
+            $skipped = 0;
+
+            foreach ($mappings as $mapping) {
+                if (DB::table($this->permissionsTable())->where('name', $mapping['new'])->exists()) {
+                    $skipped++;
+
+                    continue;
+                }
+
+                $renamed += DB::table($this->permissionsTable())
+                    ->where('name', $mapping['old'])
+                    ->update([
+                        'name' => $mapping['new'],
+                        'group_name' => $mapping['group'],
+                    ]);
+            }
+
+            return [$renamed, $skipped];
+        });
+    }
+
+    private function permissionsTable(): string
+    {
+        return config('permission.table_names.permissions', 'permissions');
+    }
+
+    private function hasAlreadyRun(): bool
+    {
+        return DB::table(shopper_table('settings'))
+            ->where('key', 'permissions_dot_notation_applied')
+            ->exists();
+    }
+
+    private function markAsRun(): void
+    {
+        DB::table(shopper_table('settings'))->insert([
+            'key' => 'permissions_dot_notation_applied',
+            'value' => json_encode(now()->toIso8601String()),
+        ]);
+    }
+}

--- a/packages/upgrade/src/UpgradeServiceProvider.php
+++ b/packages/upgrade/src/UpgradeServiceProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Shopper\Upgrade;
 
 use Shopper\Upgrade\Console\FixZeroDecimalCurrency;
+use Shopper\Upgrade\Console\MigratePermissions;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 
@@ -16,6 +17,7 @@ final class UpgradeServiceProvider extends PackageServiceProvider
             ->name('shopper-upgrade')
             ->hasCommands([
                 FixZeroDecimalCurrency::class,
+                MigratePermissions::class,
             ]);
     }
 }

--- a/tests/Upgrade/MigratePermissionsTest.php
+++ b/tests/Upgrade/MigratePermissionsTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+
+uses(Tests\Upgrade\TestCase::class);
+
+function permissionsTable(): string
+{
+    return config('permission.table_names.permissions', 'permissions');
+}
+
+function seedLegacyPermission(string $name, string $group): void
+{
+    DB::table(permissionsTable())->insert([
+        'name' => $name,
+        'guard_name' => 'web',
+        'group_name' => $group,
+        'can_be_removed' => false,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+}
+
+beforeEach(function (): void {
+    DB::table(permissionsTable())->delete();
+});
+
+describe('shopper:upgrade:permissions', function (): void {
+    it('renames underscore permissions to dot notation and regroups them', function (): void {
+        seedLegacyPermission('browse_brands', 'brands');
+        seedLegacyPermission('add_products', 'products');
+        seedLegacyPermission('edit_product_variants', 'products');
+        seedLegacyPermission('access_setting', 'system');
+
+        $this->artisan('shopper:upgrade:permissions', ['--force' => true])
+            ->assertSuccessful();
+
+        expect(DB::table(permissionsTable())->where('name', 'brands.browse')->value('group_name'))->toBe('catalog')
+            ->and(DB::table(permissionsTable())->where('name', 'products.create')->exists())->toBeTrue()
+            ->and(DB::table(permissionsTable())->where('name', 'products.variants.edit')->value('group_name'))->toBe('products')
+            ->and(DB::table(permissionsTable())->where('name', 'system.settings')->value('group_name'))->toBe('system')
+            ->and(DB::table(permissionsTable())->where('name', 'browse_brands')->exists())->toBeFalse();
+    });
+
+    it('does not modify data with `--dry-run`', function (): void {
+        seedLegacyPermission('browse_orders', 'orders');
+
+        $this->artisan('shopper:upgrade:permissions', ['--dry-run' => true])
+            ->assertSuccessful();
+
+        expect(DB::table(permissionsTable())->where('name', 'browse_orders')->exists())->toBeTrue()
+            ->and(DB::table(permissionsTable())->where('name', 'orders.browse')->exists())->toBeFalse();
+    });
+
+    it('skips when no underscore permissions exist', function (): void {
+        seedLegacyPermission('orders.browse', 'sales');
+
+        $this->artisan('shopper:upgrade:permissions', ['--force' => true])
+            ->assertSuccessful();
+
+        expect(DB::table(permissionsTable())->where('name', 'orders.browse')->value('group_name'))->toBe('sales');
+    });
+
+    it('does not run twice without `--force`', function (): void {
+        seedLegacyPermission('browse_brands', 'brands');
+
+        $this->artisan('shopper:upgrade:permissions', ['--force' => true])->assertSuccessful();
+
+        seedLegacyPermission('add_brands', 'brands');
+
+        $this->artisan('shopper:upgrade:permissions')->assertSuccessful();
+
+        expect(DB::table(permissionsTable())->where('name', 'add_brands')->exists())->toBeTrue()
+            ->and(DB::table(permissionsTable())->where('name', 'brands.create')->exists())->toBeFalse();
+    });
+
+    it('skips a rename when the dot-notation name already exists', function (): void {
+        seedLegacyPermission('browse_brands', 'brands');
+        seedLegacyPermission('brands.browse', 'catalog');
+
+        $this->artisan('shopper:upgrade:permissions', ['--force' => true])
+            ->assertSuccessful();
+
+        expect(DB::table(permissionsTable())->where('name', 'browse_brands')->exists())->toBeTrue()
+            ->and(DB::table(permissionsTable())->where('name', 'brands.browse')->count())->toBe(1);
+    });
+
+    it('cancels when user refuses confirmation', function (): void {
+        seedLegacyPermission('browse_brands', 'brands');
+
+        $this->artisan('shopper:upgrade:permissions')
+            ->expectsConfirmation('Rename these permissions to dot notation?', 'no')
+            ->assertSuccessful();
+
+        expect(DB::table(permissionsTable())->where('name', 'browse_brands')->exists())->toBeTrue()
+            ->and(DB::table(permissionsTable())->where('name', 'brands.browse')->exists())->toBeFalse();
+    });
+})
+    ->group('upgrade');


### PR DESCRIPTION
Adds the missing `shopper:upgrade:permissions` command and fixes the two-factor-auth upgrade skill, both referenced by the `shopper/upgrade` package but not yet shipped.

## Command

`shopper:upgrade:permissions` renames admin permissions from the 2.x underscore format (`read_orders`) to the 3.x dot notation (`orders.read`) and regroups them under the new domain groups (`catalog`, `sales`, `inventory`, `system`).

The 2.x to 3.x mapping is built programmatically from the same resource and action structure used by `PermissionsTableSeeder`, so it stays in sync without a large hardcoded table. `add_*` maps to `.create`; the other actions map 1:1; `product_variants` becomes `products.variants`.

It mirrors the existing `FixZeroDecimalCurrency` command:

- `--dry-run` previews the renames without writing
- `--force` skips confirmation
- idempotency guard via a `settings` row
- transactional update
- defensive skip when the dot-notation name already exists, avoiding a unique constraint violation mid-upgrade

## Skill fix

The `shopper-upgrade-two-factor-auth` skill claimed the database columns stay the same. They are renamed to avoid colliding with Laravel Fortify:

| 2.x | 3.x |
|---|---|
| `two_factor_secret` | `store_two_factor_secret` |
| `two_factor_recovery_codes` | `store_two_factor_recovery_codes` |

`two_factor_confirmed_at` is unchanged. The rename is handled by the idempotent migration `2026_03_10_000000_rename_two_factor_columns_on_users_table`.