### PR TITLE
feat(payment): ingest provider webhooks and reconcile order status

### DIFF
--- a/packages/api/routes/store.php
+++ b/packages/api/routes/store.php
@@ -15,3 +15,7 @@ ShopperApi::store(function (): void {
 ShopperApi::authenticated(function (): void {
     require __DIR__.'/store/account.php';
 });
+
+ShopperApi::webhooks(function (): void {
+    require __DIR__.'/store/payment.php';
+});

--- a/packages/api/routes/store/payment.php
+++ b/packages/api/routes/store/payment.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Route;
+use Shopper\Api\Http\Controllers\Payment\WebhookController;
+
+Route::post('/webhooks/{driver}', WebhookController::class);

--- a/packages/api/src/Http/Controllers/Payment/WebhookController.php
+++ b/packages/api/src/Http/Controllers/Payment/WebhookController.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Shopper\Api\Http\Controllers\Payment;
 
-use Illuminate\Database\QueryException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Shopper\Payment\DataTransferObjects\WebhookResult;
@@ -48,8 +47,10 @@ final class WebhookController
     }
 
     /**
-     * Record the event id once. A duplicate delivery hits the unique constraint
-     * and reports false so the caller can acknowledge without reprocessing.
+     * Record the event id once. A duplicate delivery is ignored at the database
+     * level and reports false so the caller can acknowledge without
+     * reprocessing. insertOrIgnore avoids the failed-INSERT that would abort the
+     * surrounding transaction on Postgres.
      */
     private function firstDelivery(string $driver, WebhookResult $result): bool
     {
@@ -57,19 +58,19 @@ final class WebhookController
             return true;
         }
 
-        try {
-            PaymentWebhookEvent::query()->create([
-                'driver' => $driver,
-                'event_id' => $result->eventId,
-                'type' => $result->action,
-                'payload' => $result->toArray(),
-                'processed_at' => now(),
-            ]);
-        } catch (QueryException) {
-            return false;
-        }
+        $now = now();
 
-        return true;
+        $inserted = PaymentWebhookEvent::query()->insertOrIgnore([
+            'driver' => $driver,
+            'event_id' => $result->eventId,
+            'type' => $result->action,
+            'payload' => json_encode($result->toArray()),
+            'processed_at' => $now,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+
+        return $inserted > 0;
     }
 
     /**

--- a/packages/api/src/Http/Controllers/Payment/WebhookController.php
+++ b/packages/api/src/Http/Controllers/Payment/WebhookController.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Api\Http\Controllers\Payment;
+
+use Illuminate\Database\QueryException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Shopper\Payment\DataTransferObjects\WebhookResult;
+use Shopper\Payment\Facades\Payment;
+use Shopper\Payment\Models\PaymentWebhookEvent;
+use Shopper\Payment\Services\PaymentProcessingService;
+use Throwable;
+
+final class WebhookController
+{
+    public function __construct(
+        private readonly PaymentProcessingService $service,
+    ) {}
+
+    public function __invoke(Request $request, string $driver): JsonResponse
+    {
+        if (! in_array($driver, Payment::availableDrivers(), strict: true)) {
+            abort(404);
+        }
+
+        try {
+            $result = Payment::driver($driver)->handleWebhook(
+                [...$request->all(), '_raw_body' => $request->getContent()],
+                $this->headers($request),
+            );
+        } catch (Throwable) {
+            return response()->json(['error' => 'Invalid webhook payload.'], 400);
+        }
+
+        if ($result->isIgnored()) {
+            return response()->json(['received' => true]);
+        }
+
+        if (! $this->firstDelivery($driver, $result)) {
+            return response()->json(['received' => true]);
+        }
+
+        $this->service->processWebhook($driver, $result);
+
+        return response()->json(['received' => true]);
+    }
+
+    /**
+     * Record the event id once. A duplicate delivery hits the unique constraint
+     * and reports false so the caller can acknowledge without reprocessing.
+     */
+    private function firstDelivery(string $driver, WebhookResult $result): bool
+    {
+        if ($result->eventId === null) {
+            return true;
+        }
+
+        try {
+            PaymentWebhookEvent::query()->create([
+                'driver' => $driver,
+                'event_id' => $result->eventId,
+                'type' => $result->action,
+                'payload' => $result->toArray(),
+                'processed_at' => now(),
+            ]);
+        } catch (QueryException) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function headers(Request $request): array
+    {
+        return array_map(
+            static fn (array $values): string => (string) ($values[0] ?? ''),
+            $request->headers->all(),
+        );
+    }
+}

--- a/packages/http/config/http.php
+++ b/packages/http/config/http.php
@@ -65,5 +65,6 @@ return [
     'middleware' => [
         'store' => [],
         'authenticated' => [],
+        'webhook' => [],
     ],
 ];

--- a/packages/http/src/Facades/ShopperApi.php
+++ b/packages/http/src/Facades/ShopperApi.php
@@ -11,6 +11,7 @@ use Shopper\Http\ShopperApiRouter;
 /**
  * @method static RouteRegistrar store(\Closure $routes)
  * @method static RouteRegistrar authenticated(\Closure $routes)
+ * @method static RouteRegistrar webhooks(\Closure $routes)
  * @method static string prefix()
  *
  * @see ShopperApiRouter

--- a/packages/http/src/HttpServiceProvider.php
+++ b/packages/http/src/HttpServiceProvider.php
@@ -106,5 +106,9 @@ final class HttpServiceProvider extends PackageServiceProvider
             'auth:sanctum',
             ResolveCustomer::class,
         ], (array) config('shopper.http.middleware.authenticated', [])));
+
+        $router->middlewareGroup('shopper:store-webhook', array_merge([
+            'throttle:'.RateLimit::Webhook->value,
+        ], (array) config('shopper.http.middleware.webhook', [])));
     }
 }

--- a/packages/http/src/ShopperApiRouter.php
+++ b/packages/http/src/ShopperApiRouter.php
@@ -24,6 +24,13 @@ final class ShopperApiRouter
             ->group($routes);
     }
 
+    public function webhooks(Closure $routes): RouteRegistrar
+    {
+        return Route::prefix($this->prefix())
+            ->middleware('shopper:store-webhook')
+            ->group($routes);
+    }
+
     public function prefix(): string
     {
         return (string) config('shopper.http.prefix', 'store');

--- a/packages/payment/database/migrations/2026_06_25_000001_create_payment_webhook_events_table.php
+++ b/packages/payment/database/migrations/2026_06_25_000001_create_payment_webhook_events_table.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Shopper\Core\Helpers\Migration;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create($this->getTableName('payment_webhook_events'), function (Blueprint $table): void {
+            $this->addCommonFields($table);
+
+            $table->string('driver');
+            $table->string('event_id');
+            $table->string('type')->nullable();
+            $table->jsonb('payload')->nullable();
+            $table->timestamp('processed_at')->nullable();
+
+            $table->unique(['driver', 'event_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists($this->getTableName('payment_webhook_events'));
+    }
+};

--- a/packages/payment/src/DataTransferObjects/WebhookResult.php
+++ b/packages/payment/src/DataTransferObjects/WebhookResult.php
@@ -14,6 +14,7 @@ final readonly class WebhookResult
         public ?string $reference = null,
         public ?int $amount = null,
         public array $data = [],
+        public ?string $eventId = null,
     ) {}
 
     public static function ignored(): self
@@ -36,6 +37,7 @@ final readonly class WebhookResult
             'reference' => $this->reference,
             'amount' => $this->amount,
             'data' => $this->data,
+            'event_id' => $this->eventId,
         ];
     }
 }

--- a/packages/payment/src/Models/PaymentWebhookEvent.php
+++ b/packages/payment/src/Models/PaymentWebhookEvent.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Payment\Models;
+
+use Carbon\CarbonInterface;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @property-read int $id
+ * @property-read string $driver
+ * @property-read string $event_id
+ * @property-read ?string $type
+ * @property-read array<string, mixed>|null $payload
+ * @property-read ?CarbonInterface $processed_at
+ * @property-read CarbonInterface $created_at
+ * @property-read CarbonInterface $updated_at
+ */
+class PaymentWebhookEvent extends Model
+{
+    protected $guarded = [];
+
+    public function getTable(): string
+    {
+        return shopper_table('payment_webhook_events');
+    }
+
+    protected function casts(): array
+    {
+        return [
+            'payload' => 'array',
+            'processed_at' => 'datetime',
+        ];
+    }
+}

--- a/packages/payment/src/Services/PaymentProcessingService.php
+++ b/packages/payment/src/Services/PaymentProcessingService.php
@@ -6,12 +6,15 @@ namespace Shopper\Payment\Services;
 
 use Illuminate\Support\Collection;
 use Shopper\Core\Actions\ReleaseCampaignBudget;
+use Shopper\Core\Enum\OrderStatus;
 use Shopper\Core\Enum\PaymentStatus;
+use Shopper\Core\Events\Orders\OrderCancelled;
 use Shopper\Core\Models\Contracts\Order;
 use Shopper\Core\Models\PaymentMethod;
 use Shopper\Core\Models\Zone;
 use Shopper\Payment\Contracts\PaymentDriver;
 use Shopper\Payment\DataTransferObjects\PaymentResult;
+use Shopper\Payment\DataTransferObjects\WebhookResult;
 use Shopper\Payment\Enum\TransactionStatus;
 use Shopper\Payment\Enum\TransactionType;
 use Shopper\Payment\Events\PaymentFailed;
@@ -174,6 +177,28 @@ final class PaymentProcessingService
         return $result;
     }
 
+    public function processWebhook(string $driver, WebhookResult $result): void
+    {
+        if ($result->isIgnored() || $result->reference === null) {
+            return;
+        }
+
+        $order = $this->findOrderByReference($result->reference);
+
+        if ($order === null) {
+            return;
+        }
+
+        match ($result->action) {
+            'authorized' => $this->recordWebhookOutcome($order, $driver, TransactionType::Authorize, $result),
+            'captured' => $this->recordWebhookOutcome($order, $driver, TransactionType::Capture, $result),
+            'refunded' => $this->processWebhookRefund($order, $driver, $result),
+            'canceled' => $this->processWebhookCancellation($order, $driver, $result),
+            'failed' => $this->processWebhookFailure($order, $driver, $result),
+            default => null,
+        };
+    }
+
     /**
      * Get all transactions for an order.
      *
@@ -280,5 +305,90 @@ final class PaymentProcessingService
             'data' => $result->data ?: null,
             'notes' => $result->message,
         ]);
+    }
+
+    private function findOrderByReference(string $reference): ?Order
+    {
+        return PaymentTransaction::query()
+            ->where('reference', $reference)
+            ->latest()
+            ->first()?->order;
+    }
+
+    private function recordWebhookOutcome(Order $order, string $driver, TransactionType $type, WebhookResult $result): void
+    {
+        $paymentResult = new PaymentResult(
+            success: true,
+            status: $result->action,
+            reference: $result->reference,
+            amount: $result->amount,
+            data: $result->data,
+        );
+
+        $this->recordTransaction(
+            order: $order,
+            paymentMethod: $order->paymentMethod,
+            driverCode: $driver,
+            type: $type,
+            result: $paymentResult,
+            amount: $result->amount ?? $order->price_amount,
+        );
+
+        $this->syncPaymentStatus($order, $type, $paymentResult);
+    }
+
+    private function processWebhookRefund(Order $order, string $driver, WebhookResult $result): void
+    {
+        $this->recordWebhookOutcome($order, $driver, TransactionType::Refund, $result);
+        $this->releaseCampaignBudget($order);
+    }
+
+    private function processWebhookCancellation(Order $order, string $driver, WebhookResult $result): void
+    {
+        $this->recordWebhookOutcome($order, $driver, TransactionType::Cancel, $result);
+        $this->cancelOrder($order);
+    }
+
+    private function processWebhookFailure(Order $order, string $driver, WebhookResult $result): void
+    {
+        $message = $result->data['failure_message'] ?? null;
+
+        $paymentResult = PaymentResult::failed(
+            is_string($message) ? $message : 'Payment failed.',
+            $result->reference,
+        );
+
+        $this->recordTransaction(
+            order: $order,
+            paymentMethod: $order->paymentMethod,
+            driverCode: $driver,
+            type: TransactionType::Capture,
+            result: $paymentResult,
+            amount: $result->amount ?? $order->price_amount,
+        );
+
+        // Emits PaymentFailed; the failed result leaves the payment status
+        // untouched, then the order is cancelled to release reserved stock.
+        $this->syncPaymentStatus($order, TransactionType::Capture, $paymentResult);
+        $this->cancelOrder($order);
+    }
+
+    /**
+     * Cancel an order whose payment fell through, releasing the stock reserved
+     * at checkout via the OrderCancelled listener. A paid or already-cancelled
+     * order is left untouched.
+     */
+    private function cancelOrder(Order $order): void
+    {
+        if ($order->payment_status === PaymentStatus::Paid || ! $order->canBeCancelled()) {
+            return;
+        }
+
+        $order->update([
+            'status' => OrderStatus::Cancelled,
+            'cancelled_at' => now(),
+        ]);
+
+        event(new OrderCancelled($order));
     }
 }

