### PR TITLE
feat(admin): gate dashboard access behind canAccessDashboard()

### DIFF
--- a/packages/admin/src/Http/Middleware/Dashboard.php
+++ b/packages/admin/src/Http/Middleware/Dashboard.php
@@ -9,16 +9,15 @@ use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Shopper\Facades\Shopper;
 use Shopper\Models\Contracts\ShopperUser;
-use Spatie\Permission\Contracts\Permission;
 
 class Dashboard
 {
     public function handle(Request $request, Closure $next): mixed
     {
-        /** @var ShopperUser&Permission $user */
+        /** @var ShopperUser $user */
         $user = Shopper::auth()->user();
 
-        abort_if(! $user->isAdmin() && ! $user->hasPermissionTo('access_dashboard'), 403, __('Unauthorized'));
+        abort_unless($user->canAccessDashboard(), 403, __('Unauthorized'));
 
         if (blank(shopper_setting('email')) || blank(shopper_setting('street_address'))) {
             if ($request->ajax() || $request->wantsJson()) {

--- a/packages/admin/src/Models/Contracts/ShopperUser.php
+++ b/packages/admin/src/Models/Contracts/ShopperUser.php
@@ -36,6 +36,8 @@ interface ShopperUser extends Authenticatable
 
     public function isManager(): bool;
 
+    public function canAccessDashboard(): bool;
+
     public function isVerified(): bool;
 
     /**

--- a/packages/admin/src/Traits/InteractsWithShopper.php
+++ b/packages/admin/src/Traits/InteractsWithShopper.php
@@ -53,6 +53,13 @@ trait InteractsWithShopper
         return $this->hasRole(config('shopper.admin.roles.manager'));
     }
 
+    public function canAccessDashboard(): bool
+    {
+        return $this->isAdmin()
+            || $this->isManager()
+            || $this->hasPermissionTo('access_dashboard');
+    }
+
     public function isVerified(): bool
     {
         return $this->email_verified_at !== null;

--- a/tests/Core/Models/UserTest.php
+++ b/tests/Core/Models/UserTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Shopper\Core\Models\Address;
+use Shopper\Models\Permission;
 use Shopper\Models\Role;
 use Tests\Core\Stubs\User;
 
@@ -52,6 +53,29 @@ describe(User::class, function (): void {
         $user = User::factory()->create();
 
         expect($user->isManager())->toBeFalse();
+    });
+
+    it('grants dashboard access to admin, manager, and holders of the `access_dashboard` permission', function (): void {
+        $admin = User::factory()->create();
+        $admin->assignRole(Role::query()->firstOrCreate(['name' => config('shopper.admin.roles.admin')]));
+
+        $manager = User::factory()->create();
+        $manager->assignRole(Role::query()->firstOrCreate(['name' => config('shopper.admin.roles.manager')]));
+
+        $staff = User::factory()->create();
+        Permission::query()->firstOrCreate(['name' => 'access_dashboard']);
+        $staff->givePermissionTo('access_dashboard');
+
+        expect($admin->canAccessDashboard())->toBeTrue()
+            ->and($manager->canAccessDashboard())->toBeTrue()
+            ->and($staff->canAccessDashboard())->toBeTrue();
+    });
+
+    it('denies dashboard access to customers without the `access_dashboard` permission', function (): void {
+        $customer = User::factory()->create();
+        $customer->assignRole(Role::query()->firstOrCreate(['name' => config('shopper.admin.roles.user')]));
+
+        expect($customer->canAccessDashboard())->toBeFalse();
     });
 
     it('checks if user email is verified', function (): void {


### PR DESCRIPTION
The `Dashboard` middleware only special-cased the `administrator` role:

```php
abort_if(! $user->isAdmin() && ! $user->hasPermissionTo("access_dashboard"), 403);
```

The shipped `manager` role gets no permissions from any seeder and is not the admin role, so a freshly created manager hits a 403 on every admin page until an administrator manually grants `access_dashboard`. Two staff roles ship, only one can actually enter the panel.

## Change

Move the decision into an overridable `canAccessDashboard()` method on the `ShopperUser` contract:

```php
public function canAccessDashboard(): bool
{
    return $this->isAdmin()
        || $this->isManager()
        || $this->hasPermissionTo("access_dashboard");
}
```

The middleware now calls `abort_unless($user->canAccessDashboard(), 403)`. Admins, managers, and holders of the `access_dashboard` permission can enter; host apps override the method on their own user model for custom rules.

## Notes

- Adds a method to the `ShopperUser` contract. Apps using the `InteractsWithShopper` trait (the documented path) get the default implementation automatically; an app implementing the contract without the trait must add the method.