### PR TITLE
fix(security): restrict the product files media collection

### DIFF
--- a/packages/admin/config/media.php
+++ b/packages/admin/config/media.php
@@ -38,6 +38,30 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Downloadable File Types
+    |--------------------------------------------------------------------------
+    |
+    | Mime types accepted by the product "files" collection used for
+    | downloadable goods. Executable types (HTML, SVG, JavaScript) are
+    | deliberately excluded to prevent stored XSS from same-origin media.
+    |
+    */
+
+    'accepts_file_types' => [
+        'application/pdf',
+        'application/zip',
+        'application/x-rar-compressed',
+        'application/x-7z-compressed',
+        'application/msword',
+        'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        'application/vnd.ms-excel',
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        'text/plain',
+        'text/csv',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Media Filesize
     |--------------------------------------------------------------------------
     |

--- a/packages/admin/src/Livewire/Pages/Product/Files.php
+++ b/packages/admin/src/Livewire/Pages/Product/Files.php
@@ -46,6 +46,7 @@ class Files extends Component implements HasSchemas
                     ->collection('files')
                     ->label(__('shopper::words.files'))
                     ->helperText(__('shopper::pages/products.files_helpText'))
+                    ->acceptedFileTypes(config('shopper.media.accepts_file_types', []))
                     ->multiple()
                     ->panelLayout('grid')
                     ->columnSpan(['lg' => 2]),

--- a/packages/core/src/Models/Product.php
+++ b/packages/core/src/Models/Product.php
@@ -168,6 +168,7 @@ class Product extends Model implements HasReviews, Priceable, ProductContract, S
                 'files' => new MediaCollectionConfig(
                     name: 'files',
                     disk: config('shopper.media.storage.disk_name', 'public'),
+                    acceptsMimeTypes: config('shopper.media.accepts_file_types', []),
                 ),
             ]
         );

--- a/tests/Core/Media/MediaCollectionMimeTest.php
+++ b/tests/Core/Media/MediaCollectionMimeTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Http\UploadedFile;
+use Spatie\MediaLibrary\MediaCollections\Exceptions\FileUnacceptableForCollection;
+use Tests\Core\Stubs\Product;
+
+uses(Tests\Core\TestCase::class);
+
+describe('media collection mime enforcement', function (): void {
+    it('rejects an executable HTML file uploaded to the product files collection', function (): void {
+        $product = Product::factory()->create();
+
+        $payload = UploadedFile::fake()->createWithContent(
+            'payload.html',
+            '<script>alert(document.domain)</script>',
+        );
+
+        expect(fn (): mixed => $product->addMedia($payload)->toMediaCollection('files'))
+            ->toThrow(FileUnacceptableForCollection::class);
+    });
+
+    it('accepts an allowed document in the product files collection', function (): void {
+        $product = Product::factory()->create();
+
+        $document = UploadedFile::fake()->createWithContent('notes.txt', 'product manual');
+
+        $media = $product->addMedia($document)->toMediaCollection('files');
+
+        expect($media->collection_name)->toBe('files');
+    });
+
+    it('rejects an SVG uploaded to an image collection', function (): void {
+        $product = Product::factory()->create();
+
+        $svg = UploadedFile::fake()->createWithContent(
+            'logo.svg',
+            '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>',
+        );
+
+        expect(fn (): mixed => $product->addMedia($svg)
+            ->toMediaCollection(config('shopper.media.storage.collection_name')))
+            ->toThrow(FileUnacceptableForCollection::class);
+    });
+})->group('media', 'security');


### PR DESCRIPTION
Ports the remaining half of #595 (GHSA-vmvv-x5cp-2qv6) from 2.x to 3.x.

SVG is already absent from `accepts_mime_types` on 3.x. The gap that remained is the product `files` collection, which had no MIME restriction:

```php
// Product::getMediaCollections()
"files" => new MediaCollectionConfig(
    name: "files",
    disk: config("shopper.media.storage.disk_name", "public"),
),
```

With no `acceptsMimeTypes` and no `->acceptedFileTypes()` on the upload, a staff member with an upload permission could store an HTML payload served inline from the same-origin `public` disk, enabling stored XSS.

## Fix

- Add a configurable `accepts_file_types` allowlist (documents and archives, no HTML/SVG/JS) to `config/shopper/media.php`.
- Apply it to the product `files` collection (`acceptsMimeTypes`), enforced server-side by the media library.
- Mirror it on the Filament upload with `->acceptedFileTypes()`.

`tests/Core/Media/MediaCollectionMimeTest.php` proves an HTML file is rejected by the `files` collection, an SVG is rejected by an image collection, and an allowed document is accepted.

## Upgrade note

Stores that published `config/shopper/media.php` must add the new `accepts_file_types` key by hand to receive this protection.