### PR TITLE
ci: harden monorepo-split and add SDK npm publishing

### DIFF
--- a/.github/workflows/monorepo-split.yml
+++ b/.github/workflows/monorepo-split.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - '*'
 
+permissions:
+  contents: read
+
 jobs:
   split-monorepo:
     runs-on: ubuntu-latest
@@ -18,6 +21,7 @@ jobs:
           - core
           - http
           - payment
+          - sdk
           - sidebar
           - shipping
           - stripe
@@ -36,6 +40,8 @@ jobs:
             repository: http
           - package: payment
             repository: payment
+          - package: sdk
+            repository: shopper-sdk
           - package: sidebar
             repository: sidebar
           - package: shipping
@@ -48,6 +54,8 @@ jobs:
             repository: upgrade
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Monorepo Split of ${{ matrix.package }}
         uses: danharrin/monorepo-split-github-action@v2.4.2
         env:

--- a/packages/sdk/.github/workflows/npm-publish.yml
+++ b/packages/sdk/.github/workflows/npm-publish.yml
@@ -1,0 +1,43 @@
+name: Publish to npm
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g. 1.0.0-beta.1)'
+        required: true
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Update npm for OIDC trusted publishing
+        run: npm install -g npm@latest
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Set version
+        run: npm version ${{ github.event.inputs.version }} --no-git-tag-version --allow-same-version
+
+      - name: Publish to npm
+        run: |
+          if [[ "${{ github.event.inputs.version }}" == *-* ]]; then
+            npm publish --access public --provenance --tag beta
+          else
+            npm publish --access public --provenance
+          fi


### PR DESCRIPTION
Hardens the `monorepo-split` workflow and wires npm publishing for the new `sdk` package ahead of the 3.x prerelease.

## Split workflow

- Add `permissions: contents: read` (least privilege).
- Set `persist-credentials: false` on checkout so the default token is not left in the git config (the split authenticates via `ACCESS_TOKEN`).
- Add `sdk` to the matrix, mirrored to the `shopperlabs/shopper-sdk` repository.

## SDK npm publishing

New `packages/sdk/.github/workflows/npm-publish.yml`, propagated to `shopper-sdk` by the split:

- `workflow_dispatch` with an explicit version input, so the SDK keeps an independent semver instead of riding the framework tag.
- Publishes prereleases under the `beta` dist-tag (versions containing `-`) and stable releases under `latest`.
- OIDC trusted publishing with provenance, matching the `shopper-types` setup.

## Not included

- `packages/sdk/package.json` version and the `@shopperlabs/shopper-types` range bump for the first beta.
- npm trusted publisher configuration for `@shopperlabs/shopper-sdk`.
- Packagist registration of `shopper/api` and `shopper/http`.