### PR TITLE
fix(security): lock model properties on pricing and variant slide-overs

### DIFF
--- a/packages/admin/src/Livewire/SlideOvers/ManagePricing.php
+++ b/packages/admin/src/Livewire/SlideOvers/ManagePricing.php
@@ -35,6 +35,7 @@ class ManagePricing extends SlideOverComponent implements HasActions, HasSchemas
     use InteractsWithSlideOverForm;
 
     /** @var (Model&Priceable<Model>) */
+    #[Locked]
     public Model&Priceable $model;
 
     #[Locked]

--- a/packages/admin/src/Livewire/SlideOvers/UpdateVariant.php
+++ b/packages/admin/src/Livewire/SlideOvers/UpdateVariant.php
@@ -23,6 +23,7 @@ use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\HtmlString;
 use Laravelcm\LivewireSlideOvers\SlideOverComponent;
 use Livewire\Attributes\Computed;
+use Livewire\Attributes\Locked;
 use Shopper\Components\Form\ShippingField;
 use Shopper\Components\Separator;
 use Shopper\Contracts\SlideOverForm;
@@ -45,8 +46,10 @@ class UpdateVariant extends SlideOverComponent implements HasActions, HasSchemas
     use InteractsWithSchemas;
     use InteractsWithSlideOverForm;
 
+    #[Locked]
     public ?ProductVariant $variant = null;
 
+    #[Locked]
     public ?Product $product = null;
 
     public string $action = 'save';


### PR DESCRIPTION
## Problem

`ManagePricing` exposed `$model`, and `UpdateVariant` exposed `$variant` and `$product`, as public Eloquent properties without `#[Locked]`. Livewire serializes these to the client and accepts them back on the next request, so an admin could swap the model id from the browser and overwrite the pricing of another product, or another variant, that the legitimate slide-over never opened. This is an IDOR within the admin.

`ManagePricing` already locked `$currencyId` but not `$model`.

## Fix

Add `#[Locked]` to the three properties, matching the locks already present on `Pricing::$model` and `ZoneShippingOptions::$selectedZoneId` (#573).