### PR TITLE
fix(security): block executable uploads in media collections

### DIFF
--- a/packages/admin/config/media.php
+++ b/packages/admin/config/media.php
@@ -34,7 +34,30 @@ return [
         'image/png',
         'image/webp',
         'image/avif',
-        'image/svg+xml',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Downloadable File Types
+    |--------------------------------------------------------------------------
+    |
+    | Mime types accepted by the product "files" collection used for
+    | downloadable goods. Executable types (HTML, SVG, JavaScript) are
+    | deliberately excluded to prevent stored XSS from same-origin media.
+    |
+    */
+
+    'accepts_file_types' => [
+        'application/pdf',
+        'application/zip',
+        'application/x-rar-compressed',
+        'application/x-7z-compressed',
+        'application/msword',
+        'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        'application/vnd.ms-excel',
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        'text/plain',
+        'text/csv',
     ],
 
     /*

--- a/packages/admin/src/Livewire/Components/Products/Form/Files.php
+++ b/packages/admin/src/Livewire/Components/Products/Form/Files.php
@@ -44,6 +44,7 @@ class Files extends Component implements HasSchemas
                     ->collection('files')
                     ->label(__('shopper::words.files'))
                     ->helperText(__('shopper::pages/products.files_helpText'))
+                    ->acceptedFileTypes(config('shopper.media.accepts_file_types', []))
                     ->multiple()
                     ->panelLayout('grid')
                     ->columnSpan(['lg' => 2]),

--- a/packages/core/src/Models/Product.php
+++ b/packages/core/src/Models/Product.php
@@ -186,6 +186,7 @@ class Product extends Model implements HasReviews, Priceable, ProductContract, S
                 'files' => new MediaCollectionConfig(
                     name: 'files',
                     disk: config('shopper.media.storage.disk_name', 'public'),
+                    acceptsMimeTypes: config('shopper.media.accepts_file_types', []),
                 ),
             ]
         );

--- a/tests/Core/Media/MediaCollectionMimeTest.php
+++ b/tests/Core/Media/MediaCollectionMimeTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Http\UploadedFile;
+use Spatie\MediaLibrary\MediaCollections\Exceptions\FileUnacceptableForCollection;
+use Tests\Core\Stubs\Product;
+
+uses(Tests\Core\TestCase::class);
+
+describe('media collection mime enforcement', function (): void {
+    it('rejects an executable HTML file uploaded to the product files collection', function (): void {
+        $product = Product::factory()->create();
+
+        $payload = UploadedFile::fake()->createWithContent(
+            'payload.html',
+            '<script>alert(document.domain)</script>',
+        );
+
+        expect(fn (): mixed => $product->addMedia($payload)->toMediaCollection('files'))
+            ->toThrow(FileUnacceptableForCollection::class);
+    });
+
+    it('accepts an allowed document in the product files collection', function (): void {
+        $product = Product::factory()->create();
+
+        $document = UploadedFile::fake()->createWithContent('notes.txt', 'product manual');
+
+        $media = $product->addMedia($document)->toMediaCollection('files');
+
+        expect($media->collection_name)->toBe('files');
+    });
+
+    it('rejects an SVG uploaded to an image collection', function (): void {
+        $product = Product::factory()->create();
+
+        $svg = UploadedFile::fake()->createWithContent(
+            'logo.svg',
+            '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>',
+        );
+
+        expect(fn (): mixed => $product->addMedia($svg)
+            ->toMediaCollection(config('shopper.media.storage.collection_name')))
+            ->toThrow(FileUnacceptableForCollection::class);
+    });
+})->group('media', 'security');


### PR DESCRIPTION
Addresses the stored XSS / privilege-escalation chain reported in GHSA-vmvv-x5cp-2qv6.

## Problem

Media is served inline from the same-origin `public` disk, and two collections accepted executable content:

- `image/svg+xml` was allowlisted for every image collection (`accepts_mime_types`), and Filament `->image()` matches it via the `image/*` wildcard.
- The product `files` collection (`Product::getMediaCollections()`) had no `acceptsMimeTypes`, and `Files.php` set neither `->image()` nor `->acceptedFileTypes()`, so it accepted arbitrary types including `text/html`.

A staff member with only an upload permission (`edit_products`, `add_brands`, ...) could store an HTML or SVG payload served inline at `/storage/...`. Opened by an administrator, it runs in their session and can drive `CreateTeamMember` to mint a new administrator account.

## Fix (upload restriction — breaks the chain at the source)

- Remove `image/svg+xml` from the default `accepts_mime_types`.
- Add a configurable `accepts_file_types` allowlist (documents and archives, no HTML/SVG/JS) and apply it to the product `files` collection.
- Enforcement is server-side via the media library (`acceptsMimeTypes` on the registered collection) and mirrored on the Filament upload with `->acceptedFileTypes()`.

`tests/Core/Media/MediaCollectionMimeTest.php` proves an HTML file is rejected by the `files` collection, an SVG is rejected by an image collection, and an allowed document is accepted.

## Upgrade note

Stores that **published** `config/shopper/media.php` keep their own copy: they retain `image/svg+xml` and lack the new `accepts_file_types` key (which falls back to an empty, unrestricted list for the `files` collection). Published configs must be updated manually to receive this protection.

## Out of scope (defense in depth, tracked separately)

- Content-Security-Policy on the admin panel.
- Serving media from a separate cookieless origin and/or `Content-Disposition: attachment` + `X-Content-Type-Options: nosniff`.
- Step-up re-authentication before assigning the `administrator` role in `CreateTeamMember`.