--- a/packages/stripe/src/StripeDriver.php
+++ b/packages/stripe/src/StripeDriver.php
@@ -244,12 +244,14 @@ final class StripeDriver extends Driver
                 reference: $object->id,
                 amount: $object->amount_capturable ?? $object->amount,
                 data: ['stripe_event' => $event->type],
+                eventId: $event->id,
             ),
             'payment_intent.succeeded' => new WebhookResult(
                 action: 'captured',
                 reference: $object->id,
                 amount: $object->amount_received ?? $object->amount,
                 data: ['stripe_event' => $event->type],
+                eventId: $event->id,
             ),
             'payment_intent.payment_failed' => new WebhookResult(
                 action: 'failed',
@@ -259,18 +261,21 @@ final class StripeDriver extends Driver
                     'stripe_event' => $event->type,
                     'failure_message' => $object->last_payment_error?->message,
                 ],
+                eventId: $event->id,
             ),
             'payment_intent.canceled' => new WebhookResult(
                 action: 'canceled',
                 reference: $object->id,
                 amount: $object->amount,
                 data: ['stripe_event' => $event->type],
+                eventId: $event->id,
             ),
             'charge.refunded' => new WebhookResult(
                 action: 'refunded',
                 reference: $object->payment_intent,
                 amount: $object->amount_refunded,
                 data: ['stripe_event' => $event->type],
+                eventId: $event->id,
             ),
             default => WebhookResult::ignored(),
         };

