### PR TITLE
fix(admin): enforce fine-grained permissions on destructive variant, attribute and tag actions

### DIFF
--- a/packages/admin/src/Livewire/Components/Settings/Taxes/TaxRates.php
+++ b/packages/admin/src/Livewire/Components/Settings/Taxes/TaxRates.php
@@ -95,6 +95,7 @@ class TaxRates extends Component implements HasActions, HasSchemas, HasTable
                         ['taxZoneId' => $this->selectedTaxZoneId, 'taxRateId' => $record->id]
                     )),
                 DeleteAction::make('delete')
+                    ->authorize('system.settings')
                     ->label(__('shopper::forms.actions.delete'))
                     ->icon(Untitledui::Trash03)
                     ->iconButton(),

--- a/packages/admin/src/Livewire/Pages/Product/Variant.php
+++ b/packages/admin/src/Livewire/Pages/Product/Variant.php
@@ -110,6 +110,7 @@ class Variant extends AbstractPageComponent implements HasActions, HasSchemas
     public function mediaAction(): Action
     {
         return Action::make('media')
+            ->authorize('products.variants.edit')
             ->label(__('shopper::forms.actions.edit'))
             ->color('gray')
             ->record($this->variant) // @phpstan-ignore-line

--- a/packages/admin/src/Livewire/Pages/Product/Variants.php
+++ b/packages/admin/src/Livewire/Pages/Product/Variants.php
@@ -120,6 +120,7 @@ class Variants extends Component implements HasActions, HasSchemas, HasTable
                         ),
                     ),
                 DeleteAction::make()
+                    ->authorize('products.variants.delete')
                     ->icon(Untitledui::Trash03)
                     ->iconButton()
                     ->modalIcon(Untitledui::Trash03)
