### PR TITLE
feat(upgrade): Boost skills for the remaining 2.x to 3.x breaking changes

### DIFF
--- a/packages/upgrade/resources/boost/skills/shopper-upgrade-config/SKILL.md
+++ b/packages/upgrade/resources/boost/skills/shopper-upgrade-config/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: shopper-upgrade-config
+description: Guides reconciliation of published config files (cart pipelines, max_promotions, discount components) after upgrading to Shopper 3.x. Only needed if the app published config/shopper/cart.php or config/shopper/components/discount.php under 2.x.
+license: MIT
+metadata:
+    author: shopperlabs
+---
+
+# Shopper Upgrade: Published Config Reconciliation
+
+You are upgrading a project from Shopper 2.x to 3.x. A config file published under 2.x keeps its old shape and silently overrides the package defaults. This skill covers the two config files whose changes affect runtime behaviour.
+
+## Pre-check
+
+```bash
+ls config/shopper/cart.php config/shopper/components/discount.php 2>/dev/null
+```
+
+If **no results**, the app never published these files and inherits the 3.x defaults automatically. Skip this skill.
+
+## config/shopper/cart.php
+
+The promotion engine added a pipeline stage and a limit. A 2.x copy is missing both, so automatic promotions never run and the stacking limit is undefined.
+
+Add `ApplyAutomaticPromotions` to the cart pipeline, before `ApplyDiscounts`:
+
+```php
+'pipelines' => [
+    'cart' => [
+        Pipelines\CalculateLines::class,
+        Pipelines\ApplyAutomaticPromotions::class, // add this
+        Pipelines\ApplyDiscounts::class,
+        Pipelines\CalculateTax::class,
+        Pipelines\Calculate::class,
+    ],
+],
+```
+
+Add the stacking limit at the top level of the config:
+
+```php
+// The highest number of promotions that may apply to a single cart at once.
+'max_promotions' => 5,
+```
+
+## config/shopper/components/discount.php
+
+The discount form slide-over was removed and replaced by the promotion components. If your published copy still registers the old key, replace it:
+
+| Removed | Added |
+|---|---|
+| `slide-overs.discount-form` | `slide-overs.add-promotion` |
+| | `slide-overs.discount-products-picker` |
+| | `slide-overs.discount-customers-picker` |
+| | `discounts.stats-panel` |
+| | `discount-edit` (page) |
+
+The simplest path is to re-publish the component config and re-apply your overrides:
+
+```bash
+php artisan shopper:component:publish
+```
+
+## Verify
+
+After merging, confirm a cart with an automatic promotion applies it, and the discount admin screens open without a missing-component error.

