### PR TITLE
fix(tax): exact taxable total + cart rate-limiting

### DIFF
--- a/packages/api/routes/store/cart.php
+++ b/packages/api/routes/store/cart.php
@@ -14,10 +14,12 @@ use Shopper\Api\Http\Controllers\Cart\PaymentSessionController;
 use Shopper\Api\Http\Controllers\Cart\ShippingOptionController;
 use Shopper\Http\Enum\RateLimit;
 
-Route::post('/carts', [CartController::class, 'store']);
+Route::post('/carts', [CartController::class, 'store'])
+    ->middleware('throttle:'.RateLimit::Checkout->value);
 Route::get('/carts/{cartId}', [CartController::class, 'show']);
 Route::patch('/carts/{cartId}', [CartController::class, 'update']);
-Route::post('/carts/{cartId}/lines', [CartLineController::class, 'store']);
+Route::post('/carts/{cartId}/lines', [CartLineController::class, 'store'])
+    ->middleware('throttle:'.RateLimit::Checkout->value);
 Route::patch('/carts/{cartId}/lines/{lineId}', [CartLineController::class, 'update']);
 Route::delete('/carts/{cartId}/lines/{lineId}', [CartLineController::class, 'destroy']);
 Route::post('/carts/{cartId}/addresses', [CartAddressController::class, 'store']);

--- a/packages/cart/src/Taxes/CartLineTaxAdapter.php
+++ b/packages/cart/src/Taxes/CartLineTaxAdapter.php
@@ -16,14 +16,9 @@ final readonly class CartLineTaxAdapter implements TaxableItem
         private int $taxableTotal,
     ) {}
 
-    public function getTaxableAmount(): int
+    public function getTaxableTotal(): int
     {
-        return (int) round($this->taxableTotal / $this->line->quantity);
-    }
-
-    public function getQuantity(): int
-    {
-        return $this->line->quantity;
+        return $this->taxableTotal;
     }
 
     public function getProductType(): ?string

--- a/packages/core/src/Contracts/TaxableItem.php
+++ b/packages/core/src/Contracts/TaxableItem.php
@@ -6,9 +6,13 @@ namespace Shopper\Core\Contracts;
 
 interface TaxableItem
 {
-    public function getTaxableAmount(): int;
-
-    public function getQuantity(): int;
+    /**
+     * The exact taxable total for the whole line. Returning the total, rather
+     * than a per-unit amount the provider multiplies back by quantity, keeps
+     * the tax base free of the rounding drift a divide-then-multiply round trip
+     * introduces when a line discount is not divisible by the quantity.
+     */
+    public function getTaxableTotal(): int;
 
     public function getProductType(): ?string;
 

--- a/packages/core/src/Taxes/OrderItemTaxAdapter.php
+++ b/packages/core/src/Taxes/OrderItemTaxAdapter.php
@@ -15,14 +15,9 @@ final readonly class OrderItemTaxAdapter implements TaxableItem
         private OrderItem $item,
     ) {}
 
-    public function getTaxableAmount(): int
+    public function getTaxableTotal(): int
     {
-        return $this->item->unit_price_amount;
-    }
-
-    public function getQuantity(): int
-    {
-        return $this->item->quantity;
+        return $this->item->unit_price_amount * $this->item->quantity;
     }
 
     public function getProductType(): ?string

--- a/packages/core/src/Taxes/SystemTaxProvider.php
+++ b/packages/core/src/Taxes/SystemTaxProvider.php
@@ -39,7 +39,7 @@ final class SystemTaxProvider implements TaxCalculationProvider
         }
 
         $amount = $this->calculateTaxAmount(
-            $item->getTaxableAmount() * $item->getQuantity(),
+            $item->getTaxableTotal(),
             $taxRate->rate,
             $taxZone->is_tax_inclusive,
         );

--- a/tests/Cart/Feature/CartCalculationTest.php
+++ b/tests/Cart/Feature/CartCalculationTest.php
@@ -194,6 +194,62 @@ describe(CalculateLines::class, function (): void {
             ->and($context->total)->toBe(2750);
     });
 
