### PR TITLE
feat(upgrade): Rector ruleset for 2.x to 3.x class renames

### DIFF
--- a/packages/upgrade/composer.json
+++ b/packages/upgrade/composer.json
@@ -8,7 +8,9 @@
     "illuminate/database": "^12.0|^13.0",
     "illuminate/support": "^12.0|^13.0",
     "laravel/prompts": "^0.3.16",
-    "spatie/laravel-package-tools": "^1.9"
+    "rector/rector": "^2.4",
+    "spatie/laravel-package-tools": "^1.9",
+    "symfony/process": "^7.0|^8.0"
   },
   "suggest": {
     "shopper/core": "Required for the shopper_table() and zero_decimal_currencies() helpers used by upgrade commands."

--- a/packages/upgrade/rector.php
+++ b/packages/upgrade/rector.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Renaming\Rector\Name\RenameClassRector;
+use Shopper\Upgrade\Rector\ClassRenames;
+
+return RectorConfig::configure()
+    ->withImportNames(
+        importShortClasses: false,
+        removeUnusedImports: true,
+    )
+    ->withConfiguredRule(RenameClassRector::class, ClassRenames::MAP);

--- a/packages/upgrade/src/Console/RunRector.php
+++ b/packages/upgrade/src/Console/RunRector.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Upgrade\Console;
+
+use Illuminate\Console\Command;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Process\Process;
+
+#[AsCommand('shopper:upgrade:rector')]
+final class RunRector extends Command
+{
+    protected $signature = 'shopper:upgrade:rector
+        {--path=app : Comma-separated paths to process}
+        {--dry-run : Preview changes without modifying any file}';
+
+    protected $description = 'Apply the 2.x to 3.x class rename rules to your application code with Rector';
+
+    public function handle(): int
+    {
+        $binary = base_path('vendor/bin/rector');
+
+        if (! file_exists($binary)) {
+            $this->error('Rector is not installed. Run: composer require rector/rector --dev');
+
+            return self::FAILURE;
+        }
+
+        $arguments = [
+            $binary,
+            'process',
+            ...array_map('trim', explode(',', (string) $this->option('path'))),
+            '--config',
+            (string) realpath(__DIR__.'/../../rector.php'),
+            '--clear-cache',
+        ];
+
+        if ($this->option('dry-run')) {
+            $arguments[] = '--dry-run';
+        }
+
+        $process = new Process($arguments, base_path(), timeout: null);
+
+        if (Process::isTtySupported()) {
+            $process->setTty(true);
+        }
+
+        $process->run(function (string $type, string $buffer): void {
+            $this->output->write($buffer);
+        });
+
+        return $process->getExitCode() ?? self::FAILURE;
+    }
+}

--- a/packages/upgrade/src/Rector/ClassRenames.php
+++ b/packages/upgrade/src/Rector/ClassRenames.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Upgrade\Rector;
+
+/**
+ * The 2.x => 3.x class, interface and trait renames that are pure symbol moves,
+ * safe to apply mechanically with Rector's RenameClassRector.
+ *
+ * Behavioral migrations (new contract methods, removed components, money
+ * semantics) are intentionally NOT here — those are handled by the Boost
+ * upgrade skills, because they require judgment Rector cannot make.
+ *
+ * Note: Rector renames these symbols everywhere they are referenced (imports,
+ * type-hints, `new`, `::class`, `implements`, `use TraitName`, and `extends`
+ * of the abstract Setting base). It deliberately leaves `extends` of the now
+ * final Setting item classes untouched, since a final class cannot be
+ * extended — that case is covered by the settings skill.
+ */
+final class ClassRenames
+{
+    /**
+     * @var array<string, string>
+     */
+    public const array MAP = [
+        // Settings moved under the Navigation subsystem.
+        'Shopper\Settings\Setting' => 'Shopper\Navigation\Setting\Setting',
+        'Shopper\Settings\SettingManager' => 'Shopper\Navigation\Setting\SettingManager',
+        'Shopper\Settings\Items\CarrierSetting' => 'Shopper\Navigation\Setting\Items\CarrierSetting',
+        'Shopper\Settings\Items\CurrencySetting' => 'Shopper\Navigation\Setting\Items\CurrencySetting',
+        'Shopper\Settings\Items\GeneralSetting' => 'Shopper\Navigation\Setting\Items\GeneralSetting',
+        'Shopper\Settings\Items\LegalSetting' => 'Shopper\Navigation\Setting\Items\LegalSetting',
+        'Shopper\Settings\Items\LocationSetting' => 'Shopper\Navigation\Setting\Items\LocationSetting',
+        'Shopper\Settings\Items\PaymentSetting' => 'Shopper\Navigation\Setting\Items\PaymentSetting',
+        'Shopper\Settings\Items\StaffSetting' => 'Shopper\Navigation\Setting\Items\StaffSetting',
+        'Shopper\Settings\Items\TaxSetting' => 'Shopper\Navigation\Setting\Items\TaxSetting',
+        'Shopper\Settings\Items\ZoneSetting' => 'Shopper\Navigation\Setting\Items\ZoneSetting',
+
+        // Model contracts relocated across packages.
+        'Shopper\Core\Models\Contracts\ShopperUser' => 'Shopper\Models\Contracts\ShopperUser',
+        'Shopper\Core\Models\Contracts\Cart' => 'Shopper\Cart\Models\Contracts\Cart',
+        'Shopper\Core\Models\Contracts\CartLine' => 'Shopper\Cart\Models\Contracts\CartLine',
+
+        // Two-factor trait split: the old monolith maps to the primary trait.
+        // The companion InteractsWithStoreAuthenticationRecovery trait and the
+        // matching interfaces are added through the two-factor-auth skill.
+        'Shopper\Traits\TwoFactorAuthenticatable' => 'Shopper\Traits\InteractsWithStoreAuthentication',
+
+        // Product edit screens moved from Livewire components to pages.
+        'Shopper\Livewire\Components\Products\Form\Edit' => 'Shopper\Livewire\Pages\Product\Overview',
+        'Shopper\Livewire\Components\Products\Form\Attributes' => 'Shopper\Livewire\Pages\Product\Attributes',
+        'Shopper\Livewire\Components\Products\Form\Files' => 'Shopper\Livewire\Pages\Product\Files',
+        'Shopper\Livewire\Components\Products\Form\Inventory' => 'Shopper\Livewire\Pages\Product\Inventory',
+        'Shopper\Livewire\Components\Products\Form\Media' => 'Shopper\Livewire\Pages\Product\Media',
+        'Shopper\Livewire\Components\Products\Form\RelatedProducts' => 'Shopper\Livewire\Pages\Product\Related',
+        'Shopper\Livewire\Components\Products\Form\Seo' => 'Shopper\Livewire\Pages\Product\Seo',
+        'Shopper\Livewire\Components\Products\Form\Shipping' => 'Shopper\Livewire\Pages\Product\Shipping',
+        'Shopper\Livewire\Components\Products\Form\Variants' => 'Shopper\Livewire\Pages\Product\Variants',
+    ];
+}

--- a/packages/upgrade/src/UpgradeServiceProvider.php
+++ b/packages/upgrade/src/UpgradeServiceProvider.php
@@ -6,6 +6,7 @@ namespace Shopper\Upgrade;
 
 use Shopper\Upgrade\Console\FixZeroDecimalCurrency;
 use Shopper\Upgrade\Console\MigratePermissions;
+use Shopper\Upgrade\Console\RunRector;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 
@@ -18,6 +19,7 @@ final class UpgradeServiceProvider extends PackageServiceProvider
             ->hasCommands([
                 FixZeroDecimalCurrency::class,
                 MigratePermissions::class,
+                RunRector::class,
             ]);
     }
 }

