### PR TITLE
fix(settings): use the media disk for logo and cover uploads

### DIFF
--- a/packages/admin/src/Livewire/Pages/Settings/General.php
+++ b/packages/admin/src/Livewire/Pages/Settings/General.php
@@ -133,12 +133,12 @@ class General extends Component implements HasActions, HasSchemas
                             ->avatar()
                             ->image()
                             ->maxSize(1024)
-                            ->disk(config('shopper.media.storage.collection_name')),
+                            ->disk(config('shopper.media.storage.disk_name')),
                         FileUpload::make('cover')
                             ->label(__('shopper::forms.label.cover_photo'))
                             ->image()
                             ->maxSize(1024)
-                            ->disk(config('shopper.media.storage.collection_name')),
+                            ->disk(config('shopper.media.storage.disk_name')),
                     ]),
                 Separator::make(),
                 Section::make(__('shopper::pages/settings/global.general.store_address'))

--- a/tests/Admin/Livewire/Pages/Settings/GeneralTest.php
+++ b/tests/Admin/Livewire/Pages/Settings/GeneralTest.php
@@ -2,7 +2,11 @@
 
 declare(strict_types=1);
 
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
 use Livewire\Livewire;
+use Shopper\Core\Models\Country;
+use Shopper\Core\Models\Currency;
 use Shopper\Core\Models\Setting;
 use Shopper\Livewire\Pages\Settings\General;
 use Tests\Core\Stubs\User;
@@ -38,5 +42,36 @@ describe(General::class, function (): void {
         $component = Livewire::test(General::class);
 
         expect($component->get('data'))->toBeArray();
+    });
+
+    it('stores the logo on the configured media disk', function (): void {
+        $disk = config('shopper.media.storage.disk_name');
+
+        Storage::fake($disk);
+
+        $country = Country::query()->firstOr(fn () => Country::factory()->create());
+        $currency = Currency::query()->firstOr(fn () => Currency::factory()->create());
+
+        Livewire::test(General::class)
+            ->fillForm([
+                'name' => 'Test Store',
+                'email' => 'store@example.com',
+                'legal_name' => 'Test Store LLC',
+                'street_address' => 'Akwa Avenue 34',
+                'city' => 'Douala',
+                'postal_code' => '00237',
+                'country_id' => $country->id,
+                'currencies' => [$currency->id],
+                'default_currency_id' => $currency->id,
+                'logo' => UploadedFile::fake()->image('logo.png'),
+            ])
+            ->call('store')
+            ->assertHasNoFormErrors();
+
+        $logo = Setting::query()->where('key', 'logo')->value('value');
+
+        expect($logo)->not->toBeNull();
+
+        Storage::disk($disk)->assertExists($logo);
     });
 })->group('livewire', 'settings');


### PR DESCRIPTION
## Problem

Uploading a logo or cover image in the general settings raised `Disk [uploads] does not have a configured driver`.

The `logo` and `cover` `FileUpload` fields passed the Spatie media **collection name** (`uploads`) to `->disk()` instead of the configured **disk name** (`public`). `collection_name` is a media-library collection, not a Laravel filesystem disk, so the upload failed.

## Fix

Point both fields at `shopper.media.storage.disk_name`, matching the `RichEditor` attachments disk in the same form.