### PR TITLE
feat(upgrade): shopper:upgrade orchestrator command

### DIFF
--- a/packages/upgrade/src/Console/UpgradeCommand.php
+++ b/packages/upgrade/src/Console/UpgradeCommand.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Upgrade\Console;
+
+use Illuminate\Console\Command;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Process\Process;
+
+use function Laravel\Prompts\confirm;
+use function Laravel\Prompts\info;
+use function Laravel\Prompts\note;
+use function Laravel\Prompts\warning;
+
+#[AsCommand('shopper:upgrade')]
+final class UpgradeCommand extends Command
+{
+    protected $signature = 'shopper:upgrade
+        {--path=app : Comma-separated paths for Rector to process}
+        {--force : Run every step without confirmation}';
+
+    protected $description = 'Run the full 2.x to 3.x upgrade: migrations, code renames and data migrations';
+
+    public function handle(): int
+    {
+        warning('This will run database migrations, rewrite application code with Rector, and migrate permission and money data.');
+        note('Make sure your work is committed to git and your database is backed up before continuing.');
+
+        if (! $this->option('force')) {
+            if ($this->workingTreeIsDirty() && ! confirm('Your git working tree has uncommitted changes. Continue anyway?', default: false)) {
+                warning('Upgrade cancelled. Commit or stash your changes first.');
+
+                return self::SUCCESS;
+            }
+
+            if (! confirm('Run the 2.x to 3.x upgrade now?', default: false)) {
+                warning('Upgrade cancelled.');
+
+                return self::SUCCESS;
+            }
+        }
+
+        info('Step 1/4 — Running database migrations');
+        $this->call('migrate', ['--force' => true]);
+
+        info('Step 2/4 — Renaming classes with Rector');
+        $this->runRector();
+
+        info('Step 3/4 — Migrating permissions to dot notation');
+        $this->call('shopper:upgrade:permissions', ['--force' => true]);
+
+        info('Step 4/4 — Fixing zero-decimal currency amounts');
+        $this->call('shopper:upgrade:fix-zero-decimal-currencies', ['--force' => true]);
+
+        $this->printNextSteps();
+
+        return self::SUCCESS;
+    }
+
+    private function runRector(): void
+    {
+        $path = (string) $this->option('path');
+
+        $hasTarget = collect(explode(',', $path))
+            ->map(fn (string $segment): string => mb_trim($segment))
+            ->filter()
+            ->contains(fn (string $segment): bool => is_dir(base_path($segment)));
+
+        if (! $hasTarget) {
+            warning("None of the paths [{$path}] exist — skipping Rector. Run `shopper:upgrade:rector --path=...` manually.");
+
+            return;
+        }
+
+        $this->call('shopper:upgrade:rector', ['--path' => $path]);
+    }
+
+    private function workingTreeIsDirty(): bool
+    {
+        $process = new Process(['git', 'status', '--porcelain'], base_path());
+        $process->run();
+
+        if (! $process->isSuccessful()) {
+            return false;
+        }
+
+        return mb_trim($process->getOutput()) !== '';
+    }
+
+    private function printNextSteps(): void
+    {
+        info('Automated upgrade steps complete.');
+
+        note(
+            "Next steps:\n".
+            "  1. Review the changes Rector made to your code.\n".
+            "  2. Run `php artisan boost:update --discover` to pull the Shopper upgrade skills for the changes that need manual judgment (settings, contracts, product edit, config).\n".
+            '  3. Run your test suite and boot the app to confirm everything works.'
+        );
+    }
+}

--- a/packages/upgrade/src/UpgradeServiceProvider.php
+++ b/packages/upgrade/src/UpgradeServiceProvider.php
@@ -7,6 +7,7 @@ namespace Shopper\Upgrade;
 use Shopper\Upgrade\Console\FixZeroDecimalCurrency;
 use Shopper\Upgrade\Console\MigratePermissions;
 use Shopper\Upgrade\Console\RunRector;
+use Shopper\Upgrade\Console\UpgradeCommand;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 
@@ -17,6 +18,7 @@ final class UpgradeServiceProvider extends PackageServiceProvider
         $package
             ->name('shopper-upgrade')
             ->hasCommands([
+                UpgradeCommand::class,
                 FixZeroDecimalCurrency::class,
                 MigratePermissions::class,
                 RunRector::class,

--- a/tests/Upgrade/UpgradeCommandTest.php
+++ b/tests/Upgrade/UpgradeCommandTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+
+uses(Tests\Upgrade\TestCase::class);
+
+describe('shopper:upgrade', function (): void {
+    it('chains the data migrations when forced', function (): void {
+        $table = config('permission.table_names.permissions', 'permissions');
+
+        DB::table($table)->delete();
+        DB::table($table)->insert([
+            'name' => 'browse_brands',
+            'guard_name' => 'web',
+            'group_name' => 'brands',
+            'can_be_removed' => false,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $this->artisan('shopper:upgrade', ['--force' => true, '--path' => 'rector-target-that-does-not-exist'])
+            ->assertSuccessful();
+
+        expect(DB::table($table)->where('name', 'brands.browse')->value('group_name'))->toBe('catalog')
+            ->and(DB::table($table)->where('name', 'browse_brands')->exists())->toBeFalse();
+    });
+})
+    ->group('upgrade');


### PR DESCRIPTION
Adds the `shopper:upgrade` command that ties the upgrade package together. It runs the full 2.x to 3.x upgrade in order:

1. `migrate` — schema changes (2FA columns, public_id, campaigns, order promotions)
2. `shopper:upgrade:rector` — the class renames (#563)
3. `shopper:upgrade:permissions` — permission dot notation (#562)
4. `shopper:upgrade:fix-zero-decimal-currencies` — money data

## Safety

- Warns to back up the database and commit to git first
- Checks the git working tree and confirms before running, unless `--force`
- The Rector step is skipped with a notice when none of the `--path` targets exist, so the command never fails on a missing directory
- Finishes by pointing the user at the Rector diff and `boost:update --discover` to pull the upgrade skills for the changes that need manual judgment (settings, contracts, product edit, config)

Depends on #562 and #563. Complements the skills in #564.