--- a/packages/upgrade/resources/boost/skills/shopper-upgrade-contracts/SKILL.md
+++ b/packages/upgrade/resources/boost/skills/shopper-upgrade-contracts/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: shopper-upgrade-contracts
+description: Guides migration of model contracts moved across packages (ShopperUser, Cart, CartLine) and the new required methods on the PaymentDriver and Order contracts. Needed when upgrading to Shopper 3.x if the app has custom payment drivers, a custom Order or Cart model, or type-hints on the moved contracts.
+license: MIT
+metadata:
+    author: shopperlabs
+---
+
+# Shopper Upgrade: Contract Changes
+
+You are upgrading a project from Shopper 2.x to 3.x. Some model contracts moved to other packages, and two contracts gained methods that custom implementations must add.
+
+## Pre-check
+
+```bash
+grep -rEl "Shopper\\\\Core\\\\Models\\\\Contracts\\\\(ShopperUser|Cart|CartLine)|implements PaymentDriver|PaymentDriver\b" app/ --include="*.php" 2>/dev/null
+```
+
+If **no results**, this upgrade does not apply. Skip it and inform the user.
+
+## Contracts moved across packages
+
+`php artisan shopper:upgrade:rector` rewrites these references automatically (imports, type-hints, `implements`). Run it first.
+
+| 2.x                                         | 3.x                                      |
+|---------------------------------------------|------------------------------------------|
+| `Shopper\Core\Models\Contracts\ShopperUser` | `Shopper\Models\Contracts\ShopperUser`   |
+| `Shopper\Core\Models\Contracts\Cart`        | `Shopper\Cart\Models\Contracts\Cart`     |
+| `Shopper\Core\Models\Contracts\CartLine`    | `Shopper\Cart\Models\Contracts\CartLine` |
+
+```bash
+php artisan shopper:upgrade:rector
+```
+
+## New required method: PaymentDriver::mode()
+
+Every class implementing `Shopper\Payment\Contracts\PaymentDriver` must now declare `mode()`. Without it the class is no longer a valid implementation and PHP throws a fatal error.
+
+```php
+use Shopper\Payment\Enum\PaymentMode;
+
+/**
+ * Return the live/test mode of the driver, or null when the driver has no
+ * such notion (manual providers, unconfigured drivers).
+ */
+public function mode(): ?PaymentMode
+{
+    // Return PaymentMode::Live or PaymentMode::Test based on your driver's
+    // configuration, or null when it does not apply.
+    return $this->isLiveMode() ? PaymentMode::Live : PaymentMode::Test;
+}
+```
+
+`PaymentMode` has two cases: `PaymentMode::Live` and `PaymentMode::Test`.
+
+## New required method: Order::promotions()
+
+If the app uses a **custom Order model** that implements `Shopper\Core\Models\Contracts\Order` from scratch (not one that extends `Shopper\Core\Models\Order`), it must add the `promotions()` relationship:
+
+```php
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Shopper\Core\Models\OrderPromotion;
+
+public function promotions(): HasMany
+{
+    return $this->hasMany(OrderPromotion::class, 'order_id');
+}
+```
+
+Most projects extend the default `Shopper\Core\Models\Order` and inherit this automatically — no change needed in that case.
+
+## Search patterns
+
+```bash
+grep -rn "implements PaymentDriver\|implements Order\b\|Shopper\\\\Core\\\\Models\\\\Contracts" app/ --include="*.php"
+```
+
+Add the missing methods, then verify the app boots and the payment drivers resolve.