--- a/tests/Upgrade/RectorRenamesTest.php
+++ b/tests/Upgrade/RectorRenamesTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use Shopper\Upgrade\Rector\ClassRenames;
+
+function symbolExists(string $fqcn): bool
+{
+    return class_exists($fqcn) || interface_exists($fqcn) || trait_exists($fqcn);
+}
+
+describe('ClassRenames::MAP', function (): void {
+    it('maps every removed 2.x symbol to an existing 3.x symbol', function (): void {
+        foreach (ClassRenames::MAP as $old => $new) {
+            expect(symbolExists($new))->toBeTrue("3.x target [{$new}] does not exist");
+            expect(symbolExists($old))->toBeFalse("2.x source [{$old}] still exists on 3.x, it is not a clean rename");
+        }
+    });
+
+    it('never points two different sources at the same target', function (): void {
+        $targets = array_values(ClassRenames::MAP);
+
+        expect($targets)->toHaveCount(count(array_unique($targets)));
+    });
+
+    it('keeps the source and target fully qualified without a leading slash', function (): void {
+        foreach (ClassRenames::MAP as $old => $new) {
+            expect($old)->not->toStartWith('\\')
+                ->and($new)->not->toStartWith('\\')
+                ->and($old)->not->toBe($new);
+        }
+    });
+})
+    ->group('upgrade');


### PR DESCRIPTION
Adds the Rector leg of the `shopper/upgrade` package: a `RenameClassRector` ruleset and the `shopper:upgrade:rector` command that mechanically migrates the class, interface and trait moves between 2.x and 3.x.

## What it renames

24 verified symbol moves (each confirmed absent on 2.x and present on 3.x by `RectorRenamesTest`):

- `Shopper\Settings\*` to `Shopper\Navigation\Setting\*` (base, manager, 9 setting items)
- `Shopper\Core\Models\Contracts\{ShopperUser,Cart,CartLine}` to their new packages
- `Shopper\Traits\TwoFactorAuthenticatable` to `Shopper\Traits\InteractsWithStoreAuthentication`
- the 9 product edit screens from `Shopper\Livewire\Components\Products\Form\*` to `Shopper\Livewire\Pages\Product\*` (including `Edit` to `Overview`, `RelatedProducts` to `Related`)

## Command

`shopper:upgrade:rector --path=app --dry-run` shells out to `vendor/bin/rector process`. The config path is resolved relative to the package, so it works both inside the monorepo and once installed under `vendor/shopper/upgrade`. `withImportNames` keeps the rewritten imports clean and drops the unused ones.

## Scope

Rector renames these symbols in imports, type-hints, `new`, `::class`, `implements`, `use TraitName`, and `extends` of the abstract `Setting` base (the real custom-settings pattern). It intentionally leaves `extends` of the now `final` setting item classes untouched, because a final class cannot be extended. That architectural change, along with the other behavioral migrations (new contract methods, removed components, money semantics), is handled by the Boost upgrade skills rather than a blind rename.

Depends on the upgrade package merged in #562.