### PR TITLE
feat(orders): guard order status changes with a state machine

### DIFF
--- a/packages/admin/src/Livewire/Pages/Order/Detail.php
+++ b/packages/admin/src/Livewire/Pages/Order/Detail.php
@@ -63,10 +63,7 @@ class Detail extends AbstractPageComponent implements HasActions, HasSchemas
             ->authorize('orders.edit')
             ->visible($this->order->canBeCancelled())
             ->action(function (): void {
-                $this->order->update([
-                    'status' => OrderStatus::Cancelled,
-                    'cancelled_at' => now(),
-                ]);
+                $this->order->transitionTo(OrderStatus::Cancelled);
 
                 $this->order->refresh();
                 $this->dispatch('order.updated');
@@ -87,7 +84,7 @@ class Detail extends AbstractPageComponent implements HasActions, HasSchemas
             ->authorize('orders.edit')
             ->visible($this->order->isNew())
             ->action(function (): void {
-                $this->order->update(['status' => OrderStatus::Processing]);
+                $this->order->transitionTo(OrderStatus::Processing);
 
                 $this->order->refresh();
                 $this->dispatch('order.updated');
@@ -106,13 +103,11 @@ class Detail extends AbstractPageComponent implements HasActions, HasSchemas
             ->authorize('orders.edit')
             ->visible($this->order->isPaymentPending() || $this->order->isPaymentAuthorized())
             ->action(function (): void {
-                $data = ['payment_status' => PaymentStatus::Paid];
+                $this->order->update(['payment_status' => PaymentStatus::Paid]);
 
                 if ($this->order->isNew()) {
-                    $data['status'] = OrderStatus::Processing;
+                    $this->order->transitionTo(OrderStatus::Processing);
                 }
-
-                $this->order->update($data);
 
                 $this->order->refresh();
                 $this->dispatch('order.updated');
@@ -133,7 +128,7 @@ class Detail extends AbstractPageComponent implements HasActions, HasSchemas
             ->authorize('orders.edit')
             ->visible($this->order->isProcessing() && $this->order->isPaid())
             ->action(function (): void {
-                $this->order->update(['status' => OrderStatus::Completed]);
+                $this->order->transitionTo(OrderStatus::Completed);
 
                 $this->order->refresh();
                 $this->dispatch('order.updated');
@@ -206,10 +201,7 @@ class Detail extends AbstractPageComponent implements HasActions, HasSchemas
             ->modalDescription(__('shopper::pages/orders.modals.archived_notice'))
             ->modalSubmitActionLabel(__('shopper::forms.actions.confirm'))
             ->action(function (): void {
-                $this->order->update([
-                    'status' => OrderStatus::Archived,
-                    'archived_at' => now(),
-                ]);
+                $this->order->transitionTo(OrderStatus::Archived);
 
                 event(new OrderArchived($this->order));
 

--- a/packages/core/src/Actions/RecordShipmentEventAction.php
+++ b/packages/core/src/Actions/RecordShipmentEventAction.php
@@ -62,7 +62,7 @@ final class RecordShipmentEventAction
         $order = $shipment->order;
 
         if ($order->status === OrderStatus::New) {
-            $order->update(['status' => OrderStatus::Processing]);
+            $order->transitionTo(OrderStatus::Processing);
         }
 
         (new SyncOrderShippingStatusAction)->execute($order);
@@ -85,7 +85,7 @@ final class RecordShipmentEventAction
             ->doesntExist();
 
         if ($allDelivered && $order->status === OrderStatus::Processing) {
-            $order->update(['status' => OrderStatus::Completed]);
+            $order->transitionTo(OrderStatus::Completed);
         }
     }
 

--- a/packages/core/src/Enum/OrderStatus.php
+++ b/packages/core/src/Enum/OrderStatus.php
@@ -32,6 +32,25 @@ enum OrderStatus: string implements HasColor, HasIcon, HasLabel
 
     case Archived = 'archived';
 
+    /**
+     * @return array<string, list<self>>
+     */
+    public static function transitions(): array
+    {
+        return [
+            self::New->value => [self::Processing, self::Completed, self::Cancelled, self::Archived],
+            self::Processing->value => [self::Completed, self::Cancelled, self::Archived],
+            self::Completed->value => [self::Cancelled, self::Archived],
+            self::Cancelled->value => [self::Archived],
+            self::Archived->value => [],
+        ];
+    }
+
+    public function canTransitionTo(self $status): bool
+    {
+        return in_array($status, self::transitions()[$this->value] ?? [], strict: true);
+    }
+
     public function getColor(): string
     {
         return match ($this) {

--- a/packages/core/src/Exceptions/InvalidOrderStatusTransitionException.php
+++ b/packages/core/src/Exceptions/InvalidOrderStatusTransitionException.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Core\Exceptions;
+
+use RuntimeException;
+use Shopper\Core\Enum\OrderStatus;
+
+final class InvalidOrderStatusTransitionException extends RuntimeException
+{
+    public static function between(OrderStatus $from, OrderStatus $to): self
+    {
+        return new self(sprintf(
+            'Cannot transition an order from "%s" to "%s".',
+            $from->value,
+            $to->value,
+        ));
+    }
+}

--- a/packages/core/src/Models/Contracts/Order.php
+++ b/packages/core/src/Models/Contracts/Order.php
@@ -7,12 +7,17 @@ namespace Shopper\Core\Models\Contracts;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
+use Shopper\Core\Enum\OrderStatus;
 
 interface Order
 {
     public function setDefaultOrderStatus(): void;
 
     public function total(): float|int;
+
+    public function canTransitionTo(OrderStatus $status): bool;
+
+    public function transitionTo(OrderStatus $status): void;
 
     public function canBeCancelled(): bool;
 

--- a/packages/core/src/Models/Order.php
+++ b/packages/core/src/Models/Order.php
@@ -21,6 +21,7 @@ use Shopper\Core\Enum\ShippingStatus;
 use Shopper\Core\Models\Contracts\Order as OrderContract;
 use Shopper\Core\Models\Traits\HasPublicId;
 use Shopper\Core\Traits\HasModelContract;
+use Shopper\Core\Traits\HasOrderStatusTransitions;
 
 /**
  * @property-read int $id
@@ -70,6 +71,7 @@ class Order extends Model implements OrderContract
     use HasFactory;
 
     use HasModelContract;
+    use HasOrderStatusTransitions;
     use HasPublicId;
     use SoftDeletes;
 

--- a/packages/core/src/Traits/HasOrderStatusTransitions.php
+++ b/packages/core/src/Traits/HasOrderStatusTransitions.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Core\Traits;
+
+use Shopper\Core\Enum\OrderStatus;
+use Shopper\Core\Exceptions\InvalidOrderStatusTransitionException;
+
+trait HasOrderStatusTransitions
+{
+    public function canTransitionTo(OrderStatus $status): bool
+    {
+        return $this->status->canTransitionTo($status);
+    }
+
+    public function transitionTo(OrderStatus $status): void
+    {
+        if (! $this->canTransitionTo($status)) {
+            throw InvalidOrderStatusTransitionException::between($this->status, $status);
+        }
+
+        $this->update([
+            'status' => $status,
+            ...$this->statusTimestamps($status),
+        ]);
+    }
+
+    /**
+     * @return array<string, \Illuminate\Support\Carbon>
+     */
+    private function statusTimestamps(OrderStatus $status): array
+    {
+        return match ($status) {
+            OrderStatus::Cancelled => ['cancelled_at' => now()],
+            OrderStatus::Archived => ['archived_at' => now()],
+            default => [],
+        };
+    }
+}

--- a/packages/payment/src/Services/PaymentProcessingService.php
+++ b/packages/payment/src/Services/PaymentProcessingService.php
@@ -373,21 +373,16 @@ final class PaymentProcessingService
         $this->cancelOrder($order);
     }
 
-    /**
-     * Cancel an order whose payment fell through, releasing the stock reserved
-     * at checkout via the OrderCancelled listener. A paid or already-cancelled
-     * order is left untouched.
-     */
     private function cancelOrder(Order $order): void
     {
-        if ($order->payment_status === PaymentStatus::Paid || ! $order->canBeCancelled()) {
+        if ($order->payment_status === PaymentStatus::Paid
+            || ! $order->canBeCancelled()
+            || ! $order->canTransitionTo(OrderStatus::Cancelled)
+        ) {
             return;
         }
 
-        $order->update([
-            'status' => OrderStatus::Cancelled,
-            'cancelled_at' => now(),
-        ]);
+        $order->transitionTo(OrderStatus::Cancelled);
 
         event(new OrderCancelled($order));
     }

--- a/tests/Core/Models/OrderStatusTransitionTest.php
+++ b/tests/Core/Models/OrderStatusTransitionTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+use Shopper\Core\Enum\OrderStatus;
+use Shopper\Core\Exceptions\InvalidOrderStatusTransitionException;
+use Shopper\Core\Models\Order;
+
+uses(Tests\Core\TestCase::class);
+
+describe('OrderStatus transitions', function (): void {
+    it('allows a `New` order to move forward, cancel, or archive', function (): void {
+        expect(OrderStatus::New->canTransitionTo(OrderStatus::Processing))->toBeTrue()
+            ->and(OrderStatus::New->canTransitionTo(OrderStatus::Completed))->toBeTrue()
+            ->and(OrderStatus::New->canTransitionTo(OrderStatus::Cancelled))->toBeTrue()
+            ->and(OrderStatus::New->canTransitionTo(OrderStatus::Archived))->toBeTrue();
+    });
+
+    it('only allows a `Cancelled` order to be archived', function (): void {
+        expect(OrderStatus::Cancelled->canTransitionTo(OrderStatus::Archived))->toBeTrue()
+            ->and(OrderStatus::Cancelled->canTransitionTo(OrderStatus::Completed))->toBeFalse()
+            ->and(OrderStatus::Cancelled->canTransitionTo(OrderStatus::Processing))->toBeFalse()
+            ->and(OrderStatus::Cancelled->canTransitionTo(OrderStatus::New))->toBeFalse();
+    });
+
+    it('treats `Archived` as a terminal state', function (): void {
+        expect(OrderStatus::Archived->canTransitionTo(OrderStatus::New))->toBeFalse()
+            ->and(OrderStatus::Archived->canTransitionTo(OrderStatus::Processing))->toBeFalse()
+            ->and(OrderStatus::Archived->canTransitionTo(OrderStatus::Cancelled))->toBeFalse();
+    });
+});
+
+describe('Order::transitionTo', function (): void {
+    it('persists a valid transition', function (): void {
+        $order = Order::factory()->create(['status' => OrderStatus::New]);
+
+        $order->transitionTo(OrderStatus::Processing);
+
+        expect($order->refresh()->status)->toBe(OrderStatus::Processing);
+    });
+
+    it('stamps `cancelled_at` when cancelling', function (): void {
+        $order = Order::factory()->create(['status' => OrderStatus::Processing, 'cancelled_at' => null]);
+
+        $order->transitionTo(OrderStatus::Cancelled);
+
+        expect($order->refresh()->status)->toBe(OrderStatus::Cancelled)
+            ->and($order->cancelled_at)->not->toBeNull();
+    });
+
+    it('stamps `archived_at` when archiving', function (): void {
+        $order = Order::factory()->create(['status' => OrderStatus::Processing, 'archived_at' => null]);
+
+        $order->transitionTo(OrderStatus::Archived);
+
+        expect($order->refresh()->status)->toBe(OrderStatus::Archived)
+            ->and($order->archived_at)->not->toBeNull();
+    });
+
+    it('throws when the transition is invalid', function (): void {
+        $order = Order::factory()->create(['status' => OrderStatus::Cancelled]);
+
+        expect(fn () => $order->transitionTo(OrderStatus::Completed))
+            ->toThrow(InvalidOrderStatusTransitionException::class);
+
+        expect($order->refresh()->status)->toBe(OrderStatus::Cancelled);
+    });
+
+    it('delegates `canTransitionTo` to the current status', function (): void {
+        $order = Order::factory()->create(['status' => OrderStatus::Archived]);
+
+        expect($order->canTransitionTo(OrderStatus::New))->toBeFalse()
+            ->and($order->canTransitionTo(OrderStatus::Cancelled))->toBeFalse();
+    });
+})->group('orders');


### PR DESCRIPTION
## Problem

Order status was written with raw `$order->update(['status' => ...])` calls everywhere, protected only by Filament `visible()` guards in the admin UI. Those guards are UI-only: any other caller (the Store API, a queued job, a payment webhook, a console command) could move an order from any status to any other. `Cancelled -> Completed` was possible, which would ship goods whose stock had already been restored by the cancellation, corrupting the financial record.

## Fix

- `OrderStatus` gains a `transitions()` map and a `canTransitionTo()` guard:

```
New        -> Processing, Completed, Cancelled, Archived
Processing -> Completed, Cancelled, Archived
Completed  -> Cancelled, Archived
Cancelled  -> Archived
Archived   -> (terminal)
```

- New `HasOrderStatusTransitions` trait on the Order model. `transitionTo()` enforces the map, stamps the coupled `cancelled_at`/`archived_at` timestamp, and throws `InvalidOrderStatusTransitionException` on an invalid move so the caller surfaces the error instead of silently corrupting the record.
- Every status write now routes through `transitionTo()`: admin `Order/Detail` actions, `RecordShipmentEventAction` (pickup -> Processing, delivery -> Completed), and `PaymentProcessingService::cancelOrder` (which pre-guards with `canTransitionTo()` to stay silent on the async webhook path).

This also hardens the order cancellation introduced by the payment webhook work: a failed payment can only cancel an order that is actually in a cancellable state.

## Breaking changes

- The `Order` contract gains `canTransitionTo(OrderStatus): bool` and `transitionTo(OrderStatus): void`. A custom Order model satisfies them by using the `HasOrderStatusTransitions` trait.
- Invalid status transitions now throw `InvalidOrderStatusTransitionException` instead of persisting silently. Callers writing status directly should guard with `canTransitionTo()` or catch the exception. Factories that set arbitrary statuses keep working: they write the column directly and never go through the state machine.