--- a/packages/upgrade/resources/boost/skills/shopper-upgrade-product-edit/SKILL.md
+++ b/packages/upgrade/resources/boost/skills/shopper-upgrade-product-edit/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: shopper-upgrade-product-edit
+description: Guides migration of the product edit screen from Livewire form components to pages, and the new section registration in config/shopper/components/product.php. Needed when upgrading to Shopper 3.x if the app overrode product edit components or referenced their Livewire component names in custom views.
+license: MIT
+metadata:
+    author: shopperlabs
+---
+
+# Shopper Upgrade: Product Edit Restructure
+
+You are upgrading a project from Shopper 2.x to 3.x. The product edit screen was reworked from a set of Livewire form components into an extensible navigation shell made of pages and registered sections.
+
+## Pre-check
+
+```bash
+grep -rEl "Products\\\\Form\\\\|products\.form\.|product-edit" app/ config/ resources/ --include="*.php" --include="*.blade.php" 2>/dev/null
+```
+
+If **no results**, this upgrade does not apply. Skip it and inform the user.
+
+## Classes moved
+
+`php artisan shopper:upgrade:rector` rewrites these automatically. Run it first.
+
+| 2.x                                                         | 3.x                                         |
+|-------------------------------------------------------------|---------------------------------------------|
+| `Shopper\Livewire\Components\Products\Form\Edit`            | `Shopper\Livewire\Pages\Product\Overview`   |
+| `Shopper\Livewire\Components\Products\Form\Attributes`      | `Shopper\Livewire\Pages\Product\Attributes` |
+| `Shopper\Livewire\Components\Products\Form\Files`           | `Shopper\Livewire\Pages\Product\Files`      |
+| `Shopper\Livewire\Components\Products\Form\Inventory`       | `Shopper\Livewire\Pages\Product\Inventory`  |
+| `Shopper\Livewire\Components\Products\Form\Media`           | `Shopper\Livewire\Pages\Product\Media`      |
+| `Shopper\Livewire\Components\Products\Form\RelatedProducts` | `Shopper\Livewire\Pages\Product\Related`    |
+| `Shopper\Livewire\Components\Products\Form\Seo`             | `Shopper\Livewire\Pages\Product\Seo`        |
+| `Shopper\Livewire\Components\Products\Form\Shipping`        | `Shopper\Livewire\Pages\Product\Shipping`   |
+| `Shopper\Livewire\Components\Products\Form\Variants`        | `Shopper\Livewire\Pages\Product\Variants`   |
+
+```bash
+php artisan shopper:upgrade:rector
+```
+
+## Published config/shopper/components/product.php
+
+The `product-edit` page key and the nine `products.form.*` component keys were removed. The new config registers one page per tab plus a `sections` list that drives the edit sidebar:
+
+```php
+return [
+    'sections' => [
+        Sections\OverviewSection::class => true,
+        Sections\MediaSection::class => true,
+        // ... AttributesSection, VariantsSection, InventorySection,
+        //     PricingSection, ShippingSection, FilesSection, SeoSection,
+        //     RelatedProductsSection
+    ],
+
+    'pages' => [
+        'product-overview' => Livewire\Pages\Product\Overview::class,
+        'product-media' => Livewire\Pages\Product\Media::class,
+        // ... product-attributes, product-variants, product-inventory,
+        //     product-pricing, product-shipping, product-files,
+        //     product-seo, product-related
+    ],
+
+    'components' => [
+        'products.delete-action' => Components\Products\DeleteAction::class,
+    ],
+];
+```
+
+If you published this config under 2.x, re-publish it and re-apply your overrides:
+
+```bash
+php artisan shopper:component:publish
+```
+
+To add a custom tab, register a section class in `sections` and a page in `pages` rather than overriding a monolithic edit component.
+
+## Custom Blade views
+
+Livewire components are registered as `shopper-{key}`, so the old `products.form.*` keys resolved to `shopper-products.form.*` and the new page keys resolve to `shopper-product-*`. Update any custom view that rendered a product form component by name:
+
+```blade
+{{-- Before --}}
+@livewire('shopper-products.form.edit', ['product' => $product])
+
+{{-- After --}}
+@livewire('shopper-product-overview', ['product' => $product])
+```
+
+Check the exact aliases in `config/shopper/components/product.php` if a reference does not resolve.
+
+## Search patterns
+
+```bash
+grep -rn "Products\\\\Form\\\\\|products\.form\.\|product-edit" app/ config/ resources/
+```

