### PR TITLE
perf(admin): trim collection and attribute deck queries

### DIFF
--- a/packages/admin/src/Livewire/Components/Collection/CollectionProducts.php
+++ b/packages/admin/src/Livewire/Components/Collection/CollectionProducts.php
@@ -47,7 +47,7 @@ class CollectionProducts extends Component implements HasActions, HasSchemas, Ha
     #[Computed]
     public function productsIds(): array
     {
-        return $this->collection->products->pluck('id')->toArray();
+        return $this->collection->products()->pluck('id')->toArray();
     }
 
     public function table(Table $table): Table

--- a/packages/admin/src/Livewire/SlideOvers/ChooseProductAttributes.php
+++ b/packages/admin/src/Livewire/SlideOvers/ChooseProductAttributes.php
@@ -65,6 +65,11 @@ class ChooseProductAttributes extends SlideOverComponent implements HasActions, 
 
     public function form(Schema $schema): Schema
     {
+        $attributes = Attribute::query()
+            ->scopes('enabled')
+            ->select('id', 'name', 'description', 'icon')
+            ->get();
+
         return $schema
             ->components([
                 SlideOverWizard::make([
@@ -72,26 +77,9 @@ class ChooseProductAttributes extends SlideOverComponent implements HasActions, 
                         ->icon(Untitledui::PuzzlePiece)
                         ->schema([
                             RadioDeck::make('attributes')
-                                ->options(
-                                    Attribute::query()
-                                        ->scopes('enabled')
-                                        ->select('id', 'name')
-                                        ->pluck('name', 'id')
-                                )
-                                ->descriptions(
-                                    Attribute::query()
-                                        ->scopes('enabled')
-                                        ->select('id', 'description')
-                                        ->pluck('description', 'id')
-                                        ->toArray()
-                                )
-                                ->icons(
-                                    Attribute::query()
-                                        ->scopes('enabled')
-                                        ->select('id', 'icon')
-                                        ->pluck('icon', 'id')
-                                        ->toArray()
-                                )
+                                ->options($attributes->pluck('name', 'id'))
+                                ->descriptions($attributes->pluck('description', 'id')->toArray())
+                                ->icons($attributes->pluck('icon', 'id')->toArray())
                                 ->alignment(Alignment::Start)
                                 ->iconSize(IconSize::Small)
                                 ->color('primary')

--- a/packages/admin/src/Livewire/SlideOvers/CollectionProductsList.php
+++ b/packages/admin/src/Livewire/SlideOvers/CollectionProductsList.php
@@ -94,7 +94,7 @@ class CollectionProductsList extends SlideOverComponent implements HasActions, H
                     ->icon(Untitledui::Plus)
                     ->action(function (EloquentCollection $records): void {
                         /** @var array<int> $currentProducts */
-                        $currentProducts = $this->collection->products->pluck('id')->toArray();
+                        $currentProducts = $this->collection->products()->pluck('id')->toArray();
 
                         $this->collection->products()->sync(
                             array_merge($records->pluck('id')->toArray(), $currentProducts)


### PR DESCRIPTION
## Problem

Two admin paths did more work than needed:

- `CollectionProducts::productsIds()` and `CollectionProductsList` read product ids with `$this->collection->products->pluck('id')`, which hydrates every related product model into memory just to collect their ids.
- `ChooseProductAttributes::form()` ran three identical `enabled` attribute queries, one each for the label, description and icon decks.

## Fix

- Pluck the ids on the relation query (`->products()->pluck('id')`) so the database returns just the ids.
- Fetch the enabled attributes once in `form()` and reuse the collection for the three decks.