@@ -127,6 +128,7 @@ class Variants extends Component implements HasActions, HasSchemas, HasTable
             ])
             ->groupedBulkActions([
                 DeleteBulkAction::make()
+                    ->authorize('products.variants.delete')
                     ->label(__('shopper::forms.actions.delete'))
                     ->requiresConfirmation()
                     ->action(function (Collection $records): void {

--- a/packages/admin/src/Livewire/Pages/Tag/Index.php
+++ b/packages/admin/src/Livewire/Pages/Tag/Index.php
@@ -132,6 +132,7 @@ class Index extends AbstractPageComponent implements HasActions, HasSchemas, Has
     public function createAction(): Action
     {
         return Action::make('create')
+            ->authorize('tags.create')
             ->label(__('shopper::forms.actions.create'))
             ->schema($this->tagForm(...))
             ->modalWidth(Width::Medium)

--- a/packages/admin/src/Livewire/SlideOvers/AttributeValues.php
+++ b/packages/admin/src/Livewire/SlideOvers/AttributeValues.php
@@ -117,6 +117,7 @@ class AttributeValues extends SlideOverComponent implements HasActions, HasSchem
                         $this->dispatch('$refresh');
                     }),
                 Action::make('delete')
+                    ->authorize('attributes.delete')
                     ->icon(Untitledui::Trash03)
                     ->color('danger')
                     ->iconButton()
@@ -125,6 +126,7 @@ class AttributeValues extends SlideOverComponent implements HasActions, HasSchem
             ])
             ->toolbarActions([
                 BulkAction::make('delete')
+                    ->authorize('attributes.delete')
                     ->label(__('shopper::forms.actions.delete'))
                     ->icon(Untitledui::Trash03)
                     ->color('danger')

--- a/tests/Admin/Livewire/Components/Products/Form/VariantsTest.php
+++ b/tests/Admin/Livewire/Components/Products/Form/VariantsTest.php
@@ -6,11 +6,13 @@ use Livewire\Livewire;
 use Shopper\Core\Enum\ProductType;
 use Shopper\Livewire\Pages\Product\Variants;
 use Tests\Core\Stubs\Product;
+use Tests\Core\Stubs\ProductVariant;
 use Tests\Core\Stubs\User;
 
 uses(Tests\Admin\TestCase::class);
 
 beforeEach(function (): void {
+    Livewire::withoutLazyLoading();
 
     $this->user = User::factory()->create();
     $this->actingAs($this->user);
@@ -38,4 +40,32 @@ describe(Variants::class, function (): void {
 
         expect($component->get('product')->id)->toBe($this->product->id);
     });
-})->group('livewire', 'components', 'products');
+
+    it('hides the delete action for users without `products.variants.delete`', function (): void {
+        $variant = ProductVariant::factory()->create(['product_id' => $this->product->id]);
+
+        Livewire::test(Variants::class, ['product' => $this->product])
+            ->loadTable()
+            ->assertTableActionHidden('delete', $variant);
+    });
+
+    it('hides the bulk delete action for users without `products.variants.delete`', function (): void {
+        ProductVariant::factory()->count(3)->create(['product_id' => $this->product->id]);
+
+        Livewire::test(Variants::class, ['product' => $this->product])
+            ->loadTable()
+            ->assertTableBulkActionHidden('delete');
+    });
+
+    it('allows deleting a variant with `products.variants.delete`', function (): void {
+        $this->user->givePermissionTo('products.variants.delete');
+
+        $variant = ProductVariant::factory()->create(['product_id' => $this->product->id]);
+
+        Livewire::test(Variants::class, ['product' => $this->product])
+            ->loadTable()
+            ->callTableAction('delete', $variant);
+
+        expect(ProductVariant::query()->find($variant->id))->toBeNull();
+    });
+})->group('livewire', 'components', 'products', 'security');

--- a/tests/Admin/Livewire/Pages/Product/VariantTest.php
+++ b/tests/Admin/Livewire/Pages/Product/VariantTest.php
@@ -105,11 +105,21 @@ describe(Variant::class, function (): void {
             ->assertHasActionErrors(['barcode' => 'unique']);
     });
 
-    it('has media action', function (): void {
+    it('hides the media action for users without `products.variants.edit`', function (): void {
         Livewire::test(Variant::class, [
             'product' => $this->product,
             'variant' => $this->variant,
         ])
-            ->assertActionExists('media');
+            ->assertActionHidden('media');
+    });
+
+    it('shows the media action for users with `products.variants.edit`', function (): void {
+        $this->user->givePermissionTo('products.variants.edit');
+
+        Livewire::test(Variant::class, [
+            'product' => $this->product,
+            'variant' => $this->variant,
+        ])
+            ->assertActionVisible('media');
     });
 })->group('livewire', 'products');

--- a/tests/Admin/Livewire/Pages/Tag/IndexTest.php
+++ b/tests/Admin/Livewire/Pages/Tag/IndexTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+use Livewire\Livewire;
+use Shopper\Livewire\Pages\Tag\Index;
+use Tests\Core\Stubs\User;
+
+uses(Tests\Admin\TestCase::class);
+
+beforeEach(function (): void {
+    $this->user = User::factory()->create();
+    $this->user->givePermissionTo('tags.browse');
+    $this->actingAs($this->user);
+});
+
+describe(Index::class, function (): void {
+    it('hides the create action for users without `tags.create`', function (): void {
+        Livewire::test(Index::class)
+            ->assertActionHidden('create');
+    });
+
+    it('shows the create action for users with `tags.create`', function (): void {
+        $this->user->givePermissionTo('tags.create');
+
+        Livewire::test(Index::class)
+            ->assertActionVisible('create');
+    });
+})->group('livewire', 'products', 'security');

--- a/tests/Admin/Livewire/SlideOvers/AttributeValuesTest.php
+++ b/tests/Admin/Livewire/SlideOvers/AttributeValuesTest.php
@@ -133,6 +133,8 @@ describe(AttributeValues::class, function (): void {
     });
 
     it('can delete attribute value via action', function (): void {
+        $this->user->givePermissionTo('attributes.delete');
+
         $value = AttributeValue::factory()->create([
             'attribute_id' => $this->attribute->id,
         ]);
@@ -144,6 +146,8 @@ describe(AttributeValues::class, function (): void {
     });
 
     it('can bulk delete attribute values', function (): void {
+        $this->user->givePermissionTo('attributes.delete');
+
         $values = AttributeValue::factory()->count(3)->create([
             'attribute_id' => $this->attribute->id,
         ]);
@@ -152,6 +156,24 @@ describe(AttributeValues::class, function (): void {
             ->callTableBulkAction('delete', $values);
 
         expect(AttributeValue::query()->whereIn('id', $values->pluck('id'))->count())->toBe(0);
+    });
+
+    it('hides the delete action for users without `attributes.delete`', function (): void {
+        $value = AttributeValue::factory()->create([
+            'attribute_id' => $this->attribute->id,
+        ]);
+
+        Livewire::test(AttributeValues::class, ['attributeId' => $this->attribute->id])
+            ->assertTableActionHidden('delete', $value);
+    });
+
+    it('hides the bulk delete action for users without `attributes.delete`', function (): void {
+        AttributeValue::factory()->count(3)->create([
+            'attribute_id' => $this->attribute->id,
+        ]);
+
+        Livewire::test(AttributeValues::class, ['attributeId' => $this->attribute->id])
+            ->assertTableBulkActionHidden('delete');
     });
 
     it('can remove value via method', function (): void {


### PR DESCRIPTION
## Summary

Several Filament actions in the admin panel inherited only a coarser route or `mount()` gate and never re-checked the stricter permission their operation actually requires. A user holding the coarser permission could trigger the destructive action without the fine-grained one. This is the same class as GHSA-93v2-gcw2-vfwc (variant deletion).

Filament enforces both `->authorize()` and `->visible()` server-side via `isDisabled()` (`mountAction`/`callMountedAction` return before running the callback), so adding `->authorize()` on the action definition closes the gap.

## Fixes

| Action | Was gated by | Now requires |
|---|---|---|
| `Variants` DeleteAction | route `products.edit` | `products.variants.delete` |
| `Variants` DeleteBulkAction | route `products.edit` | `products.variants.delete` |
| `AttributeValues` delete | mount `attributes.edit` | `attributes.delete` |
| `AttributeValues` bulk delete | mount `attributes.edit` | `attributes.delete` |
| `Variant` mediaAction | mount `products.edit` | `products.variants.edit` |
| `Tag` createAction | mount `tags.browse` | `tags.create` |
| `TaxRates` DeleteAction | parent `system.settings` | `system.settings` (consistency) |

## Tests

Positive and negative authorization tests added for each gated action (action hidden/disabled without the fine-grained permission, allowed with it).