### PR TITLE
fix(admin): show derived discount status in the listing

### DIFF
--- a/packages/admin/resources/views/livewire/components/account/dropdown.blade.php
+++ b/packages/admin/resources/views/livewire/components/account/dropdown.blade.php
@@ -5,7 +5,7 @@
             class="focus:ring-primary-500 relative inline-flex w-full items-center rounded-full text-sm leading-5 focus:ring-2 focus:ring-offset-2 dark:focus:ring-offset-gray-800"
             type="button"
         >
-            <img class="size-8 rounded-full" src="{{ $user->picture }}" alt="{{ $user->email }}" />
+            <img class="size-8 rounded-full object-cover" src="{{ $user->picture }}" alt="{{ $user->email }}" />
             <span class="sr-only">{{ $user->full_name }}</span>
             <span
                 class="bg-success-400 absolute right-0 bottom-0 block size-2.5 rounded-full ring-2 ring-white dark:ring-white/10"

--- a/packages/admin/resources/views/livewire/tables/cells/administrators/name.blade.php
+++ b/packages/admin/resources/views/livewire/tables/cells/administrators/name.blade.php
@@ -4,7 +4,7 @@
 
 <div class="flex items-center">
     <div class="size-10 shrink-0">
-        <img class="size-10 rounded-full" src="{{ $user->picture }}" alt="{{ $user->last_name }} avatar" />
+        <img class="size-10 rounded-full object-cover" src="{{ $user->picture }}" alt="{{ $user->last_name }} avatar" />
     </div>
     <div class="ml-4">
         <div class="flex items-center gap-2">
@@ -12,7 +12,7 @@
                 {{ $user->full_name }}
             </span>
             @if ($user->id ===shopper()->auth()->id())
-                <x-filament::badge icon="untitledui-user-circle" color="gray" size="sm">
+                <x-filament::badge color="gray" size="sm">
                     {{ __('shopper::words.me') }}
                 </x-filament::badge>
             @endif

--- a/packages/admin/resources/views/livewire/tables/cells/discounts/date.blade.php
+++ b/packages/admin/resources/views/livewire/tables/cells/discounts/date.blade.php
@@ -1,24 +1,15 @@
 @php
-    $discount = $getRecord();
+    $discount = $getRecord()
 @endphp
 
-<div class="flex shrink-0 items-center gap-3">
-    <x-filament::badge :color="$discount->start_at <= now() ? 'success' : 'warning'">
-        @if ($discount->start_at <= now())
-            {{ __('shopper::words.active_for_users') }}
-        @else
-            {{ __('shopper::words.scheduled') }}
-        @endif
-    </x-filament::badge>
-    <p class="text-sm leading-6 text-gray-500 dark:text-gray-400">
-        @if ($discount->end_at)
-            <span>{{ $discount->start_at->format('d M, Y') }}</span>
-            <span>-</span>
-            <span>{{ $discount->end_at->format('d M, Y') }}</span>
-        @else
-            <span>
-                {{ __('shopper::words.from_date', ['date' => $discount->start_at->format('d M, Y')]) }}
-            </span>
-        @endif
-    </p>
-</div>
+<p class="text-sm leading-6 text-gray-500 dark:text-gray-400">
+    @if ($discount->end_at)
+        <span>{{ $discount->start_at->format('d M, Y') }}</span>
+        <span>-</span>
+        <span>{{ $discount->end_at->format('d M, Y') }}</span>
+    @else
+        <span>
+            {{ __('shopper::words.from_date', ['date' => $discount->start_at->format('d M, Y')]) }}
+        </span>
+    @endif
+</p>

--- a/packages/admin/src/Livewire/Pages/Discount/Index.php
+++ b/packages/admin/src/Livewire/Pages/Discount/Index.php
@@ -12,7 +12,6 @@ use Filament\Forms\Components\DatePicker;
 use Filament\Notifications\Notification;
 use Filament\Schemas\Concerns\InteractsWithSchemas;
 use Filament\Schemas\Contracts\HasSchemas;
-use Filament\Tables\Columns\IconColumn;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Columns\ViewColumn;
 use Filament\Tables\Concerns\InteractsWithTable;
@@ -27,6 +26,7 @@ use Illuminate\Database\Eloquent\Collection;
 use Mckenziearts\Icons\Untitledui\Enums\Untitledui;
 use Shopper\Core\Enum\DiscountApplyTo;
 use Shopper\Core\Enum\DiscountEligibility;
+use Shopper\Core\Enum\DiscountStatus;
 use Shopper\Core\Models\Discount;
 use Shopper\Livewire\Pages\AbstractPageComponent;
 use Shopper\Traits\HandlesAuthorizationExceptions;
@@ -74,10 +74,12 @@ class Index extends AbstractPageComponent implements HasActions, HasSchemas, Has
                     ->toggledHiddenByDefault()
                     ->color('gray')
                     ->badge(),
-                IconColumn::make('is_active')
+                TextColumn::make('status')
                     ->label(__('shopper::forms.label.status'))
