### PR TITLE
fix(security): enforce per-user discount limit on guest carts

### DIFF
--- a/packages/cart/src/Actions/CreateOrderFromCartAction.php
+++ b/packages/cart/src/Actions/CreateOrderFromCartAction.php
@@ -107,7 +107,11 @@ final readonly class CreateOrderFromCartAction
             return null;
         }
 
-        if ($discount->usage_limit_per_user && $cart->customer_id !== null) {
+        if ($discount->usage_limit_per_user) {
+            if ($cart->customer_id === null) {
+                throw DiscountLimitReachedException::perUser($discount->code);
+            }
+
             $alreadyRedeemed = resolve(OrderContract::class)::query()
                 ->where('discount_id', $discount->id)
                 ->where('customer_id', $cart->customer_id)

--- a/packages/cart/src/Discounts/DiscountValidator.php
+++ b/packages/cart/src/Discounts/DiscountValidator.php
@@ -40,7 +40,11 @@ final readonly class DiscountValidator
             return new DiscountValidationResult(false, __('shopper-cart::messages.discount.usage_limit_reached'));
         }
 
-        if ($discount->usage_limit_per_user && $context->cart->customer_id) {
+        if ($discount->usage_limit_per_user) {
+            if (! $context->cart->customer_id) {
+                return new DiscountValidationResult(false, __('shopper-cart::messages.discount.requires_login'));
+            }
+
             $alreadyRedeemed = resolve(OrderContract::class)::query()
                 ->where('discount_id', $discount->id)
                 ->where('customer_id', $context->cart->customer_id)

--- a/tests/Cart/Feature/CreateOrderFromCartTest.php
+++ b/tests/Cart/Feature/CreateOrderFromCartTest.php
@@ -224,6 +224,37 @@ describe(CreateOrderFromCartAction::class, function (): void {
             ->and(Order::query()->where('discount_id', $discount->id)->count())->toBe(1);
     });
 
+    it('rejects a per-user discount on a guest checkout with no customer', function (): void {
+        $discount = Discount::factory()->create([
+            'code' => 'GUESTONCE',
+            'is_active' => true,
+            'type' => DiscountType::Percentage,
+            'value' => 10,
+            'total_use' => 0,
+            'usage_limit' => null,
+            'usage_limit_per_user' => true,
+            'eligibility' => DiscountEligibility::Everyone,
+            'min_required' => DiscountRequirement::None,
+        ]);
+
+        $guestCart = Cart::query()->create([
+            'currency_code' => 'USD',
+            'customer_id' => null,
+        ]);
+        $this->cartManager->add($guestCart, $this->product);
+        $this->cartManager->applyCoupon($guestCart, 'GUESTONCE');
+
+        try {
+            $this->action->execute($guestCart->refresh());
+            $this->fail('Expected DiscountLimitReachedException was not thrown.');
+        } catch (DiscountLimitReachedException) {
+            // expected
+        }
+
+        expect(Order::query()->where('discount_id', $discount->id)->count())->toBe(0)
+            ->and($discount->refresh()->total_use)->toBe(0);
+    });
+
     it('throws `CartCompletedException` for already completed cart', function (): void {
         $this->cart->update(['completed_at' => now()]);
 

--- a/tests/Cart/Feature/DiscountValidatorTest.php
+++ b/tests/Cart/Feature/DiscountValidatorTest.php
@@ -168,6 +168,23 @@ describe(DiscountValidator::class, function (): void {
         expect($result->valid)->toBeFalse();
     });
 
+    it('rejects a per-user discount for a guest cart with no customer', function (): void {
+        $guestCart = Cart::query()->create([
+            'currency_code' => 'USD',
+            'customer_id' => null,
+        ]);
+        $guestContext = new CartPipelineContext($guestCart);
+
+        $discount = Discount::factory()->create(array_merge(validDiscountAttributes(), [
+            'usage_limit_per_user' => true,
+        ]));
+
+        $result = $this->validator->validate($discount, $guestContext);
+
+        expect($result->valid)->toBeFalse()
+            ->and($result->failureReason)->toBe(__('shopper-cart::messages.discount.requires_login'));
+    });
+
     it('rejects a discount requiring login when no customer', function (): void {
         $guestCart = Cart::query()->create([
             'currency_code' => 'USD',


### PR DESCRIPTION
## Problem

A coupon flagged `usage_limit_per_user` was only checked when the cart carried a `customer_id`. The guard `$discount->usage_limit_per_user && $cart->customer_id` skipped the check entirely for guest carts (`customer_id` null), so a guest could reuse a once-per-customer code as many times as they wanted by ordering without an account. Direct revenue impact.

## Fix

2.x carts and orders carry no email, so a per-user limit cannot be attributed to an anonymous buyer. The per-user restriction is therefore unenforceable for guests, and the coupon is rejected for guest carts in both layers:

- `DiscountValidator::validate()` returns `requires_login` when a `usage_limit_per_user` coupon is applied to a guest cart, mirroring the existing `DiscountEligibility::Customers` behaviour. The redeemed-by-customer check is unchanged for authenticated carts.
- `CreateOrderFromCartAction::reserveDiscount()` throws `DiscountLimitReachedException::perUser` for the same case, as defense in depth at checkout.

A merchant who wants guests to use a coupon should not set a per-user limit on it.

## Note

The 3.x fix (#584) tracks guest redemptions by email; that column does not exist in 2.x, so this port stays within the 2.x data model rather than introducing a schema change.