--- a/tests/Api/Feature/PaymentWebhookTest.php
+++ b/tests/Api/Feature/PaymentWebhookTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+use Shopper\Core\Enum\PaymentStatus;
+use Shopper\Core\Models\Order;
+use Shopper\Core\Models\PaymentMethod;
+use Shopper\Payment\Enum\TransactionStatus;
+use Shopper\Payment\Enum\TransactionType;
+use Shopper\Payment\Facades\Payment;
+use Shopper\Payment\Models\PaymentTransaction;
+use Shopper\Payment\Models\PaymentWebhookEvent;
+use Tests\Api\Stubs\FakePaymentDriver;
+
+uses(Tests\Api\TestCase::class);
+
+beforeEach(function (): void {
+    setupCurrencies();
+
+    Payment::extend('fake', fn (): FakePaymentDriver => new FakePaymentDriver);
+
+    $this->method = PaymentMethod::factory()->create(['driver' => 'fake', 'is_enabled' => true]);
+    $this->order = Order::factory()->create([
+        'payment_method_id' => $this->method->id,
+        'price_amount' => 5000,
+        'currency_code' => 'USD',
+        'payment_status' => PaymentStatus::Pending,
+    ]);
+
+    PaymentTransaction::query()->create([
+        'order_id' => $this->order->id,
+        'payment_method_id' => $this->method->id,
+        'driver' => 'fake',
+        'type' => TransactionType::Initiate,
+        'status' => TransactionStatus::Pending,
+        'amount' => 5000,
+        'currency_code' => 'USD',
+        'reference' => 'pi_abc',
+    ]);
+});
+
+it('returns 404 for an unknown driver', function (): void {
+    $this->postJson('/store/webhooks/unknown', ['action' => 'captured'])
+        ->assertNotFound();
+});
+
+it('rejects an unverified payload with a 400', function (): void {
+    $this->postJson('/store/webhooks/fake', ['action' => 'invalid'])
+        ->assertStatus(400);
+
+    expect($this->order->refresh()->payment_status)->toBe(PaymentStatus::Pending);
+});
+
+it('advances the order to Paid on a captured event', function (): void {
+    $this->postJson('/store/webhooks/fake', [
+        'action' => 'captured',
+        'reference' => 'pi_abc',
+        'amount' => 5000,
+        'event_id' => 'evt_capture_1',
+    ])->assertOk()->assertJson(['received' => true]);
+
+    expect($this->order->refresh()->payment_status)->toBe(PaymentStatus::Paid)
+        ->and(PaymentTransaction::query()->where('order_id', $this->order->id)->where('type', TransactionType::Capture)->count())->toBe(1);
+});
+
+it('is idempotent: a redelivered event id is not processed twice', function (): void {
+    $payload = [
+        'action' => 'captured',
+        'reference' => 'pi_abc',
+        'amount' => 5000,
+        'event_id' => 'evt_capture_2',
+    ];
+
+    $this->postJson('/store/webhooks/fake', $payload)->assertOk();
+    $this->postJson('/store/webhooks/fake', $payload)->assertOk();
+
+    expect(PaymentTransaction::query()->where('order_id', $this->order->id)->where('type', TransactionType::Capture)->count())->toBe(1)
+        ->and(PaymentWebhookEvent::query()->where('event_id', 'evt_capture_2')->count())->toBe(1);
+});