-                    ->boolean()
-                    ->sortable(),
+                    ->badge()
+                    ->formatStateUsing(fn (DiscountStatus $state): string => $state->getLabel())
+                    ->icon(fn (DiscountStatus $state): string => $state->getIcon())
+                    ->color(fn (DiscountStatus $state): string => $state->getColor()),
                 ViewColumn::make('start_at')
                     ->label(__('shopper::words.date'))
                     ->toggleable()

--- a/packages/core/resources/lang/en/status.php
+++ b/packages/core/resources/lang/en/status.php
@@ -60,4 +60,13 @@ return [
         'reserved' => 'Reserved for order',
         'cancelled' => 'Released from cancelled order',
     ],
+
+    'discount' => [
+        'draft' => 'Draft',
+        'scheduled' => 'Scheduled',
+        'active' => 'Active',
+        'disabled' => 'Disabled',
+        'expired' => 'Expired',
+        'limit_reached' => 'Limit reached',
+    ],
 ];

--- a/packages/core/resources/lang/es/status.php
+++ b/packages/core/resources/lang/es/status.php
@@ -60,4 +60,13 @@ return [
         'reserved' => 'Reservado para pedido',
         'cancelled' => 'Liberado por cancelación de pedido',
     ],
+
+    'discount' => [
+        'draft' => 'Borrador',
+        'scheduled' => 'Programado',
+        'active' => 'Activo',
+        'disabled' => 'Desactivado',
+        'expired' => 'Expirado',
+        'limit_reached' => 'Límite alcanzado',
+    ],
 ];

--- a/packages/core/resources/lang/fr/status.php
+++ b/packages/core/resources/lang/fr/status.php
@@ -60,4 +60,13 @@ return [
         'reserved' => 'Réservé pour commande',
         'cancelled' => 'Libéré suite à annulation de commande',
     ],
+
+    'discount' => [
+        'draft' => 'Brouillon',
+        'scheduled' => 'Programmé',
+        'active' => 'Actif',
+        'disabled' => 'Désactivé',
+        'expired' => 'Expiré',
+        'limit_reached' => 'Limite atteinte',
+    ],
 ];

--- a/packages/core/src/Enum/DiscountStatus.php
+++ b/packages/core/src/Enum/DiscountStatus.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Core\Enum;
+
+use Shopper\Core\Contracts\HasColor;
+use Shopper\Core\Contracts\HasIcon;
+use Shopper\Core\Contracts\HasLabel;
+use Shopper\Core\Traits\ArrayableEnum;
+use Shopper\Core\Traits\HasEnumStaticMethods;
+
+/**
+ * @method static string Draft()
+ * @method static string Scheduled()
+ * @method static string Active()
+ * @method static string Disabled()
+ * @method static string Expired()
+ * @method static string LimitReached()
+ */
+enum DiscountStatus: string implements HasColor, HasIcon, HasLabel
+{
+    use ArrayableEnum;
+    use HasEnumStaticMethods;
+
+    case Draft = 'draft';
+
+    case Scheduled = 'scheduled';
+
+    case Active = 'active';
+
+    case Disabled = 'disabled';
+
+    case Expired = 'expired';
+
+    case LimitReached = 'limit_reached';
+
+    public function getColor(): string
+    {
+        return match ($this) {
+            self::Draft, self::Disabled => 'gray',
+            self::Scheduled => 'info',
+            self::Active => 'success',
+            self::Expired, self::LimitReached => 'warning',
+        };
+    }
+
+    public function getIcon(): string
+    {
+        return match ($this) {
+            self::Draft => 'untitledui-file-04',
+            self::Scheduled => 'untitledui-clock',
+            self::Active => 'untitledui-check-circle',
+            self::Disabled => 'untitledui-eye-off',
+            self::Expired => 'untitledui-hourglass-03',
+            self::LimitReached => 'untitledui-bar-chart-square-up',
+        };
+    }
+
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::Draft => __('shopper-core::status.discount.draft'),
+            self::Scheduled => __('shopper-core::status.discount.scheduled'),
+            self::Active => __('shopper-core::status.discount.active'),
+            self::Disabled => __('shopper-core::status.discount.disabled'),
+            self::Expired => __('shopper-core::status.discount.expired'),
+            self::LimitReached => __('shopper-core::status.discount.limit_reached'),
+        };
+    }
+}

--- a/packages/core/src/Models/Discount.php
+++ b/packages/core/src/Models/Discount.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace Shopper\Core\Models;
 
 use Carbon\CarbonInterface;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Shopper\Core\Database\Factories\DiscountFactory;
+use Shopper\Core\Enum\DiscountStatus;
 use Shopper\Core\Enum\DiscountType;
 use Shopper\Core\Models\Contracts\Discount as DiscountContract;
 
@@ -27,6 +29,7 @@ use Shopper\Core\Models\Contracts\Discount as DiscountContract;
  * @property-read ?int $usage_limit
  * @property-read bool $usage_limit_per_user
  * @property-read bool $is_active
