### PR TITLE
fix(security): close admin IDOR, guest coupon bypass, and payment_session injection

### DIFF
--- a/packages/admin/src/Livewire/SlideOvers/ManagePricing.php
+++ b/packages/admin/src/Livewire/SlideOvers/ManagePricing.php
@@ -35,6 +35,7 @@ class ManagePricing extends SlideOverComponent implements HasActions, HasSchemas
     use InteractsWithSlideOverForm;
 
     /** @var (Model&Priceable<Model>) */
+    #[Locked]
     public Model&Priceable $model;
 
     #[Locked]

--- a/packages/admin/src/Livewire/SlideOvers/UpdateVariant.php
+++ b/packages/admin/src/Livewire/SlideOvers/UpdateVariant.php
@@ -23,6 +23,7 @@ use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\HtmlString;
 use Laravelcm\LivewireSlideOvers\SlideOverComponent;
 use Livewire\Attributes\Computed;
+use Livewire\Attributes\Locked;
 use Shopper\Components\Form\ShippingField;
 use Shopper\Components\Separator;
 use Shopper\Contracts\SlideOverForm;
@@ -45,8 +46,10 @@ class UpdateVariant extends SlideOverComponent implements HasActions, HasSchemas
     use InteractsWithSchemas;
     use InteractsWithSlideOverForm;
 
+    #[Locked]
     public ?ProductVariant $variant = null;
 
+    #[Locked]
     public ?Product $product = null;
 
     public string $action = 'save';

--- a/packages/api/src/Actions/CreateCartPaymentSessionAction.php
+++ b/packages/api/src/Actions/CreateCartPaymentSessionAction.php
@@ -20,13 +20,6 @@ final readonly class CreateCartPaymentSessionAction
         private CancelPaymentSessionAction $cancelSession,
     ) {}
 
-    /**
-     * Start (or resume) a payment session for the cart with the driver of its
-     * payment method. The amount is always the pipeline-computed total, never
-     * a client value. Posting again with an unchanged total resumes the
-     * existing session instead of opening a duplicate intent at the provider;
-     * a total that moved (line added, shipping picked) opens a fresh one.
-     */
     public function execute(Cart $cart): PaymentSession
     {
         $method = $cart->paymentMethod;
@@ -77,14 +70,12 @@ final readonly class CreateCartPaymentSessionAction
             ],
         );
 
-        $cart->update([
-            'payment_session' => [
-                'driver' => $driverCode,
-                'reference' => $result->reference,
-                'amount' => $amount,
-                'currency' => $cart->currency_code,
-                'version' => $version,
-            ],
+        $this->cartManager->setPaymentSession($cart, [
+            'driver' => $driverCode,
+            'reference' => $result->reference,
+            'amount' => $amount,
+            'currency' => $cart->currency_code,
+            'version' => $version,
         ]);
 
         return new PaymentSession($cart, $driverCode, $result);

--- a/packages/cart/src/Actions/CreateOrderFromCartAction.php
+++ b/packages/cart/src/Actions/CreateOrderFromCartAction.php
@@ -195,10 +195,13 @@ final readonly class CreateOrderFromCartAction
                 continue;
             }
 
-            if ($discount->usage_limit_per_user && $cart->customer_id !== null) {
-                $alreadyRedeemed = OrderPromotion::query()
+            if ($discount->usage_limit_per_user) {
+                $column = $cart->customer_id !== null ? 'customer_id' : 'email';
+                $value = $cart->customer_id ?? $cart->email;
+
+                $alreadyRedeemed = $value !== null && OrderPromotion::query()
                     ->where('discount_id', $discount->id)
-                    ->whereHas('order', fn (Builder $query) => $query->where('customer_id', $cart->customer_id))
+                    ->whereHas('order', fn (Builder $query) => $query->where($column, $value))
                     ->exists();
 
                 if ($alreadyRedeemed) {

--- a/packages/cart/src/CartManager.php
+++ b/packages/cart/src/CartManager.php
@@ -157,6 +157,15 @@ final readonly class CartManager
     }
 
     /**
+     * @param  array<string, mixed>|null  $session
+     */
+    public function setPaymentSession(Cart $cart, ?array $session): void
+    {
+        $cart->setAttribute('payment_session', $session);
+        $cart->save();
+    }
+
+    /**
      * @param  array<string, mixed>|null  $metadata
      */
     public function setMetadata(Cart $cart, ?array $metadata): void
@@ -190,8 +199,9 @@ final readonly class CartManager
                 'currency_code' => $currencyCode,
                 'shipping_option_id' => null,
                 'shipping_amount' => null,
-                'payment_session' => null,
             ]);
+
+            $this->setPaymentSession($cart, null);
         });
     }
 

