### PR TITLE
fix(security): scope the customer detail route to customers only

### DIFF
--- a/packages/admin/src/Livewire/Pages/Customers/Show.php
+++ b/packages/admin/src/Livewire/Pages/Customers/Show.php
@@ -39,7 +39,10 @@ class Show extends AbstractPageComponent implements HasActions, HasSchemas
         $userModel = config('auth.providers.users.model');
 
         /** @var ShopperUser $customer */
-        $customer = $userModel::query()->with(['addresses', 'orders'])->findOrFail($user);
+        $customer = $userModel::query()
+            ->customers()
+            ->with(['addresses', 'orders'])
+            ->findOrFail($user);
 
         $this->customer = $customer;
     }

--- a/tests/Admin/Livewire/Pages/Customers/ShowTest.php
+++ b/tests/Admin/Livewire/Pages/Customers/ShowTest.php
@@ -2,8 +2,10 @@
 
 declare(strict_types=1);
 
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Livewire\Livewire;
 use Shopper\Livewire\Pages\Customers\Show;
+use Shopper\Models\Role;
 use Tests\Core\Stubs\User;
 
 uses(Tests\Admin\TestCase::class);
@@ -12,11 +14,14 @@ beforeEach(function (): void {
     $this->user = User::factory()->create();
     $this->user->givePermissionTo('read_customers');
     $this->actingAs($this->user);
+
+    $this->customerRole = Role::query()->firstOrCreate(['name' => config('shopper.admin.roles.user')]);
 });
 
 describe(Show::class, function (): void {
     it('can render customer show component', function (): void {
         $customer = User::factory()->create();
+        $customer->assignRole($this->customerRole);
 
         Livewire::test(Show::class, ['user' => $customer->id])
             ->assertOk()
@@ -25,10 +30,19 @@ describe(Show::class, function (): void {
 
     it('loads customer with relationships on mount', function (): void {
         $customer = User::factory()->create();
+        $customer->assignRole($this->customerRole);
 
         $component = Livewire::test(Show::class, ['user' => $customer->id]);
 
         expect($component->get('customer'))->not->toBeNull()
             ->and($component->get('customer')->id)->toBe($customer->id);
+    });
+
+    it('does not expose a staff account through the customer detail route', function (): void {
+        $staff = User::factory()->create();
+        $staff->assignRole(Role::query()->firstOrCreate(['name' => config('shopper.admin.roles.admin')]));
+
+        expect(fn (): mixed => Livewire::test(Show::class, ['user' => $staff->id]))
+            ->toThrow(ModelNotFoundException::class);
     });
 })->group('livewire', 'customers');


### PR DESCRIPTION
Fixes the IDOR reported in GHSA-w7mm-g5pr-gpff.

## Problem

`Customers/Show.php` loaded any user by ID:

```php
$customer = $userModel::query()->with(["addresses", "orders"])->findOrFail($user);
```

The listing (`Customers/Index.php`) scopes results to the customer role via `->scopes("customers")`, but the detail page did not. A staff member holding only `read_customers` could open `/customers/{id}/show` against an administrator or staff account and read their profile, addresses and orders — bypassing the `view_users` boundary that protects team management.

## Fix

Apply the same `customers` scope to the lookup:

```php
$customer = $userModel::query()
    ->customers()
    ->with(["addresses", "orders"])
    ->findOrFail($user);
```

Non-customer accounts now resolve to a 404. Because the `#[Locked]` `$customer` property is populated from this scoped query, `anonymizeAction()` is also bound to a customer, covering the advisory's second recommendation without a redundant check.

## Tests

`ShowTest` now asserts a `read_customers` user cannot load a staff account (`ModelNotFoundException`); existing render tests assign the customer role to the viewed user.