### PR TITLE
fix(admin): unclip product delete modal and trim collection/attribute queries

### DIFF
--- a/packages/admin/resources/views/components/layouts/product.blade.php
+++ b/packages/admin/resources/views/components/layouts/product.blade.php
@@ -12,7 +12,7 @@
 @endphp
 
 <x-shopper::layouts.app :title="$title">
-    <div class="sticky top-0 z-10 bg-sh-surface border-b border-sh-border py-8 backdrop-blur-lg">
+    <div class="sticky top-0 z-10 bg-sh-surface border-b border-sh-border py-8">
         <x-shopper::container>
             <x-shopper::heading>
                 <x-slot:title>

--- a/packages/admin/src/Livewire/Components/Collection/CollectionProducts.php
+++ b/packages/admin/src/Livewire/Components/Collection/CollectionProducts.php
@@ -47,7 +47,7 @@ class CollectionProducts extends Component implements HasActions, HasSchemas, Ha
     #[Computed]
     public function productsIds(): array
     {
-        return $this->collection->products->pluck('id')->toArray();
+        return $this->collection->products()->pluck('id')->toArray();
     }
 
     public function table(Table $table): Table

--- a/packages/admin/src/Livewire/SlideOvers/ChooseProductAttributes.php
+++ b/packages/admin/src/Livewire/SlideOvers/ChooseProductAttributes.php
@@ -65,6 +65,11 @@ class ChooseProductAttributes extends SlideOverComponent implements HasActions, 
 
     public function form(Schema $schema): Schema
     {
+        $attributes = Attribute::query()
+            ->scopes('enabled')
+            ->select('id', 'name', 'description', 'icon')
+            ->get();
+
         return $schema
             ->components([
                 SlideOverWizard::make([
@@ -72,26 +77,9 @@ class ChooseProductAttributes extends SlideOverComponent implements HasActions, 
                         ->icon(Untitledui::PuzzlePiece)
                         ->schema([
                             RadioDeck::make('attributes')
-                                ->options(
-                                    Attribute::query()
-                                        ->scopes('enabled')
-                                        ->select('id', 'name')
-                                        ->pluck('name', 'id')
-                                )
-                                ->descriptions(
-                                    Attribute::query()
-                                        ->scopes('enabled')
-                                        ->select('id', 'description')
-                                        ->pluck('description', 'id')
-                                        ->toArray()
-                                )
-                                ->icons(
-                                    Attribute::query()
-                                        ->scopes('enabled')
-                                        ->select('id', 'icon')
-                                        ->pluck('icon', 'id')
-                                        ->toArray()
-                                )
+                                ->options($attributes->pluck('name', 'id'))
+                                ->descriptions($attributes->pluck('description', 'id')->toArray())
+                                ->icons($attributes->pluck('icon', 'id')->toArray())
                                 ->alignment(Alignment::Start)
                                 ->iconSize(IconSize::Small)
                                 ->color('primary')

--- a/packages/admin/src/Livewire/SlideOvers/CollectionProductsList.php
+++ b/packages/admin/src/Livewire/SlideOvers/CollectionProductsList.php
@@ -94,7 +94,7 @@ class CollectionProductsList extends SlideOverComponent implements HasActions, H
                     ->icon(Untitledui::Plus)
                     ->action(function (EloquentCollection $records): void {
                         /** @var array<int> $currentProducts */
-                        $currentProducts = $this->collection->products->pluck('id')->toArray();
+                        $currentProducts = $this->collection->products()->pluck('id')->toArray();
 
                         $this->collection->products()->sync(
                             array_merge($records->pluck('id')->toArray(), $currentProducts)


### PR DESCRIPTION
Two admin fixes.

## Product header clips the delete confirmation modal

The sticky header in the product edit layout carried `backdrop-blur-lg`. The surface background is opaque, so the blur is invisible, but `backdrop-filter` makes the element the containing block for fixed-position descendants. The delete confirmation modal, rendered inside the header, was therefore clipped to the header's height instead of covering the page. The order detail page uses the same header but renders its `<x-filament-actions::modals />` outside it, which is why it was unaffected. Dropping the no-op blur restores viewport-relative positioning. No visual change on an opaque surface.

## Collection product id queries

`CollectionProducts::productsIds()` and the collection products slide-over plucked ids off `$collection->products` (the loaded relation), hydrating every product model into memory just to read ids. A manual collection with thousands of products loaded thousands of full models. Plucking on the relation query selects only the id column. `ChooseProductAttributes` ran three identical enabled-attribute queries for the label, description, and icon decks on every form render; it now fetches once and reuses the result.

## Breaking changes

None. Internal admin components and a layout view only.