--- a/packages/cart/src/Discounts/DiscountValidator.php
+++ b/packages/cart/src/Discounts/DiscountValidator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Shopper\Cart\Discounts;
 
 use Illuminate\Database\Eloquent\Builder;
+use Shopper\Cart\Models\Cart;
 use Shopper\Cart\Pipelines\CartPipelineContext;
 use Shopper\Core\Enum\DiscountCondition;
 use Shopper\Core\Enum\DiscountEligibility;
@@ -51,17 +52,8 @@ final readonly class DiscountValidator
             }
         }
 
-        if ($discount->usage_limit_per_user && $context->cart->customer_id) {
-            // Counts redemptions through order_promotions (the per-discount
-            // snapshot), since a stacked code may never land on orders.discount_id.
-            $alreadyRedeemed = OrderPromotion::query()
-                ->where('discount_id', $discount->id)
-                ->whereHas('order', fn (Builder $query) => $query->where('customer_id', $context->cart->customer_id))
-                ->exists();
-
-            if ($alreadyRedeemed) {
-                return new DiscountValidationResult(false, __('shopper-cart::messages.discount.already_used'));
-            }
+        if ($discount->usage_limit_per_user && $this->customerAlreadyRedeemed($discount, $context->cart)) {
+            return new DiscountValidationResult(false, __('shopper-cart::messages.discount.already_used'));
         }
 
         if ($discount->eligibility === DiscountEligibility::Customers->value) {
@@ -112,5 +104,20 @@ final readonly class DiscountValidator
         }
 
         return new DiscountValidationResult(true);
+    }
+
+    private function customerAlreadyRedeemed(Discount $discount, Cart $cart): bool
+    {
+        $column = $cart->customer_id !== null ? 'customer_id' : 'email';
+        $value = $cart->customer_id ?? $cart->email;
+
+        if ($value === null) {
+            return false;
+        }
+
+        return OrderPromotion::query()
+            ->where('discount_id', $discount->id)
+            ->whereHas('order', fn (Builder $query) => $query->where($column, $value))
+            ->exists();
     }
 }

--- a/packages/cart/src/Models/Cart.php
+++ b/packages/cart/src/Models/Cart.php
@@ -54,7 +54,10 @@ class Cart extends Model implements CartContract
     use HasModelContract;
     use HasPublicId;
 
