### PR TITLE
fix(admin): enforce explicit permissions on every Filament action and Livewire mutation

### DIFF
--- a/packages/admin/src/Livewire/Components/Initialization/InitializationWizard.php
+++ b/packages/admin/src/Livewire/Components/Initialization/InitializationWizard.php
@@ -33,7 +33,6 @@ use Shopper\Core\Models\Country;
 use Shopper\Core\Models\Currency;
 use Shopper\Core\Models\Inventory;
 use Shopper\Core\Models\Setting;
-use Shopper\Facades\Shopper;
 use Shopper\Models\Contracts\ShopperUser;
 use Shopper\Traits\SaveSettings;
 
@@ -356,6 +355,8 @@ final class InitializationWizard extends Component implements HasActions, HasSch
      */
     private function persistStep(array $keys): void
     {
+        $this->authorizeOnboarding();
+
         $allowed = array_intersect($keys, self::ALLOWED_KEYS);
 
         $values = collect($this->data ?? [])
@@ -367,7 +368,7 @@ final class InitializationWizard extends Component implements HasActions, HasSch
 
     private function authorizeOnboarding(): void
     {
-        $user = Shopper::auth()->user();
+        $user = shopper()->auth()->user();
 
         abort_unless(
             $user instanceof ShopperUser

--- a/packages/admin/src/Livewire/Components/Products/Form/Inventory.php
+++ b/packages/admin/src/Livewire/Components/Products/Form/Inventory.php
@@ -129,6 +129,7 @@ class Inventory extends Component implements HasActions, HasSchemas, HasTable
             ])
             ->headerActions([
                 Action::make('stock')
+                    ->authorize('edit_products')
                     ->label(__('shopper::forms.label.add_stock'))
                     ->icon(Untitledui::Package)
                     ->color('gray')

--- a/packages/admin/src/Livewire/Components/Products/Form/RelatedProducts.php
+++ b/packages/admin/src/Livewire/Components/Products/Form/RelatedProducts.php
@@ -44,6 +44,7 @@ class RelatedProducts extends Component implements HasActions, HasSchemas
     public function removeAction(): Action
     {
         return Action::make('remove')
+            ->authorize('edit_products')
             ->label(__('shopper::forms.actions.remove'))
             ->icon(Untitledui::Trash03)
             ->color('danger')

--- a/packages/admin/src/Livewire/Components/Products/Form/Variants.php
+++ b/packages/admin/src/Livewire/Components/Products/Form/Variants.php
@@ -117,6 +117,7 @@ class Variants extends Component implements HasActions, HasSchemas, HasTable
                         ),
                     ),
                 DeleteAction::make()
+                    ->authorize('delete_product_variants')
                     ->icon(Untitledui::Trash03)
                     ->iconButton()
                     ->modalIcon(Untitledui::Trash03)
@@ -124,6 +125,7 @@ class Variants extends Component implements HasActions, HasSchemas, HasTable
             ])
             ->groupedBulkActions([
                 DeleteBulkAction::make()
+                    ->authorize('delete_product_variants')
                     ->label(__('shopper::forms.actions.delete'))
                     ->requiresConfirmation()
                     ->action(function (Collection $records): void {

--- a/packages/admin/src/Livewire/Components/Products/Pricing.php
+++ b/packages/admin/src/Livewire/Components/Products/Pricing.php
@@ -16,6 +16,7 @@ use Filament\Tables\Contracts\HasTable;
 use Filament\Tables\Table;
 use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Model;
+use Livewire\Attributes\Locked;
 use Livewire\Attributes\On;
 use Livewire\Component;
 use Mckenziearts\Icons\Untitledui\Enums\Untitledui;
@@ -29,6 +30,7 @@ class Pricing extends Component implements HasActions, HasSchemas, HasTable
     use InteractsWithSchemas;
     use InteractsWithTable;
 
+    #[Locked]
     public Model $model;
 
     public function table(Table $table): Table
@@ -53,6 +55,7 @@ class Pricing extends Component implements HasActions, HasSchemas, HasTable
             ])
             ->recordActions([
                 Action::make('edit')
+                    ->authorize('edit_products')
                     ->label(__('shopper::forms.actions.edit'))
                     ->icon(Untitledui::Edit03)
                     ->iconButton()
@@ -68,12 +71,14 @@ class Pricing extends Component implements HasActions, HasSchemas, HasTable
                         )
                     ),
                 DeleteAction::make()
+                    ->authorize('edit_products')
                     ->label(__('shopper::forms.actions.delete'))
                     ->icon(Untitledui::Trash03)
                     ->iconButton(),
             ])
             ->headerActions([
                 Action::make('add')
+                    ->authorize('edit_products')
                     ->label(__('shopper::pages/products.pricing.add'))
                     ->color('gray')
                     ->action(

--- a/packages/admin/src/Livewire/Components/Products/ProductTypeConfiguration.php
+++ b/packages/admin/src/Livewire/Components/Products/ProductTypeConfiguration.php
@@ -49,6 +49,8 @@ class ProductTypeConfiguration extends Component implements HasActions, HasSchem
                     ->debounce()
                     ->live()
                     ->afterStateUpdated(function (bool $state): void {
+                        $this->authorize('access_setting');
+
                         $this->saveSettings(['default_product_type' => $state ? $this->defaultProductType?->value : null]);
 
                         $this->dispatch('product-type.updated');

--- a/packages/admin/src/Livewire/Components/Settings/Taxes/TaxRates.php
+++ b/packages/admin/src/Livewire/Components/Settings/Taxes/TaxRates.php
@@ -95,6 +95,7 @@ class TaxRates extends Component implements HasActions, HasSchemas, HasTable
                         arguments: ['taxZoneId' => $this->selectedTaxZoneId, 'taxRateId' => $record->id]
                     )),
                 DeleteAction::make('delete')
+                    ->authorize('access_setting')
                     ->label(__('shopper::forms.actions.delete'))
                     ->icon(Untitledui::Trash03)
                     ->iconButton(),

--- a/packages/admin/src/Livewire/Components/Settings/Zones/ZoneShippingOptions.php
+++ b/packages/admin/src/Livewire/Components/Settings/Zones/ZoneShippingOptions.php
@@ -13,6 +13,7 @@ use Filament\Schemas\Contracts\HasSchemas;
 use Illuminate\Contracts\View\View;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\Lazy;
+use Livewire\Attributes\Locked;
 use Livewire\Attributes\On;
 use Livewire\Component;
 use Mckenziearts\Icons\Untitledui\Enums\Untitledui;
@@ -30,6 +31,7 @@ class ZoneShippingOptions extends Component implements HasActions, HasSchemas
     use InteractsWithActions;
     use InteractsWithSchemas;
 
+    #[Locked]
     public ?int $selectedZoneId = null;
 
     #[On('zone.changed')]

--- a/packages/admin/src/Livewire/Pages/Brand/Index.php
+++ b/packages/admin/src/Livewire/Pages/Brand/Index.php
@@ -23,7 +23,6 @@ use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Collection;
 use Mckenziearts\Icons\Untitledui\Enums\Untitledui;
 use Shopper\Core\Models\Contracts\Brand as BrandContract;
-use Shopper\Facades\Shopper;
 use Shopper\Livewire\Pages\AbstractPageComponent;
 use Shopper\Traits\HandlesAuthorizationExceptions;
 
@@ -68,6 +67,7 @@ class Index extends AbstractPageComponent implements HasActions, HasSchemas, Has
                     ->sortable(),
             ])
             ->reorderable('position')
+            ->authorizeReorder(shopper()->auth()->user()->can('edit_brands'))
             ->recordActions([
                 Action::make('edit')
                     ->label(__('shopper::forms.actions.edit'))
@@ -81,7 +81,7 @@ class Index extends AbstractPageComponent implements HasActions, HasSchemas, Has
                         )
                     )
                     ->authorize('edit_brands')
-                    ->visible(Shopper::auth()->user()->can('edit_brands')),
+                    ->visible(shopper()->auth()->user()->can('edit_brands')),
                 Action::make('delete')
                     ->label(__('shopper::forms.actions.delete'))
                     ->icon(Untitledui::Trash03)
@@ -91,12 +91,12 @@ class Index extends AbstractPageComponent implements HasActions, HasSchemas, Has
                     ->requiresConfirmation()
                     ->action(fn (BrandContract $record) => $record->delete())
                     ->authorize('delete_brands')
-                    ->visible(Shopper::auth()->user()->can('delete_brands')),
+                    ->visible(shopper()->auth()->user()->can('delete_brands')),
             ])
             ->groupedBulkActions([
                 BulkAction::make('enabled')
                     ->authorize('edit_brands')
-                    ->visible(Shopper::auth()->user()->can('edit_brands'))
+                    ->visible(shopper()->auth()->user()->can('edit_brands'))
                     ->label(__('shopper::forms.actions.enable'))
                     ->icon(Untitledui::CheckVerified)
                     ->action(function (Collection $records): void {
@@ -114,7 +114,7 @@ class Index extends AbstractPageComponent implements HasActions, HasSchemas, Has
                     ->deselectRecordsAfterCompletion(),
                 BulkAction::make('disabled')
                     ->authorize('edit_brands')
-                    ->visible(Shopper::auth()->user()->can('edit_brands'))
+                    ->visible(shopper()->auth()->user()->can('edit_brands'))
                     ->label(__('shopper::forms.actions.disable'))
                     ->icon(Untitledui::SlashCircle01)
                     ->action(function (Collection $records): void {
@@ -148,7 +148,7 @@ class Index extends AbstractPageComponent implements HasActions, HasSchemas, Has
                             ->send();
                     })
                     ->authorize('delete_brands')
-                    ->visible(Shopper::auth()->user()->can('delete_brands'))
+                    ->visible(shopper()->auth()->user()->can('delete_brands'))
                     ->deselectRecordsAfterCompletion(),
             ])
             ->filters([

--- a/packages/admin/src/Livewire/Pages/Product/Variant.php
+++ b/packages/admin/src/Livewire/Pages/Product/Variant.php
@@ -84,6 +84,7 @@ class Variant extends AbstractPageComponent implements HasActions, HasSchemas
     public function mediaAction(): Action
     {
         return Action::make('media')
+            ->authorize('edit_product_variants')
             ->label(__('shopper::forms.actions.edit'))
             ->color('gray')
             ->record($this->variant) // @phpstan-ignore-line

--- a/packages/admin/src/Livewire/Pages/Settings/General.php
+++ b/packages/admin/src/Livewire/Pages/Settings/General.php
@@ -245,6 +245,8 @@ class General extends Component implements HasActions, HasSchemas
 
     public function store(): void
     {
+        $this->authorize('access_setting');
+
         $this->saveSettings($this->form->getState());
 
         Notification::make()

--- a/packages/admin/src/Livewire/Pages/Tag/Index.php
+++ b/packages/admin/src/Livewire/Pages/Tag/Index.php
@@ -131,6 +131,7 @@ class Index extends AbstractPageComponent implements HasActions, HasSchemas, Has
     public function createAction(): Action
     {
         return Action::make('create')
+            ->authorize('add_tags')
             ->label(__('shopper::forms.actions.create'))
             ->schema($this->tagForm(...))
             ->modalWidth(Width::Medium)

--- a/packages/admin/src/Livewire/SlideOvers/AddVariant.php
+++ b/packages/admin/src/Livewire/SlideOvers/AddVariant.php
@@ -63,7 +63,7 @@ class AddVariant extends SlideOverComponent implements HasActions, HasSchemas
 
     public function mount(): void
     {
-        $this->authorize('add_products');
+        $this->authorize('add_product_variants');
 
         $this->form->fill();
     }
@@ -204,6 +204,8 @@ class AddVariant extends SlideOverComponent implements HasActions, HasSchemas
 
     public function save(): void
     {
+        $this->authorize('add_product_variants');
+
         $data = $this->form->getState();
 
         if (isset($data['values']) && $this->variantAlreadyExist($data['values'])) {

--- a/packages/admin/src/Livewire/SlideOvers/AttributeForm.php
+++ b/packages/admin/src/Livewire/SlideOvers/AttributeForm.php
@@ -114,8 +114,12 @@ class AttributeForm extends SlideOverComponent implements HasActions, HasSchemas
     public function store(): void
     {
         if ($this->attribute) {
+            $this->authorize('edit_attributes');
+
             $this->attribute->update($this->form->getState());
         } else {
+            $this->authorize('add_attributes');
+
             Attribute::query()->create($this->form->getState());
         }
 

--- a/packages/admin/src/Livewire/SlideOvers/AttributeValues.php
+++ b/packages/admin/src/Livewire/SlideOvers/AttributeValues.php
@@ -99,6 +99,7 @@ class AttributeValues extends SlideOverComponent implements HasActions, HasSchem
             ])
             ->recordActions([
                 Action::make('edit')
+                    ->authorize('edit_attributes')
                     ->icon(Untitledui::Edit03)
                     ->iconButton()
                     ->modalHeading(__('shopper::forms.actions.edit'))
@@ -117,6 +118,7 @@ class AttributeValues extends SlideOverComponent implements HasActions, HasSchem
                         $this->dispatch('$refresh');
                     }),
                 Action::make('delete')
+                    ->authorize('delete_attributes')
                     ->icon(Untitledui::Trash03)
                     ->color('danger')
                     ->iconButton()
@@ -125,6 +127,7 @@ class AttributeValues extends SlideOverComponent implements HasActions, HasSchem
             ])
             ->toolbarActions([
                 BulkAction::make('delete')
+                    ->authorize('delete_attributes')
                     ->label(__('shopper::forms.actions.delete'))
                     ->icon(Untitledui::Trash03)
                     ->color('danger')
@@ -162,7 +165,7 @@ class AttributeValues extends SlideOverComponent implements HasActions, HasSchem
 
     public function removeValue(int $id): void
     {
-        $this->authorize('edit_attributes');
+        $this->authorize('delete_attributes');
 
         AttributeValue::query()->find($id)->delete();
 

--- a/packages/admin/src/Livewire/SlideOvers/BrandForm.php
+++ b/packages/admin/src/Livewire/SlideOvers/BrandForm.php
@@ -49,6 +49,10 @@ class BrandForm extends SlideOverComponent implements HasActions, HasSchemas, Sl
 
     public function mount(?Brand $brand = null): void
     {
+        $user = shopper()->auth()->user();
+
+        abort_unless($user->can('add_brands') || $user->can('edit_brands'), 403);
+
         $this->brand = $brand ?? resolve(Brand::class)::query()->newModelInstance();
 
         $this->title = $this->brand->id

--- a/packages/admin/src/Livewire/SlideOvers/CategoryForm.php
+++ b/packages/admin/src/Livewire/SlideOvers/CategoryForm.php
@@ -51,6 +51,10 @@ class CategoryForm extends SlideOverComponent implements HasActions, HasSchemas,
 
     public function mount(?Category $category = null): void
     {
+        $user = shopper()->auth()->user();
+
+        abort_unless($user->can('add_categories') || $user->can('edit_categories'), 403);
+
         $this->category = $category ?? resolve(Category::class)::query()->newModelInstance();
 
         $this->title = $this->category->id

--- a/packages/admin/src/Livewire/SlideOvers/RelatedProductsList.php
+++ b/packages/admin/src/Livewire/SlideOvers/RelatedProductsList.php
@@ -90,6 +90,7 @@ class RelatedProductsList extends SlideOverComponent implements HasActions, HasS
             ->selectable()
             ->toolbarActions([
                 BulkAction::make('add')
+                    ->authorize('edit_products')
                     ->label(__('shopper::pages/collections.modal.action'))
                     ->icon(Untitledui::Plus)
                     ->action(function (Collection $records): void {

--- a/packages/admin/src/Livewire/SlideOvers/SupplierForm.php
+++ b/packages/admin/src/Livewire/SlideOvers/SupplierForm.php
@@ -48,6 +48,10 @@ class SupplierForm extends SlideOverComponent implements HasActions, HasSchemas,
 
     public function mount(?Supplier $supplier = null): void
     {
+        $user = shopper()->auth()->user();
+
+        abort_unless($user->can('add_suppliers') || $user->can('edit_suppliers'), 403);
+
         $this->supplier = $supplier ?? resolve(Supplier::class)::query()->newModelInstance();
 
         $this->title = $this->supplier->id

--- a/tests/Admin/Livewire/Components/Products/Form/VariantsTest.php
+++ b/tests/Admin/Livewire/Components/Products/Form/VariantsTest.php
@@ -6,11 +6,13 @@ use Livewire\Livewire;
 use Shopper\Core\Enum\ProductType;
 use Shopper\Livewire\Components\Products\Form\Variants;
 use Tests\Core\Stubs\Product;
+use Tests\Core\Stubs\ProductVariant;
 use Tests\Core\Stubs\User;
 
 uses(Tests\Admin\TestCase::class);
 
 beforeEach(function (): void {
+    Livewire::withoutLazyLoading();
 
     $this->user = User::factory()->create();
     $this->user->givePermissionTo('edit_products');
@@ -39,4 +41,32 @@ describe(Variants::class, function (): void {
 
         expect($component->get('product')->id)->toBe($this->product->id);
     });
-})->group('livewire', 'components', 'products');
+
+    it('hides the delete action for users without `delete_product_variants`', function (): void {
+        $variant = ProductVariant::factory()->create(['product_id' => $this->product->id]);
+
+        Livewire::test(Variants::class, ['product' => $this->product])
+            ->loadTable()
+            ->assertTableActionHidden('delete', $variant);
+    });
+
+    it('hides the bulk delete action for users without `delete_product_variants`', function (): void {
+        ProductVariant::factory()->count(3)->create(['product_id' => $this->product->id]);
+
+        Livewire::test(Variants::class, ['product' => $this->product])
+            ->loadTable()
+            ->assertTableBulkActionHidden('delete');
+    });
+
+    it('allows deleting a variant with `delete_product_variants`', function (): void {
+        $this->user->givePermissionTo('delete_product_variants');
+
+        $variant = ProductVariant::factory()->create(['product_id' => $this->product->id]);
+
+        Livewire::test(Variants::class, ['product' => $this->product])
+            ->loadTable()
+            ->callTableAction('delete', $variant);
+
+        expect(ProductVariant::query()->find($variant->id))->toBeNull();
+    });
+})->group('livewire', 'components', 'products', 'security');

--- a/tests/Admin/Livewire/Components/Products/ProductTypeConfigurationTest.php
+++ b/tests/Admin/Livewire/Components/Products/ProductTypeConfigurationTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+use Livewire\Livewire;
+use Shopper\Core\Enum\ProductType;
+use Shopper\Core\Models\Setting;
+use Shopper\Livewire\Components\Products\ProductTypeConfiguration;
+use Tests\Core\Stubs\User;
+
+uses(Tests\Admin\TestCase::class);
+
+describe(ProductTypeConfiguration::class, function (): void {
+    it('blocks writing the default product type setting for users without `access_setting`', function (): void {
+        $user = User::factory()->create();
+        $user->givePermissionTo('browse_products');
+        $this->actingAs($user);
+
+        Livewire::test(ProductTypeConfiguration::class, ['defaultProductType' => ProductType::Standard])
+            ->set('hasConfig', false);
+
+        expect(Setting::query()->where('key', 'default_product_type')->exists())->toBeFalse();
+    });
+
+    it('writes the default product type setting for users with `access_setting`', function (): void {
+        $user = User::factory()->create();
+        $user->givePermissionTo(['browse_products', 'access_setting']);
+        $this->actingAs($user);
+
+        Livewire::test(ProductTypeConfiguration::class, ['defaultProductType' => ProductType::Standard])
+            ->set('hasConfig', true);
+
+        expect(Setting::query()->where('key', 'default_product_type')->value('value'))
+            ->toBe(ProductType::Standard->value);
+    });
+})->group('livewire', 'components', 'products', 'security');

--- a/tests/Admin/Livewire/Pages/Brand/IndexTest.php
+++ b/tests/Admin/Livewire/Pages/Brand/IndexTest.php
@@ -17,6 +17,28 @@ beforeEach(function (): void {
 });
 
 describe(Index::class, function (): void {
+    it('blocks reordering brands for users without `edit_brands`', function (): void {
+        $a = Brand::factory()->create(['position' => 1]);
+        $b = Brand::factory()->create(['position' => 2]);
+
+        Livewire::test(Index::class)->call('reorderTable', [$b->getKey(), $a->getKey()]);
+
+        expect($a->refresh()->position)->toBe(1)
+            ->and($b->refresh()->position)->toBe(2);
+    });
+
+    it('allows reordering brands for users with `edit_brands`', function (): void {
+        $this->user->givePermissionTo('edit_brands');
+
+        $a = Brand::factory()->create(['position' => 1]);
+        $b = Brand::factory()->create(['position' => 2]);
+
+        Livewire::test(Index::class)->call('reorderTable', [$b->getKey(), $a->getKey()]);
+
+        expect($a->refresh()->position)->toBe(2)
+            ->and($b->refresh()->position)->toBe(1);
+    });
+
     it('can render brands index component', function (): void {
         Livewire::test(Index::class)
             ->assertOk()

--- a/tests/Admin/Livewire/Pages/Product/VariantTest.php
+++ b/tests/Admin/Livewire/Pages/Product/VariantTest.php
@@ -105,11 +105,21 @@ describe(Variant::class, function (): void {
             ->assertHasActionErrors(['barcode' => 'unique']);
     });
 
-    it('has media action', function (): void {
+    it('hides the media action for users without `edit_product_variants`', function (): void {
         Livewire::test(Variant::class, [
             'product' => $this->product,
             'variant' => $this->variant,
         ])
-            ->assertActionExists('media');
+            ->assertActionHidden('media');
+    });
+
+    it('shows the media action for users with `edit_product_variants`', function (): void {
+        $this->user->givePermissionTo('edit_product_variants');
+
+        Livewire::test(Variant::class, [
+            'product' => $this->product,
+            'variant' => $this->variant,
+        ])
+            ->assertActionVisible('media');
     });
 })->group('livewire', 'products');

--- a/tests/Admin/Livewire/Pages/Tag/IndexTest.php
+++ b/tests/Admin/Livewire/Pages/Tag/IndexTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+use Livewire\Livewire;
+use Shopper\Livewire\Pages\Tag\Index;
+use Tests\Core\Stubs\User;
+
+uses(Tests\Admin\TestCase::class);
+
+beforeEach(function (): void {
+    $this->user = User::factory()->create();
+    $this->user->givePermissionTo('browse_tags');
+    $this->actingAs($this->user);
+});
+
+describe(Index::class, function (): void {
+    it('hides the create action for users without `add_tags`', function (): void {
+        Livewire::test(Index::class)
+            ->assertActionHidden('create');
+    });
+
+    it('shows the create action for users with `add_tags`', function (): void {
+        $this->user->givePermissionTo('add_tags');
+
+        Livewire::test(Index::class)
+            ->assertActionVisible('create');
+    });
+})->group('livewire', 'products', 'security');

--- a/tests/Admin/Livewire/SlideOvers/AddVariantTest.php
+++ b/tests/Admin/Livewire/SlideOvers/AddVariantTest.php
@@ -20,7 +20,7 @@ beforeEach(function (): void {
     setupCurrencies();
 
     $this->user = User::factory()->create();
-    $this->user->givePermissionTo('add_products');
+    $this->user->givePermissionTo(['add_products', 'add_product_variants']);
     $this->actingAs($this->user);
 
     $this->product = Product::factory()->create(['type' => ProductType::Variant]);
@@ -29,6 +29,15 @@ beforeEach(function (): void {
 describe(AddVariant::class, function (): void {
     it('requires add_products permission', function (): void {
         $user = User::factory()->create();
+        $this->actingAs($user);
+
+        Livewire::test(AddVariant::class, ['product' => $this->product])
+            ->assertForbidden();
+    });
+
+    it('blocks creating a variant for users without `add_product_variants`', function (): void {
+        $user = User::factory()->create();
+        $user->givePermissionTo('add_products');
         $this->actingAs($user);
 
         Livewire::test(AddVariant::class, ['product' => $this->product])

--- a/tests/Admin/Livewire/SlideOvers/AttributeFormTest.php
+++ b/tests/Admin/Livewire/SlideOvers/AttributeFormTest.php
@@ -78,6 +78,23 @@ describe(AttributeForm::class, function (): void {
             ->assertHasFormErrors(['slug' => 'unique']);
     });
 
+    it('blocks editing an existing attribute for users without `edit_attributes`', function (): void {
+        $attribute = Attribute::factory()->create([
+            'name' => 'Old Name',
+            'description' => 'Short description',
+        ]);
+
+        Livewire::test(AttributeForm::class, ['attributeId' => $attribute->id])
+            ->fillForm([
+                'name' => 'Hacked Name',
+                'type' => FieldType::Select(),
+                'description' => 'Updated description',
+            ])
+            ->call('store');
+
+        expect($attribute->refresh()->name)->toBe('Old Name');
+    });
+
     it('can edit existing attribute', function (): void {
         $this->user->givePermissionTo('edit_attributes');
 

--- a/tests/Admin/Livewire/SlideOvers/AttributeValuesTest.php
+++ b/tests/Admin/Livewire/SlideOvers/AttributeValuesTest.php
@@ -133,6 +133,8 @@ describe(AttributeValues::class, function (): void {
     });
 
     it('can delete attribute value via action', function (): void {
+        $this->user->givePermissionTo('delete_attributes');
+
         $value = AttributeValue::factory()->create([
             'attribute_id' => $this->attribute->id,
         ]);
@@ -144,6 +146,8 @@ describe(AttributeValues::class, function (): void {
     });
 
     it('can bulk delete attribute values', function (): void {
+        $this->user->givePermissionTo('delete_attributes');
+
         $values = AttributeValue::factory()->count(3)->create([
             'attribute_id' => $this->attribute->id,
         ]);
@@ -154,7 +158,27 @@ describe(AttributeValues::class, function (): void {
         expect(AttributeValue::query()->whereIn('id', $values->pluck('id'))->count())->toBe(0);
     });
 
+    it('hides the delete action for users without `delete_attributes`', function (): void {
+        $value = AttributeValue::factory()->create([
+            'attribute_id' => $this->attribute->id,
+        ]);
+
+        Livewire::test(AttributeValues::class, ['attributeId' => $this->attribute->id])
+            ->assertTableActionHidden('delete', $value);
+    });
+
+    it('hides the bulk delete action for users without `delete_attributes`', function (): void {
+        AttributeValue::factory()->count(3)->create([
+            'attribute_id' => $this->attribute->id,
+        ]);
+
+        Livewire::test(AttributeValues::class, ['attributeId' => $this->attribute->id])
+            ->assertTableBulkActionHidden('delete');
+    });
+
     it('can remove value via method', function (): void {
+        $this->user->givePermissionTo('delete_attributes');
+
         $value = AttributeValue::factory()->create([
             'attribute_id' => $this->attribute->id,
         ]);
@@ -164,6 +188,17 @@ describe(AttributeValues::class, function (): void {
             ->assertDispatched('updateValues');
 
         expect(AttributeValue::query()->find($value->id))->toBeNull();
+    });
+
+    it('blocks removing a value via method for users without `delete_attributes`', function (): void {
+        $value = AttributeValue::factory()->create([
+            'attribute_id' => $this->attribute->id,
+        ]);
+
+        Livewire::test(AttributeValues::class, ['attributeId' => $this->attribute->id])
+            ->call('removeValue', $value->id);
+
+        expect(AttributeValue::query()->find($value->id))->not->toBeNull();
     });
 
     it('updates values list when updateValues event is dispatched', function (): void {

--- a/tests/Admin/Livewire/SlideOvers/BrandFormTest.php
+++ b/tests/Admin/Livewire/SlideOvers/BrandFormTest.php
@@ -56,24 +56,18 @@ describe(BrandForm::class, function (): void {
             ->toBe('nike-1');
     });
 
-    it('dispatches unauthorized notification when user lacks `add_brands` permission', function (): void {
-        $user = User::factory()->create();
-        $this->actingAs($user);
+    it('blocks opening the create form for users without `add_brands`', function (): void {
+        $this->actingAs(User::factory()->create());
 
         Livewire::test(BrandForm::class)
-            ->fillForm(['name' => 'Nike'])
-            ->call('save')
-            ->assertNotified(__('shopper::notifications.unauthorized.title'));
+            ->assertForbidden();
     });
 
-    it('dispatches unauthorized notification when user lacks `edit_brands` permission', function (): void {
+    it('blocks opening the edit form for users without `edit_brands`', function (): void {
         $brand = Brand::factory()->create();
-        $user = User::factory()->create();
-        $this->actingAs($user);
+        $this->actingAs(User::factory()->create());
 
         Livewire::test(BrandForm::class, ['brand' => $brand])
-            ->fillForm(['name' => 'Nike Updated'])
-            ->call('save')
-            ->assertNotified(__('shopper::notifications.unauthorized.title'));
+            ->assertForbidden();
     });
 })->group('livewire', 'slideovers', 'brands');

--- a/tests/Admin/Livewire/SlideOvers/CategoryFormTest.php
+++ b/tests/Admin/Livewire/SlideOvers/CategoryFormTest.php
@@ -18,6 +18,13 @@ beforeEach(function (): void {
 });
 
 describe(CategoryForm::class, function (): void {
+    it('blocks opening the form for users without category permissions', function (): void {
+        $this->actingAs(User::factory()->create());
+
+        Livewire::test(CategoryForm::class)
+            ->assertForbidden();
+    });
+
     it('can validate required fields on add category form', function (): void {
         Livewire::test(CategoryForm::class)
             ->fillForm()

--- a/tests/Admin/Livewire/SlideOvers/SupplierFormTest.php
+++ b/tests/Admin/Livewire/SlideOvers/SupplierFormTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+use Livewire\Livewire;
+use Shopper\Livewire\SlideOvers\SupplierForm;
+use Tests\Core\Stubs\User;
+
+uses(Tests\Admin\TestCase::class);
+
+describe(SupplierForm::class, function (): void {
+    it('blocks opening the form for users without supplier permissions', function (): void {
+        $this->actingAs(User::factory()->create());
+
+        Livewire::test(SupplierForm::class)
+            ->assertForbidden();
+    });
+
+    it('opens the form for users with supplier permissions', function (): void {
+        $user = User::factory()->create();
+        $user->givePermissionTo('add_suppliers');
+        $this->actingAs($user);
+
+        Livewire::test(SupplierForm::class)
+            ->assertSuccessful();
+    });
+})->group('livewire', 'slideovers', 'security');


### PR DESCRIPTION
## Summary

Exhaustive authorization audit of all 80 admin Livewire components that expose a Filament action, table, or form surface. Every destructive or write path now carries an explicit permission check at the correct granularity. This closes the GHSA-93v2-gcw2-vfwc class (variant deletion) and every sibling gap of the same kind.

Filament enforces both `->authorize()` and `->visible()` server-side via `isDisabled()`, and Livewire signs component snapshots (HMAC), so the fixes target real privilege-escalation paths: actions reachable with a permission strictly weaker than the operation requires, plus mount gates that leaked data through `openPanel`.

## Exploitable gaps fixed

| Area | Fix |
|---|---|
| `Variants` Delete / DeleteBulk | `delete_product_variants` |
| `AttributeValues` delete / bulk / `removeValue()` | `delete_attributes` |
| `Brand` table reorder | `authorizeReorder` with `edit_brands` |
| `SupplierForm` / `BrandForm` / `CategoryForm` mount | gate add/edit (Supplier leaked PII) |
| `AddVariant` mount + save | `add_product_variants` |
| `Variant` mediaAction | `edit_product_variants` |
| `Tag` createAction | `add_tags` |
| `AttributeForm` store | `edit_attributes` / `add_attributes` per branch |
| `ProductTypeConfiguration` / `Settings\General` / `InitializationWizard` | `access_setting` on every settings write |

## Hardening

- Explicit `->authorize()` on every mutating action previously relying only on the parent gate (`Pricing`, `Inventory` stock, `RelatedProducts`, `RelatedProductsList`).
- `#[Locked]` on `Pricing::$model` and `ZoneShippingOptions::$selectedZoneId`.
- `->authorize()` on the `TaxRates` delete action for consistency.

## Tests

Positive and negative authorization tests added for each gated path (action hidden/forbidden without the fine-grained permission, allowed with it).