### PR TITLE
fix(admin): enforce authorization on unguarded settings and bulk actions

### DIFF
--- a/packages/admin/resources/lang/tr/pages/settings/global.php
+++ b/packages/admin/resources/lang/tr/pages/settings/global.php
@@ -35,7 +35,7 @@ return [
         'detail' => 'Detaylar',
         'detail_summary' => 'Bu konuma tanımlamayı kolaylaştıracak kısa bir ad verin. Bu adı ürünler gibi alanlarda göreceksiniz.',
         'address' => 'Konum adresi',
-        'address_summary' => "Konumunuzun eksiksiz bilgileri. Lütfen geçerli bilgiler girin, müşterileriniz için erişilebilir olabilir.",
+        'address_summary' => 'Konumunuzun eksiksiz bilgileri. Lütfen geçerli bilgiler girin, müşterileriniz için erişilebilir olabilir.',
         'set_default' => 'Varsayılan konum olarak ayarla',
         'set_default_summary' => 'Bu konumdaki envanter çevrimiçi satışa uygundur ve varsayılan olarak kullanılacaktır',
         'priority_summary' => 'Stok birden fazla konuma tahsis edilirken düşük değerler önce karşılanır.',

--- a/packages/admin/resources/lang/tr/pages/settings/menu.php
+++ b/packages/admin/resources/lang/tr/pages/settings/menu.php
@@ -15,7 +15,7 @@ return [
     'payment' => 'Ödeme yöntemleri',
     'payment_description' => 'Müşterileriniz için farklı ödeme yöntemleri ekleyin.',
     'legal' => 'Yasal',
-    'legal_description' => "Mağazanızın gizlilik, koşullar gibi yasal sayfalarını yönetin.",
+    'legal_description' => 'Mağazanızın gizlilik, koşullar gibi yasal sayfalarını yönetin.',
     'carrier' => 'Kargo Şirketleri',
     'carrier_description' => 'Kargo şirketlerini ve teslimat sağlayıcılarını yönetin.',
     'zone' => 'Bölgeler',

--- a/packages/admin/resources/lang/tr/pages/settings/payments.php
+++ b/packages/admin/resources/lang/tr/pages/settings/payments.php
@@ -9,7 +9,7 @@ return [
     'add_payment' => 'Ödeme yöntemi ekle',
     'update_title' => 'Ödeme yöntemini güncelle',
     'driver_help' => 'Çevrimdışı ödemeler için "Manuel" seçin veya çevrimiçi işlemler için bir sağlayıcı seçin.',
-    'help_text' => "Müşteriler bir ödeme yöntemi seçerken görüntülenir",
+    'help_text' => 'Müşteriler bir ödeme yöntemi seçerken görüntülenir',
     'instruction' => 'Müşteriler bu ödeme yöntemiyle sipariş verdikten sonra görüntülenir',
 
 ];

--- a/packages/admin/resources/lang/tr/pages/settings/zones.php
+++ b/packages/admin/resources/lang/tr/pages/settings/zones.php
@@ -13,7 +13,7 @@ return [
     'providers_description' => 'Bu alanda bulunması gereken teslimat ve ödeme yöntemlerini ekleyin.',
     'currency_help' => 'Mağazanızı oluştururken yapılandırdığınız para birimleri listesinden bu bölgenin ana para birimi.',
     'empty_detail_heading' => 'Bölge seçilmedi',
-    'empty_detail_description' => "Bir bölge seçtiğinizde, tüm bilgileri burada görüntülenecektir",
+    'empty_detail_description' => 'Bir bölge seçtiğinizde, tüm bilgileri burada görüntülenecektir',
 
     'shipping_options' => [
         'title' => 'Kargo Seçenekleri',

--- a/packages/admin/src/Livewire/Components/Collection/CollectionProducts.php
+++ b/packages/admin/src/Livewire/Components/Collection/CollectionProducts.php
@@ -20,6 +20,7 @@ use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Livewire\Attributes\Computed;
+use Livewire\Attributes\Locked;
 use Livewire\Attributes\On;
 use Livewire\Component;
 use Mckenziearts\Icons\Untitledui\Enums\Untitledui;
@@ -37,6 +38,7 @@ class CollectionProducts extends Component implements HasActions, HasSchemas, Ha
     use InteractsWithSchemas;
     use InteractsWithTable;
 
+    #[Locked]
     public Collection $collection;
 
     /**
@@ -71,6 +73,7 @@ class CollectionProducts extends Component implements HasActions, HasSchemas, Ha
             ])
             ->recordActions([
                 Action::make('delete')
+                    ->authorize('delete_collections')
                     ->label(__('shopper::forms.actions.delete'))
                     ->icon(Untitledui::Trash03)
                     ->iconButton()
@@ -89,6 +92,7 @@ class CollectionProducts extends Component implements HasActions, HasSchemas, Ha
             ])
             ->groupedBulkActions([
                 DeleteBulkAction::make()
+                    ->authorize('delete_collections')
                     ->label(__('shopper::forms.actions.delete'))
                     ->icon(Untitledui::Trash03)
                     ->requiresConfirmation()

--- a/packages/admin/src/Livewire/Components/Products/Form/Media.php
+++ b/packages/admin/src/Livewire/Components/Products/Form/Media.php
@@ -63,6 +63,8 @@ class Media extends Component implements HasSchemas
 
     public function store(): void
     {
+        $this->authorize('edit_products');
+
         $this->validate();
 
         $this->product->update($this->form->getState());

--- a/packages/admin/src/Livewire/Components/Products/VariantStock.php
+++ b/packages/admin/src/Livewire/Components/Products/VariantStock.php
@@ -16,6 +16,7 @@ use Filament\Support\Enums\Width;
 use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Collection;
 use Livewire\Attributes\Computed;
+use Livewire\Attributes\Locked;
 use Livewire\Component;
 use Mckenziearts\Icons\Untitledui\Enums\Untitledui;
 use Shopper\Core\Models\Inventory;
@@ -31,11 +32,13 @@ class VariantStock extends Component implements HasActions, HasSchemas
     use InteractsWithActions;
     use InteractsWithSchemas;
 
+    #[Locked]
     public $variant;
 
     public function stockAction(): Action
     {
         return Action::make('stock')
+            ->authorize('edit_product_variants')
             ->label(__('shopper::forms.actions.update'))
             ->color('gray')
             ->icon(Untitledui::Package)

--- a/packages/admin/src/Livewire/Components/Settings/Taxes/Detail.php
+++ b/packages/admin/src/Livewire/Components/Settings/Taxes/Detail.php
@@ -42,6 +42,7 @@ class Detail extends Component implements HasActions, HasSchemas
     public function deleteAction(): Action
     {
         return DeleteAction::make('delete')
+            ->authorize('access_setting')
             ->record($this->taxZone)
             ->icon(Untitledui::Trash03)
             ->iconButton()

--- a/packages/admin/src/Livewire/Components/Settings/Team/UsersRole.php
+++ b/packages/admin/src/Livewire/Components/Settings/Team/UsersRole.php
@@ -66,6 +66,7 @@ class UsersRole extends Component implements HasActions, HasSchemas, HasTable
             ])
             ->recordActions([
                 DeleteAction::make('delete')
+                    ->authorize('access_setting')
                     ->label(__('shopper::forms.actions.delete'))
                     ->visible(fn (ShopperUser $record): bool => shopper()->auth()->user()->isAdmin() && ! $record->isAdmin()) // @phpstan-ignore-line
                     ->successNotificationTitle(__('shopper::notifications.users_roles.admin_deleted')),

--- a/packages/admin/src/Livewire/Components/Settings/Zones/Detail.php
+++ b/packages/admin/src/Livewire/Components/Settings/Zones/Detail.php
@@ -46,6 +46,7 @@ class Detail extends Component implements HasActions, HasSchemas
     public function deleteAction(): Action
     {
         return DeleteAction::make('delete')
+            ->authorize('access_setting')
             ->record($this->zone)
             ->icon(Untitledui::Trash03)
             ->iconButton()

--- a/packages/admin/src/Livewire/Components/Settings/Zones/ZoneShippingOptions.php
+++ b/packages/admin/src/Livewire/Components/Settings/Zones/ZoneShippingOptions.php
@@ -47,12 +47,16 @@ class ZoneShippingOptions extends Component implements HasActions, HasSchemas
     public function deleteAction(): Action
     {
         return Action::make('delete')
+            ->authorize('access_setting')
             ->requiresConfirmation()
             ->icon(Untitledui::Trash03)
             ->color('danger')
             ->iconButton()
             ->action(function (array $arguments): void {
-                CarrierOption::query()->find($arguments['id'])->delete();
+                CarrierOption::query()
+                    ->where('zone_id', $this->selectedZoneId)
+                    ->findOrFail($arguments['id'])
+                    ->delete();
 
                 Notification::make()
                     ->title(__('shopper::notifications.delete', ['item' => __('shopper::pages/settings/zones.shipping_options.single')]))

--- a/packages/admin/src/Livewire/Pages/Attribute/Browse.php
+++ b/packages/admin/src/Livewire/Pages/Attribute/Browse.php
@@ -105,6 +105,8 @@ class Browse extends AbstractPageComponent implements HasActions, HasSchemas, Ha
             ])
             ->groupedBulkActions([
                 DeleteBulkAction::make()
+                    ->authorize('delete_attributes')
+                    ->visible(shopper()->auth()->user()->can('delete_attributes'))
                     ->label(__('shopper::forms.actions.delete'))
                     ->requiresConfirmation()
                     ->action(function (Collection $records): void {
@@ -121,6 +123,8 @@ class Browse extends AbstractPageComponent implements HasActions, HasSchemas, Ha
                     })
                     ->deselectRecordsAfterCompletion(),
                 BulkAction::make('enabled')
+                    ->authorize('edit_attributes')
+                    ->visible(shopper()->auth()->user()->can('edit_attributes'))
                     ->label(__('shopper::forms.actions.enable'))
                     ->icon(Untitledui::CheckVerified)
                     ->action(function (Collection $records): void {
@@ -137,6 +141,8 @@ class Browse extends AbstractPageComponent implements HasActions, HasSchemas, Ha
                     })
                     ->deselectRecordsAfterCompletion(),
                 BulkAction::make('disabled')
+                    ->authorize('edit_attributes')
+                    ->visible(shopper()->auth()->user()->can('edit_attributes'))
                     ->label(__('shopper::forms.actions.disable'))
                     ->icon(Untitledui::SlashCircle01)
                     ->action(function (Collection $records): void {

--- a/packages/admin/src/Livewire/Pages/Brand/Index.php
+++ b/packages/admin/src/Livewire/Pages/Brand/Index.php
@@ -95,6 +95,8 @@ class Index extends AbstractPageComponent implements HasActions, HasSchemas, Has
             ])
             ->groupedBulkActions([
                 BulkAction::make('enabled')
+                    ->authorize('edit_brands')
+                    ->visible(Shopper::auth()->user()->can('edit_brands'))
                     ->label(__('shopper::forms.actions.enable'))
                     ->icon(Untitledui::CheckVerified)
                     ->action(function (Collection $records): void {
@@ -111,6 +113,8 @@ class Index extends AbstractPageComponent implements HasActions, HasSchemas, Has
                     })
                     ->deselectRecordsAfterCompletion(),
                 BulkAction::make('disabled')
+                    ->authorize('edit_brands')
+                    ->visible(Shopper::auth()->user()->can('edit_brands'))
                     ->label(__('shopper::forms.actions.disable'))
                     ->icon(Untitledui::SlashCircle01)
                     ->action(function (Collection $records): void {

--- a/packages/admin/src/Livewire/Pages/Category/Index.php
+++ b/packages/admin/src/Livewire/Pages/Category/Index.php
@@ -100,6 +100,8 @@ class Index extends AbstractPageComponent implements HasActions, HasSchemas, Has
             ])
             ->groupedBulkActions([
                 BulkAction::make('enabled')
+                    ->authorize('edit_categories')
+                    ->visible($this->getUser()->can('edit_categories'))
                     ->label(__('shopper::forms.actions.enable'))
                     ->icon(Untitledui::CheckVerified)
                     ->action(function (Collection $records): void {
@@ -116,6 +118,8 @@ class Index extends AbstractPageComponent implements HasActions, HasSchemas, Has
                     })
                     ->deselectRecordsAfterCompletion(),
                 BulkAction::make('disabled')
+                    ->authorize('edit_categories')
+                    ->visible($this->getUser()->can('edit_categories'))
                     ->label(__('shopper::forms.actions.disable'))
                     ->icon(Untitledui::SlashCircle01)
                     ->action(function (Collection $records): void {

--- a/packages/admin/src/Livewire/Pages/Supplier/Index.php
+++ b/packages/admin/src/Livewire/Pages/Supplier/Index.php
@@ -91,6 +91,8 @@ class Index extends AbstractPageComponent implements HasActions, HasSchemas, Has
             ])
             ->groupedBulkActions([
                 BulkAction::make('enabled')
+                    ->authorize('edit_suppliers')
+                    ->visible(Shopper::auth()->user()->can('edit_suppliers'))
                     ->label(__('shopper::forms.actions.enable'))
                     ->icon(Untitledui::CheckVerified)
                     ->action(function (Collection $records): void {
@@ -107,6 +109,8 @@ class Index extends AbstractPageComponent implements HasActions, HasSchemas, Has
                     })
                     ->deselectRecordsAfterCompletion(),
                 BulkAction::make('disabled')
+                    ->authorize('edit_suppliers')
+                    ->visible(Shopper::auth()->user()->can('edit_suppliers'))
                     ->label(__('shopper::forms.actions.disable'))
                     ->icon(Untitledui::SlashCircle01)
                     ->action(function (Collection $records): void {

--- a/packages/admin/src/Livewire/Pages/Tag/Index.php
+++ b/packages/admin/src/Livewire/Pages/Tag/Index.php
@@ -95,6 +95,8 @@ class Index extends AbstractPageComponent implements HasActions, HasSchemas, Has
             ])
             ->groupedBulkActions([
                 DeleteBulkAction::make()
+                    ->authorize('delete_tags')
+                    ->visible(shopper()->auth()->user()->can('delete_tags'))
                     ->label(__('shopper::forms.actions.delete'))
                     ->requiresConfirmation()
                     ->action(function (Collection $records): void {

--- a/tests/Admin/Security/SettingsCommerceDeletionAuthorizationBypassTest.php
+++ b/tests/Admin/Security/SettingsCommerceDeletionAuthorizationBypassTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+use Livewire\Livewire;
+use Shopper\Core\Models\CarrierOption;
+use Shopper\Core\Models\TaxZone;
+use Shopper\Core\Models\Zone;
+use Shopper\Livewire\Components\Settings\Taxes\Detail as TaxZoneDetail;
+use Shopper\Livewire\Components\Settings\Zones\Detail as ZoneDetail;
+use Shopper\Livewire\Components\Settings\Zones\ZoneShippingOptions;
+use Tests\Core\Stubs\User;
+
+uses(Tests\Admin\TestCase::class);
+
+beforeEach(function (): void {
+    $this->dashboardUser = User::factory()->create();
+    $this->dashboardUser->givePermissionTo('access_dashboard');
+});
+
+it('hides the zone delete action from a user without `access_setting`', function (): void {
+    $zone = Zone::factory()->create();
+    $this->actingAs($this->dashboardUser, config('shopper.auth.guard'));
+
+    Livewire::test(ZoneDetail::class, ['currentZoneId' => $zone->id])
+        ->assertActionHidden('delete');
+
+    expect(Zone::query()->whereKey($zone->id)->exists())->toBeTrue();
+});
+
+it('hides the shipping option delete action from a user without `access_setting`', function (): void {
+    $option = CarrierOption::factory()->create();
+    $this->actingAs($this->dashboardUser, config('shopper.auth.guard'));
+
+    Livewire::test(ZoneShippingOptions::class, ['selectedZoneId' => $option->zone_id])
+        ->assertActionHidden('delete');
+
+    expect(CarrierOption::query()->whereKey($option->id)->exists())->toBeTrue();
+});
+
+it('hides the tax zone delete action from a user without `access_setting`', function (): void {
+    $taxZone = TaxZone::factory()->create();
+    $this->actingAs($this->dashboardUser, config('shopper.auth.guard'));
+
+    Livewire::test(TaxZoneDetail::class, ['currentTaxZoneId' => $taxZone->id])
+        ->assertActionHidden('delete');
+
+    expect(TaxZone::query()->whereKey($taxZone->id)->exists())->toBeTrue();
+});
+
+it('allows a user with `access_setting` to delete a commerce settings record', function (): void {
+    $user = User::factory()->create();
+    $user->givePermissionTo('access_dashboard');
+    $user->givePermissionTo('access_setting');
+    $this->actingAs($user, config('shopper.auth.guard'));
+
+    $option = CarrierOption::factory()->create();
+
+    Livewire::test(ZoneShippingOptions::class, ['selectedZoneId' => $option->zone_id])
+        ->assertActionVisible('delete')
+        ->callAction('delete', arguments: ['id' => $option->id]);
+
+    expect(CarrierOption::query()->whereKey($option->id)->exists())->toBeFalse();
+});


### PR DESCRIPTION
## Summary

Several admin Livewire child components exposed destructive Filament actions without a server-side permission gate. A low-privilege user holding only `access_dashboard` could invoke them directly over the Livewire endpoint and delete commerce-critical configuration, even though the parent settings pages correctly require the relevant permission.

## Changes

Each mutating action now chains `->authorize()` and client-bound model ids are marked `#[Locked]`.

| Component | Gate added |
|---|---|
| `Settings/Zones/Detail`, `Settings/Taxes/Detail` | `access_setting` on `DeleteAction` |
| `Settings/Zones/ZoneShippingOptions` | `access_setting`, lookup scoped to the selected zone with `findOrFail` (was a client-supplied id) |
| `Settings/Team/UsersRole` | `access_setting` on admin deletion (was visibility-only) |
| `Products/VariantStock` | `edit_product_variants` + `#[Locked]` on `$variant` |
| `Collection/CollectionProducts` | `delete_collections` on record and bulk delete + `#[Locked]` on `$collection` |
| `Brand`, `Category`, `Supplier` index | `edit_*` on bulk enable/disable |
| `Attribute/Browse` | `delete_attributes` / `edit_attributes` on bulk actions |
| `Tag` index | `delete_tags` on bulk delete |
| `Products/Form/Media` | `edit_products` on `store()` |

Closes the settings deletion bypass reported privately (advisory GHSA-f7h9-qv4x-9x57) along with the related open advisories GHSA-2cg9-97gq-9mqp, GHSA-g3f9-g5vj-p62f / GHSA-9ggh-r629-xch6, GHSA-243p-f3cv-c5wh and GHSA-99h5-jhh7-v3r3.

A regression test asserts the settings delete actions are hidden from a user without `access_setting` and the records survive, while a user with `access_setting` can still delete them.