-    protected $guarded = [];
+    /**
+     * @var list<string>
+     */
+    protected $guarded = ['payment_session'];
 
     public static function configuredClass(): string
     {

--- a/tests/Api/Feature/CartEndpointsTest.php
+++ b/tests/Api/Feature/CartEndpointsTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Illuminate\Support\Collection;
 use Illuminate\Testing\TestResponse;
 use Laravel\Sanctum\Sanctum;
+use Shopper\Cart\CartManager;
 use Shopper\Cart\Models\Cart;
 use Shopper\Core\Enum\AddressType;
 use Shopper\Core\Enum\DiscountApplyTo;
@@ -452,10 +453,9 @@ it('clears the payment session when the currency changes', function (): void {
     $eur = Currency::query()->where('code', 'EUR')->first();
     $this->product->prices()->create(['amount' => 3000, 'currency_id' => $eur->id]);
 
-    $cart = Cart::factory()->create([
-        'currency_code' => 'USD',
-        'payment_session' => ['driver' => 'manual', 'reference' => 'ref_1', 'amount' => 2500, 'currency' => 'USD'],
-    ]);
+    $cart = Cart::factory()->create(['currency_code' => 'USD']);
+    resolve(CartManager::class)->setPaymentSession($cart, ['driver' => 'manual', 'reference' => 'ref_1', 'amount' => 2500, 'currency' => 'USD']);
+
     $cart->lines()->create([
         'purchasable_type' => $this->product->getMorphClass(),
         'purchasable_id' => $this->product->id,

--- a/tests/Cart/Feature/DiscountValidatorTest.php
+++ b/tests/Cart/Feature/DiscountValidatorTest.php
@@ -179,6 +179,74 @@ describe(DiscountValidator::class, function (): void {
         expect($result->valid)->toBeFalse();
     });
 
+    it('rejects a per-user discount already used by a guest with the same email', function (): void {
+        $discount = Discount::factory()->create(array_merge(validDiscountAttributes(), [
+            'usage_limit_per_user' => true,
+        ]));
+
+        $order = Order::query()->create([
+            'number' => 'GUEST-USED',
+            'price_amount' => 100,
+            'currency_code' => 'USD',
+            'customer_id' => null,
+            'email' => 'guest@example.com',
+            'discount_id' => $discount->id,
+        ]);
+        OrderPromotion::query()->create([
+            'order_id' => $order->id,
+            'discount_id' => $discount->id,
+            'code' => $discount->code,
+            'type' => $discount->type->value,
+            'value_at_apply' => $discount->value,
+            'amount' => 100,
+            'currency_code' => 'USD',
+        ]);
+
+        $guestCart = Cart::factory()->create([
+            'currency_code' => 'USD',
+            'customer_id' => null,
+            'email' => 'guest@example.com',
+        ]);
+
+        $result = $this->validator->validate($discount, new CartPipelineContext($guestCart));
+
+        expect($result->valid)->toBeFalse();
+    });
+
+    it('allows a per-user discount for a guest with a different email', function (): void {
+        $discount = Discount::factory()->create(array_merge(validDiscountAttributes(), [
+            'usage_limit_per_user' => true,
+        ]));
+
+        $order = Order::query()->create([
+            'number' => 'GUEST-OTHER',
+            'price_amount' => 100,
+            'currency_code' => 'USD',
+            'customer_id' => null,
+            'email' => 'used@example.com',
+            'discount_id' => $discount->id,
+        ]);
+        OrderPromotion::query()->create([
+            'order_id' => $order->id,
+            'discount_id' => $discount->id,
+            'code' => $discount->code,
+            'type' => $discount->type->value,
+            'value_at_apply' => $discount->value,
+            'amount' => 100,
+            'currency_code' => 'USD',
+        ]);
+
+        $guestCart = Cart::factory()->create([
+            'currency_code' => 'USD',
+            'customer_id' => null,
+            'email' => 'fresh@example.com',
+        ]);
+
+        $result = $this->validator->validate($discount, new CartPipelineContext($guestCart));
+
+        expect($result->valid)->toBeTrue();
+    });
+
     it('rejects a discount requiring login when no customer', function (): void {
         $guestCart = Cart::factory()->create([
             'currency_code' => 'USD',

--- a/tests/Cart/Feature/PaymentSessionGuardTest.php
+++ b/tests/Cart/Feature/PaymentSessionGuardTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+use Shopper\Cart\CartManager;
+use Shopper\Cart\Models\Cart;
+
+uses(Tests\Cart\TestCase::class);
+
+beforeEach(function (): void {
+    setupCurrencies();
+
+    $this->cartManager = resolve(CartManager::class);
+});
+
+describe('PaymentSessionGuardTest', function (): void {
+    it('ignores `payment_session` passed to mass assignment', function (): void {
+        $cart = Cart::factory()->create(['currency_code' => 'USD']);
+
+        $cart->update(['payment_session' => ['amount' => 1, 'reference' => 'pi_fake']]);
+        $cart->fill(['payment_session' => ['amount' => 1, 'reference' => 'pi_fake']]);
+
+        expect($cart->refresh()->payment_session)->toBeNull();
+    });
+
+    it('writes `payment_session` only through the manager setter', function (): void {
+        $cart = Cart::factory()->create(['currency_code' => 'USD']);
+
+        $this->cartManager->setPaymentSession($cart, ['amount' => 2500, 'reference' => 'pi_real']);
+
+        expect($cart->refresh()->payment_session)->toMatchArray([
+            'amount' => 2500,
+            'reference' => 'pi_real',
+        ]);
+    });
+})->group('cart');


### PR DESCRIPTION
Three hardening fixes from the pre-landing review.

## Admin IDOR on slide-overs

`UpdateVariant` exposed `$variant` and `$product`, and `ManagePricing` exposed `$model`, as public Eloquent properties without `#[Locked]`. Livewire rehydrates public model properties from the client, so an admin could swap the serialized id from the browser and have `save()` overwrite another variant's attributes or another entity's price. All three are now `#[Locked]`.

## Guest coupon bypass

`usage_limit_per_user` was only enforced when the cart had a `customer_id`. A guest could reuse a once-per-customer code indefinitely by checking out without an account. The validator and the checkout reservation now enforce the limit by `customer_id` for an authenticated cart and by `email` for a guest cart. A guest with no email yet is left to the checkout guard, which runs once the email is frozen on the order.

## payment_session injection

`payment_session` holds the provider intent (amount, reference) the order is verified against. With `Cart::$guarded = []` it was mass-assignable, so any cart update built from client input could smuggle a forged session and have the order placed against it. It is now guarded against mass assignment and written only through `CartManager::setPaymentSession()` (via `setAttribute`, so the read-only property annotation is preserved).

## Breaking changes

None. The slide-overs and CartManager are internal, and guarding a single attribute does not change the public model API.