--- a/tests/Api/Stubs/FakePaymentDriver.php
+++ b/tests/Api/Stubs/FakePaymentDriver.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Tests\Api\Stubs;
 
+use RuntimeException;
 use Shopper\Payment\DataTransferObjects\PaymentResult;
+use Shopper\Payment\DataTransferObjects\WebhookResult;
 use Shopper\Payment\Drivers\Driver;
 
 final class FakePaymentDriver extends Driver
@@ -68,6 +70,21 @@ final class FakePaymentDriver extends Driver
             success: true,
             status: 'cancelled',
             reference: $reference,
+        );
+    }
+
+    public function handleWebhook(array $payload, array $headers = []): WebhookResult
+    {
+        // Simulate signature verification failure for a malformed payload.
+        if (($payload['action'] ?? null) === 'invalid') {
+            throw new RuntimeException('Invalid webhook signature.');
+        }
+
+        return new WebhookResult(
+            action: (string) ($payload['action'] ?? 'ignored'),
+            reference: isset($payload['reference']) ? (string) $payload['reference'] : null,
+            amount: isset($payload['amount']) ? (int) $payload['amount'] : null,
+            eventId: isset($payload['event_id']) ? (string) $payload['event_id'] : null,
         );
     }
 

--- a/tests/Payment/PaymentWebhookProcessingTest.php
+++ b/tests/Payment/PaymentWebhookProcessingTest.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+use Shopper\Core\Enum\OrderStatus;
+use Shopper\Core\Enum\PaymentStatus;
+use Shopper\Core\Enum\ShippingStatus;
+use Shopper\Core\Models\Inventory;
+use Shopper\Core\Models\Order;
+use Shopper\Core\Models\OrderItem;
+use Shopper\Core\Models\PaymentMethod;
+use Shopper\Core\Models\Product;
+use Shopper\Core\Contracts\StockReserver;
+use Shopper\Payment\DataTransferObjects\WebhookResult;
+use Shopper\Payment\Enum\TransactionStatus;
+use Shopper\Payment\Enum\TransactionType;
+use Shopper\Payment\Events\PaymentFailed;
+use Shopper\Payment\Models\PaymentTransaction;
+use Shopper\Payment\Services\PaymentProcessingService;
+use Tests\Core\Stubs\User;
+
+uses(Tests\Core\TestCase::class);
+
+beforeEach(function (): void {
+    $this->user = User::factory()->create();
+
+    $this->method = PaymentMethod::factory()->create(['driver' => 'fake']);
+    $this->order = Order::factory()->create([
+        'payment_method_id' => $this->method->id,
+        'price_amount' => 5000,
+        'currency_code' => 'USD',
+        'status' => OrderStatus::New,
+        'payment_status' => PaymentStatus::Pending,
+        'shipping_status' => ShippingStatus::Unfulfilled,
+    ]);
+
+    // The intent recorded at checkout is what ties the webhook back to the order.
+    PaymentTransaction::query()->create([
+        'order_id' => $this->order->id,
+        'payment_method_id' => $this->method->id,
+        'driver' => 'fake',
+        'type' => TransactionType::Initiate,
+        'status' => TransactionStatus::Pending,
+        'amount' => 5000,
+        'currency_code' => 'USD',
+        'reference' => 'pi_123',
+    ]);
+
+    $this->service = resolve(PaymentProcessingService::class);
+});
+
+describe('PaymentWebhookProcessingTest', function (): void {
+    it('advances the order to `Paid` on a captured event', function (): void {
+        $this->service->processWebhook('fake', new WebhookResult(
+            action: 'captured',
+            reference: 'pi_123',
+            amount: 5000,
+            eventId: 'evt_1',
+        ));
+
+        $capture = PaymentTransaction::query()
+            ->where('order_id', $this->order->id)
+            ->where('type', TransactionType::Capture)
+            ->first();
+
+        expect($this->order->refresh()->payment_status)->toBe(PaymentStatus::Paid)
+            ->and($capture)->not->toBeNull()
+            ->and($capture->status)->toBe(TransactionStatus::Success)
+            ->and($capture->amount)->toBe(5000);
+    });
+
+    it('advances the order to `Authorized` on an authorized event', function (): void {
+        $this->service->processWebhook('fake', new WebhookResult(
+            action: 'authorized',
+            reference: 'pi_123',
+            amount: 5000,
+            eventId: 'evt_2',
+        ));
+
+        expect($this->order->refresh()->payment_status)->toBe(PaymentStatus::Authorized);
+    });
+
+    it('marks the order `PartiallyRefunded` then `Refunded` as refunds accumulate', function (): void {
+        $this->service->processWebhook('fake', new WebhookResult(
+            action: 'refunded',
+            reference: 'pi_123',
+            amount: 2000,
+            eventId: 'evt_3',
+        ));
+
+        expect($this->order->refresh()->payment_status)->toBe(PaymentStatus::PartiallyRefunded);
+
+        $this->service->processWebhook('fake', new WebhookResult(
+            action: 'refunded',
+            reference: 'pi_123',
+            amount: 3000,
+            eventId: 'evt_4',
+        ));
+
+        expect($this->order->refresh()->payment_status)->toBe(PaymentStatus::Refunded);
+    });
+
+    it('cancels the order and dispatches `PaymentFailed` on a failed event', function (): void {
+        Event::fake([PaymentFailed::class]);
+
+        $this->service->processWebhook('fake', new WebhookResult(
+            action: 'failed',
+            reference: 'pi_123',
+            amount: 5000,
+            data: ['failure_message' => 'card_declined'],
+            eventId: 'evt_5',
+        ));
+
+        expect($this->order->refresh()->status)->toBe(OrderStatus::Cancelled);
+        Event::assertDispatched(PaymentFailed::class);
+    });
+
+    it('restores reserved stock when a payment fails', function (): void {
+        $inventory = Inventory::factory()->create(['is_default' => true, 'priority' => 0]);
+        $product = Product::factory()->standard()->create();
+        $product->mutateStock($inventory->id, 10, event: 'Initial');
+
+        OrderItem::factory()->create([
+            'order_id' => $this->order->id,
+            'product_type' => $product->getMorphClass(),
+            'product_id' => $product->id,
+            'quantity' => 3,
+        ]);
+
+        resolve(StockReserver::class)->reserve($product, 3, $this->order, $this->user->id);
+        expect($product->getStock())->toBe(7);
+
+        $this->service->processWebhook('fake', new WebhookResult(
+            action: 'failed',
+            reference: 'pi_123',
+            amount: 5000,
+            eventId: 'evt_6',
+        ));
+
+        expect($this->order->refresh()->status)->toBe(OrderStatus::Cancelled)
+            ->and($product->getStock())->toBe(10);
+    });
+
+    it('does nothing when no order matches the reference', function (): void {
+        $this->service->processWebhook('fake', new WebhookResult(
+            action: 'captured',
+            reference: 'pi_unknown',
+            amount: 5000,
+            eventId: 'evt_7',
+        ));
+
+        expect($this->order->refresh()->payment_status)->toBe(PaymentStatus::Pending)
+            ->and(PaymentTransaction::query()->where('type', TransactionType::Capture)->count())->toBe(0);
+    });
+
+    it('ignores an ignored webhook result', function (): void {
+        $this->service->processWebhook('fake', WebhookResult::ignored());
+
+        expect($this->order->refresh()->payment_status)->toBe(PaymentStatus::Pending);
+    });
+})->group('payment', 'webhooks');

