### PR TITLE
fix(admin): enforce authorization on staff delete and create actions

### DIFF
--- a/packages/admin/src/Livewire/Components/Settings/Team/AdministratorsList.php
+++ b/packages/admin/src/Livewire/Components/Settings/Team/AdministratorsList.php
@@ -95,7 +95,7 @@ class AdministratorsList extends Component implements HasActions, HasSchemas, Ha
                         ->label(__('shopper::pages/settings/staff.delete_user'))
                         ->icon(Untitledui::Trash03)
                         ->color('danger')
-                        ->visible(fn (ShopperUser $record): bool => $this->canDelete($record))
+                        ->authorize(fn (ShopperUser $record): bool => $this->canDelete($record))
                         ->successNotificationTitle(__('shopper::notifications.users_roles.admin_deleted')),
                 ])
                     ->tooltip(__('shopper::words.actions')),
@@ -108,7 +108,7 @@ class AdministratorsList extends Component implements HasActions, HasSchemas, Ha
                     ->label(__('shopper::forms.actions.delete'))
                     ->icon(Untitledui::Trash03)
                     ->requiresConfirmation()
-                    ->visible(fn (): bool => shopper()->auth()->user()->isAdmin()) // @phpstan-ignore-line
+                    ->authorize(fn (): bool => shopper()->auth()->user()->isAdmin()) // @phpstan-ignore-line
                     ->action(function (Collection $records): void {
                         $records->each->delete();
 

--- a/packages/admin/src/Livewire/SlideOvers/CreateTeamMember.php
+++ b/packages/admin/src/Livewire/SlideOvers/CreateTeamMember.php
@@ -50,7 +50,7 @@ class CreateTeamMember extends SlideOverComponent implements HasActions, HasSche
 
     public function mount(): void
     {
-        $this->authorize('system.settings');
+        $this->authorize('system.users');
 
         $this->title = __('shopper::pages/settings/staff.add_admin');
 
@@ -121,7 +121,7 @@ class CreateTeamMember extends SlideOverComponent implements HasActions, HasSche
 
     public function store(): void
     {
-        $this->authorize('system.settings');
+        $this->authorize('system.users');
 
         $data = $this->form->getState();
         $userModel = config('auth.providers.users.model');

--- a/tests/Admin/Livewire/Components/Settings/Team/AdministratorsListTest.php
+++ b/tests/Admin/Livewire/Components/Settings/Team/AdministratorsListTest.php
@@ -85,6 +85,51 @@ describe(AdministratorsList::class, function (): void {
             ->assertTableActionHidden('delete', $this->adminUser);
     });
 
+    it('denies the delete action for a non-admin even when mounted directly', function (): void {
+        $manager = User::factory()->create();
+        $manager->assignRole(config('shopper.admin.roles.manager'));
+        $manager->givePermissionTo('system.users');
+        $this->actingAs($manager);
+
+        Livewire::test(AdministratorsList::class)
+            ->loadTable()
+            ->call('mountAction', 'delete', [], ['table' => true, 'recordKey' => $this->adminUser->getKey()]);
+
+        expect(User::query()->find($this->adminUser->id))->not->toBeNull();
+    });
+
+    it('denies the delete action on the last remaining admin even when mounted directly', function (): void {
+        $secondAdmin = User::factory()->create();
+        $secondAdmin->assignRole(config('shopper.admin.roles.admin'));
+        $this->actingAs($secondAdmin);
+
+        $this->adminUser->delete();
+
+        Livewire::test(AdministratorsList::class)
+            ->loadTable()
+            ->call('mountAction', 'delete', [], ['table' => true, 'recordKey' => $secondAdmin->getKey()]);
+
+        expect(User::query()->find($secondAdmin->id))->not->toBeNull();
+    });
+
+    it('denies the bulk delete action for a non-admin even when mounted directly', function (): void {
+        $manager = User::factory()->create();
+        $manager->assignRole(config('shopper.admin.roles.manager'));
+        $manager->givePermissionTo('system.users');
+        $this->actingAs($manager);
+
+        $editorRole = Role::create(['name' => 'editor', 'display_name' => 'Editor']);
+        $editor = User::factory()->create();
+        $editor->assignRole($editorRole->name);
+
+        Livewire::test(AdministratorsList::class)
+            ->loadTable()
+            ->set('selectedTableRecords', [(string) $editor->getKey()])
+            ->call('mountAction', 'delete', [], ['table' => true, 'bulk' => true]);
+
+        expect(User::query()->find($editor->id))->not->toBeNull();
+    });
+
     it('sends notification when copyUserId action is triggered', function (): void {
         $manager = User::factory()->create();
         $manager->assignRole(config('shopper.admin.roles.manager'));

--- a/tests/Admin/Livewire/SlideOvers/CreateTeamMemberTest.php
+++ b/tests/Admin/Livewire/SlideOvers/CreateTeamMemberTest.php
@@ -150,9 +150,9 @@ describe(CreateTeamMember::class, function (): void {
         expect($newUser->hasRole($secondRole->name))->toBeTrue();
     });
 
-    it('blocks `store` for users without `system.settings`', function (): void {
+    it('blocks `store` for users without `system.users`', function (): void {
         $reader = User::factory()->create();
-        $reader->givePermissionTo('system.users');
+        $reader->givePermissionTo('system.settings');
         $this->actingAs($reader);
 
         $initialCount = User::query()->count();


### PR DESCRIPTION
## Summary

Hardens the staff management surface in the admin panel.

- `AdministratorsList`: the `DeleteAction` and `DeleteBulkAction` now use `->authorize()` instead of `->visible()`. Authorization is the correct Filament channel for access control: it keeps the same UI behavior (unauthorized actions stay hidden) while making the security intent explicit and independent of presentation logic. The per-record rules are unchanged: only an admin can delete, never themselves, never the last remaining admin.
- `CreateTeamMember`: creating a staff member (an operation that can grant the admin role) is now gated by `system.users` instead of `system.settings`, aligning it with the rest of the staff management pages. Role and permission management stays under `system.settings`.

## Tests

New regression tests mount the actions directly (the way a tampered client would, bypassing the UI) and assert the target user is never deleted: as a manager, as the last remaining admin, and through the bulk action. The existing `CreateTeamMember` permission test now encodes the new contract.