### PR TITLE
fix(tax): tax the discounted line total exactly

### DIFF
--- a/packages/cart/src/Discounts/DiscountCalculator.php
+++ b/packages/cart/src/Discounts/DiscountCalculator.php
@@ -53,6 +53,8 @@ final readonly class DiscountCalculator
         } elseif ($discount->type === DiscountType::FixedAmount) {
             $context->discountTotal = $this->applyFixedAmount($discount, $applicableLines, $context);
         }
+
+        $context->cart->lines->load('adjustments');
     }
 
     /**

--- a/packages/cart/src/Taxes/CartLineTaxAdapter.php
+++ b/packages/cart/src/Taxes/CartLineTaxAdapter.php
@@ -16,14 +16,9 @@ final readonly class CartLineTaxAdapter implements TaxableItem
         private int $taxableTotal,
     ) {}
 
-    public function getTaxableAmount(): int
+    public function getTaxableTotal(): int
     {
-        return (int) round($this->taxableTotal / $this->line->quantity);
-    }
-
-    public function getQuantity(): int
-    {
-        return $this->line->quantity;
+        return $this->taxableTotal;
     }
 
     public function getProductType(): ?string

--- a/packages/core/src/Contracts/TaxableItem.php
+++ b/packages/core/src/Contracts/TaxableItem.php
@@ -6,9 +6,7 @@ namespace Shopper\Core\Contracts;
 
 interface TaxableItem
 {
-    public function getTaxableAmount(): int;
-
-    public function getQuantity(): int;
+    public function getTaxableTotal(): int;
 
     public function getProductType(): ?string;
 

--- a/packages/core/src/Taxes/OrderItemTaxAdapter.php
+++ b/packages/core/src/Taxes/OrderItemTaxAdapter.php
@@ -15,14 +15,9 @@ final readonly class OrderItemTaxAdapter implements TaxableItem
         private OrderItem $item,
     ) {}
 
-    public function getTaxableAmount(): int
+    public function getTaxableTotal(): int
     {
-        return $this->item->unit_price_amount;
-    }
-
-    public function getQuantity(): int
-    {
-        return $this->item->quantity;
+        return $this->item->unit_price_amount * $this->item->quantity;
     }
 
     public function getProductType(): ?string

--- a/packages/core/src/Taxes/SystemTaxProvider.php
+++ b/packages/core/src/Taxes/SystemTaxProvider.php
@@ -39,7 +39,7 @@ final class SystemTaxProvider implements TaxCalculationProvider
         }
 
         $amount = $this->calculateTaxAmount(
-            $item->getTaxableAmount() * $item->getQuantity(),
+            $item->getTaxableTotal(),
             $taxRate->rate,
             $taxZone->is_tax_inclusive,
         );

--- a/tests/Cart/Feature/CartCalculationTest.php
+++ b/tests/Cart/Feature/CartCalculationTest.php
@@ -170,6 +170,62 @@ describe(CalculateLines::class, function (): void {
             ->and($context->total)->toBe(2750);
     });
 
+    it('taxes the exact line total when a line discount is not divisible by quantity', function (): void {
+        $country = Country::query()->where('cca2', 'US')->first()
+            ?? Country::factory()->create(['cca2' => 'US', 'name' => 'United States']);
+
+        $taxZone = TaxZone::factory()->create([
+            'country_id' => $country->id,
+            'is_tax_inclusive' => false,
+        ]);
+
+        TaxRate::factory()->create([
+            'tax_zone_id' => $taxZone->id,
+            'rate' => 20.00,
+            'is_default' => true,
+        ]);
+
+        $product = Product::factory()->standard()->create();
+        $product->prices()->create([
+            'amount' => 750,
+            'currency_id' => $this->currency->id,
+        ]);
+        $product->load('prices');
+        $product->mutateStock($this->inventory->id, 100);
+
+        Discount::factory()->create([
+            'code' => 'FLAT98',
+            'is_active' => true,
+            'type' => DiscountType::FixedAmount,
+            'value' => 98,
+            'apply_to' => DiscountApplyTo::Order,
+            'eligibility' => DiscountEligibility::Everyone,
+            'min_required' => DiscountRequirement::None,
+            'start_at' => now()->subDay(),
+            'end_at' => now()->addMonth(),
+        ]);
+
+        $this->cartManager->add($this->cart, $product, quantity: 4);
+        $this->cartManager->applyCoupon($this->cart, 'FLAT98');
+        $this->cartManager->addAddress($this->cart, AddressType::Shipping, [
+            'first_name' => 'John',
+            'last_name' => 'Doe',
+            'address_1' => '123 Main St',
+            'city' => 'New York',
+            'postal_code' => '10001',
+            'country_id' => $country->id,
+        ]);
+
+        $context = $this->cartManager->calculate($this->cart->refresh());
+
+        // Subtotal 3000, discount 98 -> taxable 2902. 20% exclusive = round(2902 * 0.20) = 580.
+        // The per-unit round trip would tax round(2902 / 4) * 4 = 2904 -> 581, a 1 cent overcharge.
+        expect($context->subtotal)->toBe(3000)
+            ->and($context->discountTotal)->toBe(98)
+            ->and($context->taxTotal)->toBe(580)
+            ->and($context->total)->toBe(3482);
+    });
+
     it('handles tax inclusive mode', function (): void {
         $country = Country::query()->where('cca2', 'FR')->first()
             ?? Country::factory()->create(['cca2' => 'FR', 'name' => 'France']);

--- a/tests/Core/Stubs/TaxableItemStub.php
+++ b/tests/Core/Stubs/TaxableItemStub.php
@@ -19,14 +19,9 @@ final readonly class TaxableItemStub implements TaxableItem
         private array $categoryIds = [],
     ) {}
 
-    public function getTaxableAmount(): int
+    public function getTaxableTotal(): int
     {
-        return $this->amount;
-    }
-
-    public function getQuantity(): int
-    {
-        return $this->quantity;
+        return $this->amount * $this->quantity;
     }
 
     public function getProductType(): ?string


### PR DESCRIPTION
## Problem

Two issues left the cart computing tax against the wrong base.

1. **Tax on the pre-discount amount.** `DiscountCalculator` persists line adjustments with a raw `CartLineAdjustment::insert()`, but the in-memory `$line->adjustments` relation is eager loaded (empty) at the start of the pipeline run and never refreshed. `CalculateTax` reads `$line->adjustments->sum('amount')` from that stale, empty collection, so the discount is treated as zero and the full pre-discount line subtotal is taxed. A cart of 3000 with a 98 discount was taxed on 3000 (600 at 20%) instead of 2902 (580).

2. **Per-unit rounding drift.** Once the discounted amount reaches the tax base, `CartLineTaxAdapter` divided the taxable total by the quantity and rounded to a per-unit integer, then `SystemTaxProvider` multiplied it back by quantity. When the taxable total is not divisible by the quantity, the reconstructed base drifts: an exclusive zone overcharges by a cent, an inclusive zone records a VAT breakdown where net + tax != gross.

## Fix

- Reload the `adjustments` relation after applying a discount so `CalculateTax` sees the discounted amount.
- Replace `getTaxableAmount()` + `getQuantity()` on the `TaxableItem` contract with a single `getTaxableTotal()`. The cart adapter returns the exact total it was built from, the order adapter returns unit price times quantity, and the provider taxes the exact total once.

Covered by a calculation test: subtotal 3000, discount 98, taxable 2902, tax 580 (the per-unit round trip would tax round(2902 / 4) * 4 = 2904, a 1 cent overcharge).

## Breaking change

`TaxableItem` changes signature. Any custom implementation must replace `getTaxableAmount()` and `getQuantity()` with `getTaxableTotal()`. The only implementers in the repo are the two internal adapters and the test stub.