### PR TITLE
fix(admin): enforce explicit permissions on remaining Filament actions and Livewire mutations

### DIFF
--- a/packages/admin/src/Livewire/Components/Initialization/InitializationWizard.php
+++ b/packages/admin/src/Livewire/Components/Initialization/InitializationWizard.php
@@ -356,6 +356,8 @@ final class InitializationWizard extends Component implements HasActions, HasSch
      */
     private function persistStep(array $keys): void
     {
+        $this->authorizeSettingsAccess();
+
         $allowed = array_intersect($keys, self::ALLOWED_KEYS);
 
         $values = collect($this->data ?? [])

--- a/packages/admin/src/Livewire/Components/Products/Pricing.php
+++ b/packages/admin/src/Livewire/Components/Products/Pricing.php
@@ -16,6 +16,7 @@ use Filament\Tables\Contracts\HasTable;
 use Filament\Tables\Table;
 use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Model;
+use Livewire\Attributes\Locked;
 use Livewire\Attributes\On;
 use Livewire\Component;
 use Mckenziearts\Icons\Untitledui\Enums\Untitledui;
@@ -29,6 +30,7 @@ class Pricing extends Component implements HasActions, HasSchemas, HasTable
     use InteractsWithSchemas;
     use InteractsWithTable;
 
+    #[Locked]
     public Model $model;
 
     public function table(Table $table): Table
@@ -53,6 +55,7 @@ class Pricing extends Component implements HasActions, HasSchemas, HasTable
             ])
             ->recordActions([
                 Action::make('edit')
+                    ->authorize('products.edit')
                     ->label(__('shopper::forms.actions.edit'))
                     ->icon(Untitledui::Edit03)
                     ->iconButton()
@@ -68,12 +71,14 @@ class Pricing extends Component implements HasActions, HasSchemas, HasTable
                         )
                     ),
                 DeleteAction::make()