+    it('taxes the exact line total when a line discount is not divisible by quantity', function (): void {
+        $country = Country::query()->where('cca2', 'US')->first()
+            ?? Country::factory()->create(['cca2' => 'US', 'name' => 'United States']);
+
+        $taxZone = TaxZone::factory()->create([
+            'country_id' => $country->id,
+            'is_tax_inclusive' => false,
+        ]);
+
+        TaxRate::factory()->create([
+            'tax_zone_id' => $taxZone->id,
+            'rate' => 20.00,
+            'is_default' => true,
+        ]);
+
+        $product = Product::factory()->standard()->create();
+        $product->prices()->create([
+            'amount' => 750,
+            'currency_id' => $this->currency->id,
+        ]);
+        $product->load('prices');
+        $product->mutateStock($this->inventory->id, 100);
+
+        Discount::factory()->create([
+            'code' => 'FLAT98',
+            'is_active' => true,
+            'type' => DiscountType::FixedAmount,
+            'value' => 98,
+            'apply_to' => DiscountApplyTo::Order,
+            'eligibility' => DiscountEligibility::Everyone,
+            'min_required' => DiscountRequirement::None,
+            'start_at' => now()->subDay(),
+            'end_at' => now()->addMonth(),
+        ]);
+
+        $this->cartManager->add($this->cart, $product, quantity: 4);
+        $this->cartManager->applyCoupon($this->cart, 'FLAT98');
+        $this->cartManager->addAddress($this->cart, AddressType::Shipping, [
+            'first_name' => 'John',
+            'last_name' => 'Doe',
+            'address_1' => '123 Main St',
+            'city' => 'New York',
+            'postal_code' => '10001',
+            'country_id' => $country->id,
+        ]);
+
+        $context = $this->cartManager->calculate($this->cart->refresh());
+
+        // Subtotal 3000, discount 98 -> taxable 2902. 20% exclusive = round(2902 * 0.20) = 580.
+        // The per-unit round trip would tax round(2902 / 4) * 4 = 2904 -> 581, a 1 cent overcharge.
+        expect($context->subtotal)->toBe(3000)
+            ->and($context->discountTotal)->toBe(98)
+            ->and($context->taxTotal)->toBe(580)
+            ->and($context->total)->toBe(3482);
+    });
+
     it('taxes the discounted amount when a coupon is applied in the same run', function (): void {
         $country = Country::query()->where('cca2', 'US')->first()
             ?? Country::factory()->create(['cca2' => 'US', 'name' => 'United States']);

--- a/tests/Core/Stubs/TaxableItemStub.php
+++ b/tests/Core/Stubs/TaxableItemStub.php
@@ -19,14 +19,9 @@ final readonly class TaxableItemStub implements TaxableItem
         private array $categoryIds = [],
     ) {}
 
-    public function getTaxableAmount(): int
+    public function getTaxableTotal(): int
     {
-        return $this->amount;
-    }
-
-    public function getQuantity(): int
-    {
-        return $this->quantity;
+        return $this->amount * $this->quantity;
     }
 
     public function getProductType(): ?string


### PR DESCRIPTION
Two fixes from the pre-landing review.

## Tax: per-unit round trip overcharges on indivisible line discounts

`CartLineTaxAdapter` divided the line's taxable total by quantity and rounded, then `SystemTaxProvider` multiplied it back by quantity. When a line discount is not divisible by the quantity, the reconstructed total drifts from the real one. Concrete case, reproduced by a new test:

- Line: unit price 750, quantity 4 -> subtotal 3000.
- Fixed discount of 98 -> taxable total 2902.
- Exclusive 20% zone.

```
Buggy : round(2902 / 4) = 726 ; 726 * 4 = 2904 ; round(2904 * 0.20) = 581
Right : round(2902 * 0.20) = 580
```

The customer was charged a cent too much (2902 + 581 vs 2902 + 580). In an inclusive zone the recorded VAT is off by the same cent, so `net + tax != gross`. No existing test exercised a line discount indivisible by the quantity in a taxed zone, which is why it stayed green.

The fix exposes `getTaxableTotal()` on the `TaxableItem` contract and taxes that exact total. The cart adapter returns the total it was built from; the order adapter returns unit price times quantity exactly as before (it never had the bug, since its source is the per-unit price). `OrderItemTaxAdapter` and `SystemTaxProvider` are `final`.

## Cart: rate-limit cart creation and add-to-cart

`POST /carts` and `POST /carts/{id}/lines` were only covered by the store group's default limiter (120/min). Apply the checkout limiter (30/min) so a bot cannot spam cart creation and line additions.

## Breaking changes

The `TaxableItem` contract replaces `getTaxableAmount()` and `getQuantity()` with `getTaxableTotal()`. All internal usages are migrated (only the provider read the old pair; only the two adapters implement the contract). A custom `TaxableItem` implementation must return the taxable total instead.

## Noted, not fixed

`OrderItemTaxAdapter` taxes `unit_price * quantity` without subtracting the order item's `discount_amount`, so the order tax base can differ from the cart's when a line is discounted. Out of scope here; worth a separate look.
