### PR TITLE
ci: fix monorepo-split aborting on missing target branch

### DIFF
--- a/.github/workflows/monorepo-split.yml
+++ b/.github/workflows/monorepo-split.yml
@@ -57,7 +57,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Monorepo Split of ${{ matrix.package }}
-        uses: danharrin/monorepo-split-github-action@v2.4.2
+        uses: danharrin/monorepo-split-github-action@v2.4.5
         env:
           GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
         with:


### PR DESCRIPTION
The first `v3.0.0-beta.1` tag failed every split job with `pathspec '3.x' did not match`. The downstream repositories have no `3.x` branch yet, and `danharrin/monorepo-split-github-action@v2.4.2` runs the branch checkout through `execOrDie`, which aborts before reaching the create-branch path.

Bumping to `v2.4.5`, which tolerates the failed checkout and then creates and pushes the branch, so the first 3.x tag populates every package repository (including the empty `api`, `http` and `shopper-sdk`).