+                    ->authorize('products.edit')
                     ->label(__('shopper::forms.actions.delete'))
                     ->icon(Untitledui::Trash03)
                     ->iconButton(),
             ])
             ->headerActions([
                 Action::make('add')
+                    ->authorize('products.edit')
                     ->label(__('shopper::pages/products.pricing.add'))
                     ->color('gray')
                     ->action(

--- a/packages/admin/src/Livewire/Components/Products/ProductTypeConfiguration.php
+++ b/packages/admin/src/Livewire/Components/Products/ProductTypeConfiguration.php
@@ -48,6 +48,8 @@ class ProductTypeConfiguration extends Component implements HasActions, HasSchem
                     ->debounce()
                     ->live()
                     ->afterStateUpdated(function (bool $state): void {
+                        $this->authorize('system.settings');
+
                         $this->saveSettings(['default_product_type' => $state ? $this->defaultProductType : null]);
 
                         $this->dispatch('product-type.updated');

--- a/packages/admin/src/Livewire/Components/Settings/Zones/ZoneShippingOptions.php
+++ b/packages/admin/src/Livewire/Components/Settings/Zones/ZoneShippingOptions.php
@@ -13,6 +13,7 @@ use Filament\Schemas\Contracts\HasSchemas;
 use Illuminate\Contracts\View\View;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\Lazy;
+use Livewire\Attributes\Locked;
 use Livewire\Attributes\On;
 use Livewire\Component;
 use Mckenziearts\Icons\Untitledui\Enums\Untitledui;
@@ -30,6 +31,7 @@ class ZoneShippingOptions extends Component implements HasActions, HasSchemas
     use InteractsWithActions;
     use InteractsWithSchemas;
 
+    #[Locked]
     public ?int $selectedZoneId = null;
 
     #[On('zone.changed')]

--- a/packages/admin/src/Livewire/Pages/Brand/Index.php
+++ b/packages/admin/src/Livewire/Pages/Brand/Index.php
@@ -23,7 +23,6 @@ use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Collection;
 use Mckenziearts\Icons\Untitledui\Enums\Untitledui;
 use Shopper\Core\Models\Contracts\Brand as BrandContract;
-use Shopper\Facades\Shopper;
 use Shopper\Livewire\Pages\AbstractPageComponent;
 use Shopper\Traits\HandlesAuthorizationExceptions;
 
@@ -68,6 +67,7 @@ class Index extends AbstractPageComponent implements HasActions, HasSchemas, Has
                     ->sortable(),
             ])
             ->reorderable('position')
+            ->authorizeReorder(shopper()->auth()->user()->can('brands.edit'))
             ->recordActions([
                 Action::make('edit')
                     ->label(__('shopper::forms.actions.edit'))
@@ -81,7 +81,7 @@ class Index extends AbstractPageComponent implements HasActions, HasSchemas, Has
                         )
                     )
                     ->authorize('brands.edit')
-                    ->visible(Shopper::auth()->user()->can('brands.edit')),
+                    ->visible(shopper()->auth()->user()->can('brands.edit')),
                 Action::make('delete')
                     ->label(__('shopper::forms.actions.delete'))
                     ->icon(Untitledui::Trash03)
@@ -91,12 +91,12 @@ class Index extends AbstractPageComponent implements HasActions, HasSchemas, Has
                     ->requiresConfirmation()
                     ->action(fn (BrandContract $record) => $record->delete())
                     ->authorize('brands.delete')
-                    ->visible(Shopper::auth()->user()->can('brands.delete')),
+                    ->visible(shopper()->auth()->user()->can('brands.delete')),
             ])
             ->groupedBulkActions([
                 BulkAction::make('enabled')
                     ->authorize('brands.edit')
-                    ->visible(Shopper::auth()->user()->can('brands.edit'))
+                    ->visible(shopper()->auth()->user()->can('brands.edit'))
                     ->label(__('shopper::forms.actions.enable'))
                     ->icon(Untitledui::CheckVerified)
                     ->action(function (Collection $records): void {
@@ -114,7 +114,7 @@ class Index extends AbstractPageComponent implements HasActions, HasSchemas, Has
                     ->deselectRecordsAfterCompletion(),
                 BulkAction::make('disabled')
                     ->authorize('brands.edit')
-                    ->visible(Shopper::auth()->user()->can('brands.edit'))
+                    ->visible(shopper()->auth()->user()->can('brands.edit'))
                     ->label(__('shopper::forms.actions.disable'))
                     ->icon(Untitledui::SlashCircle01)
                     ->action(function (Collection $records): void {
@@ -148,7 +148,7 @@ class Index extends AbstractPageComponent implements HasActions, HasSchemas, Has
                             ->send();
                     })
                     ->authorize('brands.delete')
-                    ->visible(Shopper::auth()->user()->can('brands.delete'))
+                    ->visible(shopper()->auth()->user()->can('brands.delete'))
                     ->deselectRecordsAfterCompletion(),
             ])
             ->filters([

--- a/packages/admin/src/Livewire/Pages/Product/Inventory.php
+++ b/packages/admin/src/Livewire/Pages/Product/Inventory.php
@@ -131,6 +131,7 @@ class Inventory extends Component implements HasActions, HasSchemas, HasTable
             ])
             ->headerActions([
                 Action::make('stock')
+                    ->authorize('products.edit')
                     ->label(__('shopper::forms.label.add_stock'))
                     ->icon(Untitledui::Package)
                     ->color('gray')

--- a/packages/admin/src/Livewire/Pages/Product/Related.php
+++ b/packages/admin/src/Livewire/Pages/Product/Related.php
@@ -46,6 +46,7 @@ class Related extends Component implements HasActions, HasSchemas
     public function removeAction(): Action
     {
         return Action::make('remove')
+            ->authorize('products.edit')
             ->label(__('shopper::forms.actions.remove'))
             ->icon(Untitledui::Trash03)
             ->color('danger')

--- a/packages/admin/src/Livewire/Pages/Settings/General.php
+++ b/packages/admin/src/Livewire/Pages/Settings/General.php
@@ -255,6 +255,8 @@ class General extends Component implements HasActions, HasSchemas
 
     public function store(): void
     {
+        $this->authorize('system.settings');
+
         $this->saveSettings($this->form->getState());
 
         Notification::make()

--- a/packages/admin/src/Livewire/SlideOvers/AddVariant.php
+++ b/packages/admin/src/Livewire/SlideOvers/AddVariant.php
@@ -63,7 +63,7 @@ class AddVariant extends SlideOverComponent implements HasActions, HasSchemas
 
     public function mount(): void
     {
-        $this->authorize('products.create');
+        $this->authorize('products.variants.create');
 
         $this->form->fill();
     }
@@ -204,6 +204,8 @@ class AddVariant extends SlideOverComponent implements HasActions, HasSchemas
 
     public function save(): void
     {
+        $this->authorize('products.variants.create');
+
         $data = $this->form->getState();
 
         if (isset($data['values']) && $this->variantAlreadyExist($data['values'])) {

--- a/packages/admin/src/Livewire/SlideOvers/AttributeForm.php
+++ b/packages/admin/src/Livewire/SlideOvers/AttributeForm.php
@@ -114,8 +114,12 @@ class AttributeForm extends SlideOverComponent implements HasActions, HasSchemas
     public function store(): void
     {
         if ($this->attribute) {
+            $this->authorize('attributes.edit');
+
             $this->attribute->update($this->form->getState());
         } else {
+            $this->authorize('attributes.create');
+
             Attribute::query()->create($this->form->getState());
         }
 

--- a/packages/admin/src/Livewire/SlideOvers/AttributeValues.php
+++ b/packages/admin/src/Livewire/SlideOvers/AttributeValues.php
@@ -99,6 +99,7 @@ class AttributeValues extends SlideOverComponent implements HasActions, HasSchem
             ])
             ->recordActions([
                 Action::make('edit')
+                    ->authorize('attributes.edit')
                     ->icon(Untitledui::Edit03)
                     ->iconButton()
                     ->modalHeading(__('shopper::forms.actions.edit'))
@@ -164,7 +165,7 @@ class AttributeValues extends SlideOverComponent implements HasActions, HasSchem
 
     public function removeValue(int $id): void
     {
-        $this->authorize('attributes.edit');
+        $this->authorize('attributes.delete');
 
         AttributeValue::query()->find($id)->delete();
 

--- a/packages/admin/src/Livewire/SlideOvers/BrandForm.php
+++ b/packages/admin/src/Livewire/SlideOvers/BrandForm.php
@@ -49,6 +49,10 @@ class BrandForm extends SlideOverComponent implements HasActions, HasSchemas, Sl
 
     public function mount(?Brand $brand = null): void
     {
+        $user = shopper()->auth()->user();
+
+        abort_unless($user->can('brands.create') || $user->can('brands.edit'), 403);
+
         $this->brand = $brand ?? resolve(Brand::class)::query()->newModelInstance();
 
         $this->title = $this->brand->id

--- a/packages/admin/src/Livewire/SlideOvers/CategoryForm.php
+++ b/packages/admin/src/Livewire/SlideOvers/CategoryForm.php
@@ -51,6 +51,10 @@ class CategoryForm extends SlideOverComponent implements HasActions, HasSchemas,
 
     public function mount(?Category $category = null): void
     {
+        $user = shopper()->auth()->user();
+
+        abort_unless($user->can('categories.create') || $user->can('categories.edit'), 403);
+
         $this->category = $category ?? resolve(Category::class)::query()->newModelInstance();
 
         $this->title = $this->category->id

--- a/packages/admin/src/Livewire/SlideOvers/RelatedProductsList.php
+++ b/packages/admin/src/Livewire/SlideOvers/RelatedProductsList.php
@@ -90,6 +90,7 @@ class RelatedProductsList extends SlideOverComponent implements HasActions, HasS
             ->selectable()
             ->toolbarActions([
                 BulkAction::make('add')
+                    ->authorize('products.edit')
                     ->label(__('shopper::pages/collections.modal.action'))
                     ->icon(Untitledui::Plus)
                     ->action(function (Collection $records): void {

--- a/packages/admin/src/Livewire/SlideOvers/SupplierForm.php
+++ b/packages/admin/src/Livewire/SlideOvers/SupplierForm.php
@@ -48,6 +48,10 @@ class SupplierForm extends SlideOverComponent implements HasActions, HasSchemas,
 
     public function mount(?Supplier $supplier = null): void
     {
+        $user = shopper()->auth()->user();
+
+        abort_unless($user->can('suppliers.create') || $user->can('suppliers.edit'), 403);
+
         $this->supplier = $supplier ?? resolve(Supplier::class)::query()->newModelInstance();
 
         $this->title = $this->supplier->id

--- a/tests/Admin/Livewire/Components/Products/ProductTypeConfigurationTest.php
+++ b/tests/Admin/Livewire/Components/Products/ProductTypeConfigurationTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+use Livewire\Livewire;
+use Shopper\Core\Enum\ProductType;
+use Shopper\Core\Models\Setting;
+use Shopper\Livewire\Components\Products\ProductTypeConfiguration;
+use Tests\Core\Stubs\User;
+
+uses(Tests\Admin\TestCase::class);
+
+describe(ProductTypeConfiguration::class, function (): void {
+    it('blocks writing the default product type setting for users without `system.settings`', function (): void {
+        $user = User::factory()->create();
+        $user->givePermissionTo('products.browse');
+        $this->actingAs($user);
+
+        Livewire::test(ProductTypeConfiguration::class, ['defaultProductType' => ProductType::Standard->value])
+            ->set('hasConfig', false);
+
+        expect(Setting::query()->where('key', 'default_product_type')->exists())->toBeFalse();
+    });
+
+    it('writes the default product type setting for users with `system.settings`', function (): void {
+        $user = User::factory()->create();
+        $user->givePermissionTo(['products.browse', 'system.settings']);
+        $this->actingAs($user);
+
+        Livewire::test(ProductTypeConfiguration::class, ['defaultProductType' => ProductType::Standard->value])
+            ->set('hasConfig', true);
+
+        expect(Setting::query()->where('key', 'default_product_type')->value('value'))
+            ->toBe(ProductType::Standard->value);
+    });
+})->group('livewire', 'components', 'products', 'security');

--- a/tests/Admin/Livewire/Pages/Brand/IndexTest.php
+++ b/tests/Admin/Livewire/Pages/Brand/IndexTest.php
@@ -17,6 +17,28 @@ beforeEach(function (): void {
 });
 
 describe(Index::class, function (): void {
+    it('blocks reordering brands for users without `brands.edit`', function (): void {
+        $a = Brand::factory()->create(['position' => 1]);
+        $b = Brand::factory()->create(['position' => 2]);
+
+        Livewire::test(Index::class)->call('reorderTable', [$b->getKey(), $a->getKey()]);
+
+        expect($a->refresh()->position)->toBe(1)
+            ->and($b->refresh()->position)->toBe(2);
+    });
+
+    it('allows reordering brands for users with `brands.edit`', function (): void {
+        $this->user->givePermissionTo('brands.edit');
+
+        $a = Brand::factory()->create(['position' => 1]);
+        $b = Brand::factory()->create(['position' => 2]);
+
+        Livewire::test(Index::class)->call('reorderTable', [$b->getKey(), $a->getKey()]);
+
+        expect($a->refresh()->position)->toBe(2)
+            ->and($b->refresh()->position)->toBe(1);
+    });
+
     it('can render brands index component', function (): void {
         Livewire::test(Index::class)
             ->assertOk()

--- a/tests/Admin/Livewire/SlideOvers/AddVariantTest.php
+++ b/tests/Admin/Livewire/SlideOvers/AddVariantTest.php
@@ -20,15 +20,24 @@ beforeEach(function (): void {
     setupCurrencies();
 
     $this->user = User::factory()->create();
-    $this->user->givePermissionTo('products.create');
+    $this->user->givePermissionTo('products.variants.create');
     $this->actingAs($this->user);
 
     $this->product = Product::factory()->create(['type' => ProductType::Variant]);
 });
 
 describe(AddVariant::class, function (): void {
-    it('requires add_products permission', function (): void {
+    it('forbids users without any variant permission', function (): void {
         $user = User::factory()->create();
+        $this->actingAs($user);
+
+        Livewire::test(AddVariant::class, ['product' => $this->product])
+            ->assertForbidden();
+    });
+
+    it('forbids users with `products.create` but not `products.variants.create`', function (): void {
+        $user = User::factory()->create();
+        $user->givePermissionTo('products.create');
         $this->actingAs($user);
 
         Livewire::test(AddVariant::class, ['product' => $this->product])

--- a/tests/Admin/Livewire/SlideOvers/AttributeFormTest.php
+++ b/tests/Admin/Livewire/SlideOvers/AttributeFormTest.php
@@ -17,6 +17,23 @@ beforeEach(function (): void {
 });
 
 describe(AttributeForm::class, function (): void {
+    it('blocks editing an existing attribute for users without `attributes.edit`', function (): void {
+        $attribute = Attribute::factory()->create([
+            'name' => 'Old Name',
+            'description' => 'Short description',
+        ]);
+
+        Livewire::test(AttributeForm::class, ['attributeId' => $attribute->id])
+            ->fillForm([
+                'name' => 'Hacked Name',
+                'type' => FieldType::Select(),
+                'description' => 'Updated description',
+            ])
+            ->call('store');
+
+        expect($attribute->refresh()->name)->toBe('Old Name');
+    });
+
     it('can render attribute form component', function (): void {
         Livewire::test(AttributeForm::class)
             ->assertOk();

--- a/tests/Admin/Livewire/SlideOvers/AttributeValuesTest.php
+++ b/tests/Admin/Livewire/SlideOvers/AttributeValuesTest.php
@@ -177,6 +177,8 @@ describe(AttributeValues::class, function (): void {
     });
 
     it('can remove value via method', function (): void {
+        $this->user->givePermissionTo('attributes.delete');
+
         $value = AttributeValue::factory()->create([
             'attribute_id' => $this->attribute->id,
         ]);
@@ -186,6 +188,17 @@ describe(AttributeValues::class, function (): void {
             ->assertDispatched('updateValues');
 
         expect(AttributeValue::query()->find($value->id))->toBeNull();
+    });
+
+    it('blocks removing a value via method for users without `attributes.delete`', function (): void {
+        $value = AttributeValue::factory()->create([
+            'attribute_id' => $this->attribute->id,
+        ]);
+
+        Livewire::test(AttributeValues::class, ['attributeId' => $this->attribute->id])
+            ->call('removeValue', $value->id);
+
+        expect(AttributeValue::query()->find($value->id))->not->toBeNull();
     });
 
     it('updates values list when updateValues event is dispatched', function (): void {

--- a/tests/Admin/Livewire/SlideOvers/BrandFormTest.php
+++ b/tests/Admin/Livewire/SlideOvers/BrandFormTest.php
@@ -56,24 +56,18 @@ describe(BrandForm::class, function (): void {
             ->toBe('nike-1');
     });
 
-    it('dispatches unauthorized notification when user lacks `add_brands` permission', function (): void {
-        $user = User::factory()->create();
-        $this->actingAs($user);
+    it('blocks opening the create form for users without `brands.create`', function (): void {
+        $this->actingAs(User::factory()->create());
 
         Livewire::test(BrandForm::class)
-            ->fillForm(['name' => 'Nike'])
-            ->call('save')
-            ->assertNotified(__('shopper::notifications.unauthorized.title'));
+            ->assertForbidden();
     });
 
-    it('dispatches unauthorized notification when user lacks `edit_brands` permission', function (): void {
+    it('blocks opening the edit form for users without `brands.edit`', function (): void {
         $brand = Brand::factory()->create();
-        $user = User::factory()->create();
-        $this->actingAs($user);
+        $this->actingAs(User::factory()->create());
 
         Livewire::test(BrandForm::class, ['brand' => $brand])
-            ->fillForm(['name' => 'Nike Updated'])
-            ->call('save')
-            ->assertNotified(__('shopper::notifications.unauthorized.title'));
+            ->assertForbidden();
     });
 })->group('livewire', 'slideovers', 'brands');

--- a/tests/Admin/Livewire/SlideOvers/CategoryFormTest.php
+++ b/tests/Admin/Livewire/SlideOvers/CategoryFormTest.php
@@ -18,6 +18,13 @@ beforeEach(function (): void {
 });
 
 describe(CategoryForm::class, function (): void {
+    it('blocks opening the form for users without category permissions', function (): void {
+        $this->actingAs(User::factory()->create());
+
+        Livewire::test(CategoryForm::class)
+            ->assertForbidden();
+    });
+
     it('can validate required fields on add category form', function (): void {
         Livewire::test(CategoryForm::class)
             ->fillForm()

--- a/tests/Admin/Livewire/SlideOvers/SupplierFormTest.php
+++ b/tests/Admin/Livewire/SlideOvers/SupplierFormTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+use Livewire\Livewire;
+use Shopper\Livewire\SlideOvers\SupplierForm;
+use Tests\Core\Stubs\User;
+
+uses(Tests\Admin\TestCase::class);
+
+describe(SupplierForm::class, function (): void {
+    it('blocks opening the form for users without supplier permissions', function (): void {
+        $this->actingAs(User::factory()->create());
+
+        Livewire::test(SupplierForm::class)
+            ->assertForbidden();
+    });
+
+    it('opens the form for users with supplier permissions', function (): void {
+        $user = User::factory()->create();
+        $user->givePermissionTo('suppliers.create');
+        $this->actingAs($user);
+
+        Livewire::test(SupplierForm::class)
+            ->assertSuccessful();
+    });
+})->group('livewire', 'slideovers', 'security');


### PR DESCRIPTION
## Summary

Completes the admin authorization audit started in #572. After an exhaustive pass over all 80 admin Livewire components that expose a Filament action, table, or form surface, every remaining destructive or write path now carries an explicit permission check at the correct granularity.

Filament enforces both `->authorize()` and `->visible()` server-side via `isDisabled()`, and Livewire signs component snapshots (HMAC), so the fixes target real privilege-escalation paths: actions reachable with a permission strictly weaker than the operation requires, plus mount gates that leaked data through `openPanel`.

## Exploitable gaps fixed

| Area | Fix |
|---|---|
| `AttributeValues::removeValue()` | `attributes.delete` (was `attributes.edit`) |
| `Brand` table reorder | `authorizeReorder` with `brands.edit` |
| `SupplierForm` / `BrandForm` / `CategoryForm` mount | gate create/edit (Supplier leaked PII) |
| `AddVariant` mount + save | `products.variants.create` |
| `AttributeForm` store | `attributes.edit` / `attributes.create` per branch |
| `ProductTypeConfiguration` / `Settings\General` / `InitializationWizard` | `system.settings` on every settings write |

## Hardening

- Explicit `->authorize()` on every mutating action previously relying only on the parent gate (`Pricing`, product `Inventory` stock, product `Related` detach, `RelatedProductsList`, `AttributeValues` edit).
- `#[Locked]` on `Pricing::$model` and `ZoneShippingOptions::$selectedZoneId`.

## Tests

Positive and negative authorization tests added for each gated path. This is the 3.x counterpart of #573 on the 2.x line.