--- a/packages/upgrade/resources/boost/skills/shopper-upgrade-settings-namespace/SKILL.md
+++ b/packages/upgrade/resources/boost/skills/shopper-upgrade-settings-namespace/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: shopper-upgrade-settings-namespace
+description: Guides migration of the Settings subsystem from Shopper\Settings\* to Shopper\Navigation\Setting\* and the settings config changes. Needed when upgrading to Shopper 3.x if the app has custom settings pages, a published config/shopper/settings.php, or a published config/shopper/components/setting.php.
+license: MIT
+metadata:
+    author: shopperlabs
+---
+
+# Shopper Upgrade: Settings Namespace Migration
+
+You are upgrading a project from Shopper 2.x to 3.x. The settings subsystem moved under the navigation subsystem and several settings components were merged or removed.
+
+## Pre-check
+
+```bash
+grep -rEl "Shopper\\\\Settings\\\\|setting-index|settings\.legal\.|settings\.team\.users" app/ config/ --include="*.php" 2>/dev/null
+```
+
+If **no results**, this upgrade does not apply. Skip it and inform the user.
+
+## What changed
+
+`Shopper\Settings\*` moved to `Shopper\Navigation\Setting\*`:
+
+| 2.x                               | 3.x                                         |
+|-----------------------------------|---------------------------------------------|
+| `Shopper\Settings\Setting`        | `Shopper\Navigation\Setting\Setting`        |
+| `Shopper\Settings\SettingManager` | `Shopper\Navigation\Setting\SettingManager` |
+| `Shopper\Settings\Items\*Setting` | `Shopper\Navigation\Setting\Items\*Setting` |
+
+Most code references (imports, type-hints, `extends` of the abstract `Setting` base) are rewritten automatically by `php artisan shopper:upgrade:rector`. Run that first. This skill covers what Rector cannot do.
+
+## Step 1: Run Rector
+
+```bash
+php artisan shopper:upgrade:rector --dry-run
+php artisan shopper:upgrade:rector
+```
+
+## Step 2: Custom setting items that extended a concrete item
+
+The concrete `Shopper\Navigation\Setting\Items\*Setting` classes are now `final` and cannot be extended. If a custom class did `extends GeneralSetting` (or any other item), Rector leaves it untouched on purpose.
+
+Re-point it at the abstract base instead:
+
+```php
+// Before
+use Shopper\Settings\Setting;
+
+class StoreLocaleSetting extends Setting { /* ... */ }
+```
+
+The abstract base `Shopper\Navigation\Setting\Setting` is the supported extension point. Register custom items through `config/shopper/settings.php` (Step 3).
+
+## Step 3: Published config/shopper/settings.php
+
+A copy published under 2.x still imports the old namespace and will fatal on boot. Update the `use` and register the new `AppearanceSetting`:
+
+```php
+// Before
+use Shopper\Settings\Items;
+
+// After
+use Shopper\Navigation\Setting\Items;
+
+return [
+    'items' => [
+        Items\GeneralSetting::class => true,
+        Items\AppearanceSetting::class => true, // new in 3.x
+        // ...
+    ],
+];
+```
+
+## Step 4: Published config/shopper/components/setting.php
+
+These component keys were removed in 3.x. If your published copy still lists them, delete the lines:
+
+| Removed key                                                | Replacement                                                         |
+|------------------------------------------------------------|---------------------------------------------------------------------|
+| `setting-index`                                            | none — the settings hub is gone, routes go straight to `general`    |
+| `settings.legal.privacy` / `refund` / `shipping` / `terms` | merged into `Shopper\Livewire\Components\Settings\Legal\PolicyForm` |
+| `settings.team.users` (`UsersRole`)                        | `settings.team.administrators` (`AdministratorsList`)               |
+
+New keys added in 3.x: `appearance` and `settings.team.administrators`. The simplest path is to re-publish the component config and re-apply any customisations:
+
+```bash
+php artisan shopper:component:publish
+```
+
+## Search patterns
+
+```bash
+grep -rn "Shopper\\\\Settings\\\\\|setting-index\|settings\.legal\.\|settings\.team\.users\|UsersRole" app/ config/ --include="*.php"
+```


### PR DESCRIPTION
Adds the Boost skills leg of the `shopper/upgrade` package. These cover the breaking changes that `shopper:upgrade:rector` (#563) cannot resolve mechanically, because they require judgment rather than a symbol rename. Each skill is scoped by a pre-check grep so it activates only when relevant, and is auto-discovered by `boost:install` / `boost:update --discover` while the package is installed.

## Skills

- **settings-namespace** — the `Shopper\Settings` to `Shopper\Navigation\Setting` move, the published `settings.php` and `components/setting.php` config, and the now `final` setting items (whose `extends` Rector intentionally leaves alone).
- **contracts** — the `ShopperUser`, `Cart` and `CartLine` contract moves, plus the new required `PaymentDriver::mode()` and `Order::promotions()` methods that custom implementations must add.
- **product-edit** — the product edit components turned into pages, and the new `sections` / `pages` registration in `components/product.php`.
- **config** — reconciling a published cart pipeline (`ApplyAutomaticPromotions` stage and `max_promotions`) and the discount components.

The skills delegate the symbol renames to `shopper:upgrade:rector` and only document the judgment calls. All class names, config keys and commands were verified against the 3.x source.

## Scope notes

Two breaking changes from the initial analysis were dropped after verifying against the source:

- An `archived-scope` skill is not needed: `Order::archived()` still works, the scope just moved to the `#[Scope]` attribute syntax with the same call site.
- An `admin.php` config skill is not needed: there is no diff on the color, resources or inventory keys between 2.x and 3.x.

Depends on #563.