### PR TITLE
fix(sdk): independent beta version and working types publish

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4888,10 +4888,10 @@
     },
     "packages/sdk": {
       "name": "@shopperlabs/shopper-sdk",
-      "version": "3.0.0",
+      "version": "1.0.0-beta.2",
       "license": "MIT",
       "dependencies": {
-        "@shopperlabs/shopper-types": "^3.0.0"
+        "@shopperlabs/shopper-types": "^3.0.0-beta.1"
       },
       "devDependencies": {
         "typescript": "^5.2.2"

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopperlabs/shopper-sdk",
-  "version": "3.0.0",
+  "version": "1.0.0-beta.2",
   "description": "Official JavaScript SDK for the Shopper headless commerce API.",
   "author": "Arthur Monney <monneylobe@gmail.com> (https://arthurmonney.me)",
   "type": "module",
@@ -41,7 +41,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@shopperlabs/shopper-types": "^3.0.0"
+    "@shopperlabs/shopper-types": "^3.0.0-beta.1"
   },
   "devDependencies": {
     "typescript": "^5.2.2"

--- a/packages/types/.github/workflows/npm-publish.yml
+++ b/packages/types/.github/workflows/npm-publish.yml
@@ -31,5 +31,3 @@ jobs:
 
       - name: Publish to npm
         run: npm publish --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/packages/types/.github/workflows/npm-publish.yml
+++ b/packages/types/.github/workflows/npm-publish.yml
@@ -4,6 +4,11 @@ on:
   push:
     tags:
       - '*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g. 3.0.0-beta.1)'
+        required: true
 
 jobs:
   publish:
@@ -20,14 +25,23 @@ jobs:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Update npm for OIDC trusted publishing
+        run: npm install -g npm@latest
+
       - name: Install dependencies
         run: npm ci
 
       - name: Build
         run: npm run build
 
-      - name: Set version from tag
-        run: npm version ${{ github.ref_name }} --no-git-tag-version --allow-same-version
+      - name: Set version
+        run: npm version ${{ github.event.inputs.version || github.ref_name }} --no-git-tag-version --allow-same-version
 
       - name: Publish to npm
-        run: npm publish --access public --provenance
+        run: |
+          VERSION="${{ github.event.inputs.version || github.ref_name }}"
+          if [[ "$VERSION" == *-* ]]; then
+            npm publish --access public --provenance --tag beta
+          else
+            npm publish --access public --provenance
+          fi

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -81,7 +81,22 @@ abstract class TestCase extends BaseTestCase
         $app['config']->set('database.default', $connection);
         $app['config']->set('database.connections.testing', $app['config']->get('database.connections.sqlite'));
 
+        $this->registerPackageMigrations($app);
         $this->replaceModelsForTesting();
+    }
+
+    protected function registerPackageMigrations($app): void
+    {
+        $app->afterResolving('migrator', function ($migrator): void {
+            foreach ([
+                __DIR__.'/../packages/core/database/migrations',
+                __DIR__.'/../packages/admin/database/migrations',
+                __DIR__.'/../packages/cart/database/migrations',
+                __DIR__.'/../packages/payment/database/migrations',
+            ] as $path) {
+                $migrator->path($path);
+            }
+        });
     }
 
     protected function replaceModelsForTesting(): void


### PR DESCRIPTION
Follow-up to the 3.x split bootstrap, fixing npm publishing for the beta.

## SDK versioning
- Bump `@shopperlabs/shopper-sdk` to its own `1.0.0-beta.2` semver, independent of the framework tag.
- Pin `@shopperlabs/shopper-types` to `^3.0.0-beta.1` so a beta install resolves (a `^3.0.0` range excludes the `3.0.0-beta.1` prerelease).

## types publish 404
The `shopper-types` publish failed with a 404 on PUT. The 3.x workflow had added `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}`, but that secret does not exist in the split repository, so an empty token overrode the OIDC trusted publishing that the 2.x workflow uses successfully. Removing it restores pure OIDC publishing.