+ * @property-read DiscountStatus $status
  * @property-read ?int $zone_id
  * @property-read array<string, mixed>|null $metadata
  * @property-read CarbonInterface $created_at
@@ -71,6 +74,36 @@ class Discount extends Model implements DiscountContract
     public function zone(): BelongsTo
     {
         return $this->belongsTo(Zone::class, 'zone_id');
+    }
+
+    /**
+     * @return Attribute<DiscountStatus, never>
+     */
+    protected function status(): Attribute
+    {
+        return Attribute::get(function (): DiscountStatus {
+            if (! $this->exists) {
+                return DiscountStatus::Draft;
+            }
+
+            if (! $this->is_active) {
+                return DiscountStatus::Disabled;
+            }
+
+            if ($this->end_at !== null && $this->end_at->isPast()) {
+                return DiscountStatus::Expired;
+            }
+
+            if ($this->hasReachedLimit()) {
+                return DiscountStatus::LimitReached;
+            }
+
+            if ($this->start_at->isFuture()) {
+                return DiscountStatus::Scheduled;
+            }
+
+            return DiscountStatus::Active;
+        });
     }
 
     protected static function newFactory(): DiscountFactory

--- a/packages/core/src/Models/Discount.php
+++ b/packages/core/src/Models/Discount.php
@@ -76,6 +76,11 @@ class Discount extends Model implements DiscountContract
         return $this->belongsTo(Zone::class, 'zone_id');
     }
 
+    protected static function newFactory(): DiscountFactory
+    {
+        return DiscountFactory::new();
+    }
+
     /**
      * @return Attribute<DiscountStatus, never>
      */
@@ -104,11 +109,6 @@ class Discount extends Model implements DiscountContract
 
             return DiscountStatus::Active;
         });
-    }
-
-    protected static function newFactory(): DiscountFactory
-    {
-        return DiscountFactory::new();
     }
 
     protected function casts(): array

--- a/tests/Core/Models/DiscountStatusTest.php
+++ b/tests/Core/Models/DiscountStatusTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+use Shopper\Core\Enum\DiscountStatus;
+use Shopper\Core\Models\Discount;
+
+uses(Tests\Core\TestCase::class);
+
+it('reports `Active` for an enabled discount inside its window and limit', function (): void {
+    $discount = Discount::factory()->create([
+        'is_active' => true,
+        'start_at' => now()->subDay(),
+        'end_at' => now()->addMonth(),
+        'usage_limit' => null,
+    ]);
+
+    expect($discount->status)->toBe(DiscountStatus::Active);
+});
+
+it('reports `Disabled` when the discount is not active', function (): void {
+    $discount = Discount::factory()->create([
+        'is_active' => false,
+        'start_at' => now()->subDay(),
+        'end_at' => now()->addMonth(),
+    ]);
+
+    expect($discount->status)->toBe(DiscountStatus::Disabled);
+});
+
+it('reports `Expired` when `end_at` is in the past', function (): void {
+    $discount = Discount::factory()->create([
+        'is_active' => true,
+        'start_at' => now()->subWeek(),
+        'end_at' => now()->subDay(),
+    ]);
+
+    expect($discount->status)->toBe(DiscountStatus::Expired);
+});
+
+it('reports `LimitReached` when the usage limit is hit', function (): void {
+    $discount = Discount::factory()->create([
+        'is_active' => true,
+        'start_at' => now()->subDay(),
+        'end_at' => now()->addMonth(),
+        'usage_limit' => 5,
+        'total_use' => 5,
+    ]);
+
+    expect($discount->status)->toBe(DiscountStatus::LimitReached);
+});
+
+it('reports `Scheduled` when `start_at` is in the future', function (): void {
+    $discount = Discount::factory()->create([
+        'is_active' => true,
+        'start_at' => now()->addWeek(),
+        'end_at' => now()->addMonth(),
+        'usage_limit' => null,
+    ]);
+
+    expect($discount->status)->toBe(DiscountStatus::Scheduled);
+});
+
+it('reports `Draft` for an unsaved discount', function (): void {
+    expect((new Discount)->status)->toBe(DiscountStatus::Draft);
+});


### PR DESCRIPTION
The discount listing rendered a raw `is_active` icon, so a discount that was disabled, expired, or had reached its usage limit still showed up as active. The edit screen and the cart validator already treat those as inapplicable, so the listing was the odd one out.

## Changes

- Add a `DiscountStatus` enum (`draft`, `scheduled`, `active`, `disabled`, `expired`, `limit_reached`) with label, color and icon.
- Add a derived `status` accessor on the `Discount` model that resolves the real state from the active flag, the schedule window (`start_at` / `end_at`) and the usage limit.
- Render the listing status as a badge column driven by the enum instead of the boolean icon.
- Remove the misleading "active for users" badge from the date cell, which now only shows the schedule window.
- Add the `status.discount.*` translations for en, fr and es.

A second commit bundles two unrelated admin UI tweaks that were already pending in the working tree: `object-cover` on avatar images and dropping the redundant icon from the current-user badge.