--- a/tests/Payment/PaymentWebhookProcessingTest.php
+++ b/tests/Payment/PaymentWebhookProcessingTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Shopper\Core\Contracts\StockReserver;
 use Shopper\Core\Enum\OrderStatus;
 use Shopper\Core\Enum\PaymentStatus;
 use Shopper\Core\Enum\ShippingStatus;
@@ -10,7 +11,6 @@ use Shopper\Core\Models\Order;
 use Shopper\Core\Models\OrderItem;
 use Shopper\Core\Models\PaymentMethod;
 use Shopper\Core\Models\Product;
-use Shopper\Core\Contracts\StockReserver;
 use Shopper\Payment\DataTransferObjects\WebhookResult;
 use Shopper\Payment\Enum\TransactionStatus;
 use Shopper\Payment\Enum\TransactionType;


### PR DESCRIPTION
## Problem

`StripeDriver::handleWebhook()` verified the signature and returned a `WebhookResult`, but nothing consumed it: no route, no controller, no status sync. A customer paying through Stripe left the order stuck on `pending` forever (until an admin manually marked it paid), and a refund issued from the Stripe dashboard never reflected back onto the order or released the campaign budget. Providers deliver events at-least-once, and there was no idempotency guard against redelivery.

## Fix

- New `POST /store/webhooks/{driver}` endpoint on a dedicated `shopper:store-webhook` middleware group: throttled, but no auth, locale, zone, or JSON:API enforcement, since the payload is verified by the driver's own signature check and carries its own content type.
- Each event id is persisted on a new `payment_webhook_events` table under a `unique(driver, event_id)` constraint. A redelivered event hits the constraint and is acknowledged without being processed twice. The idempotency key is the event id, not the payment reference, so partial refunds that reuse the same intent are never blocked.
- `WebhookResult` gains an `eventId`, populated by the Stripe driver.
- `PaymentProcessingService::processWebhook()` reconciles the order from the verified event without calling back into the driver. The order is found by payment reference (never by amount). `captured` -> `Paid`, `authorized` -> `Authorized`, `refunded` -> `PartiallyRefunded`/`Refunded`, `canceled` -> `Voided`, `failed` -> `PaymentFailed`.
- A failed or canceled payment cancels the order, which dispatches `OrderCancelled` and restores the stock reserved at checkout. A paid order is never touched.

## Notes

- New opt-in config key `shopper.http.middleware.webhook` (defaults to `[]`) to append middleware to the webhook surface, e.g. a shared-secret check.
- `OrderCancelled` now also fires for payment-webhook-driven cancellations.

## Breaking changes

None. Every change is additive: the new `WebhookResult::$eventId` is optional and trails the constructor, `processWebhook()` is a new public method, and the route, table, and model are new.
