### PR TITLE
fix(security): restrict avatar, logo and cover uploads to safe image types

### DIFF
--- a/packages/admin/src/Livewire/Components/Account/Profile.php
+++ b/packages/admin/src/Livewire/Components/Account/Profile.php
@@ -14,6 +14,7 @@ use Filament\Schemas\Concerns\InteractsWithSchemas;
 use Filament\Schemas\Contracts\HasSchemas;
 use Filament\Schemas\Schema;
 use Illuminate\Contracts\View\View;
+use Illuminate\Support\Arr;
 use Livewire\Component;
 use Shopper\Components\Section;
 use Shopper\Traits\HandlesAuthorizationExceptions;
@@ -34,7 +35,13 @@ class Profile extends Component implements HasActions, HasSchemas
 
     public function mount(): void
     {
-        $this->form->fill($this->getUser()->toArray());
+        $this->form->fill(Arr::only($this->getUser()->toArray(), [
+            'avatar_location',
+            'first_name',
+            'last_name',
+            'email',
+            'phone_number',
+        ]));
     }
 
     public function form(Schema $schema): Schema
@@ -51,6 +58,7 @@ class Profile extends Component implements HasActions, HasSchemas
                             ->label(__('shopper::forms.label.photo'))
                             ->avatar()
                             ->image()
+                            ->acceptedFileTypes(config('shopper.media.accepts_mime_types'))
                             ->maxSize(1024)
                             ->disk(config('shopper.media.storage.disk_name')),
                         Grid::make()

--- a/packages/admin/src/Livewire/Pages/Settings/General.php
+++ b/packages/admin/src/Livewire/Pages/Settings/General.php
@@ -132,11 +132,13 @@ class General extends Component implements HasActions, HasSchemas
                             ->label(__('shopper::forms.label.logo'))
                             ->avatar()
                             ->image()
+                            ->acceptedFileTypes(config('shopper.media.accepts_mime_types'))
                             ->maxSize(1024)
                             ->disk(config('shopper.media.storage.disk_name')),
                         FileUpload::make('cover')
                             ->label(__('shopper::forms.label.cover_photo'))
                             ->image()
+                            ->acceptedFileTypes(config('shopper.media.accepts_mime_types'))
                             ->maxSize(1024)
                             ->disk(config('shopper.media.storage.disk_name')),
                     ]),

--- a/tests/Admin/Livewire/Components/Account/ProfileTest.php
+++ b/tests/Admin/Livewire/Components/Account/ProfileTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Livewire\Livewire;
+use Shopper\Livewire\Components\Account\Profile;
+use Tests\Core\Stubs\User;
+
+uses(Tests\Admin\TestCase::class);
+
+beforeEach(function (): void {
+    $this->user = User::factory()->create();
+    $this->actingAs($this->user);
+});
+
+describe(Profile::class, function (): void {
+    it('can update the profile information', function (): void {
+        Livewire::test(Profile::class)
+            ->fillForm([
+                'first_name' => 'Arthur',
+                'last_name' => 'Monney',
+                'email' => $this->user->email,
+            ])
+            ->call('save')
+            ->assertHasNoFormErrors()
+            ->assertNotified();
+
+        expect($this->user->refresh())
+            ->first_name->toBe('Arthur')
+            ->last_name->toBe('Monney');
+    });
+
+    it('fills the form with only the editable profile fields', function (): void {
+        $component = Livewire::test(Profile::class);
+
+        expect(array_keys($component->get('data')))
+            ->toEqualCanonicalizing([
+                'avatar_location',
+                'first_name',
+                'last_name',
+                'email',
+                'phone_number',
+            ]);
+    });
+
+    it('rejects an SVG file for the avatar upload', function (): void {
+        Storage::fake(config('shopper.media.storage.disk_name'));
+
+        Livewire::test(Profile::class)
+            ->fillForm([
+                'avatar_location' => UploadedFile::fake()->createWithContent(
+                    'payload.svg',
+                    '<svg xmlns="http://www.w3.org/2000/svg" onload="alert(1)"></svg>'
+                ),
+            ])
+            ->call('save')
+            ->assertHasFormErrors(['avatar_location']);
+    });
+})->group('livewire', 'components', 'account');

--- a/tests/Admin/Livewire/Pages/Settings/GeneralTest.php
+++ b/tests/Admin/Livewire/Pages/Settings/GeneralTest.php
@@ -74,4 +74,21 @@ describe(General::class, function (): void {
 
         Storage::disk($disk)->assertExists($logo);
     });
+
+    it('rejects an SVG file for the logo and cover uploads', function (): void {
+        Storage::fake(config('shopper.media.storage.disk_name'));
+
+        $svg = UploadedFile::fake()->createWithContent(
+            'payload.svg',
+            '<svg xmlns="http://www.w3.org/2000/svg" onload="alert(1)"></svg>'
+        );
+
+        Livewire::test(General::class)
+            ->fillForm([
+                'logo' => $svg,
+                'cover' => $svg,
+            ])
+            ->call('store')
+            ->assertHasFormErrors(['logo', 'cover']);
+    });
 })->group('livewire', 'settings');


### PR DESCRIPTION
## Summary

Follow-up to #597, which restricted the product files media collection. The three plain Filament `FileUpload` fields were still open to the same class of bug: `->image()` alone accepts `image/*`, and Laravel's `mimetypes` rule matches `image/svg+xml` against it. Any authenticated staff account could upload an SVG with an embedded script as their avatar or as the store logo/cover, served same-origin from the public disk, resulting in stored XSS in the admin panel.

- `Account/Profile` (avatar), `Settings/General` (logo, cover): the uploads now enforce `config('shopper.media.accepts_mime_types')`, the same jpeg/png/webp/avif allowlist used by every Spatie-managed media collection. SVG stays excluded by design.
- `Account/Profile::mount()` now fills the form with only the five editable fields instead of the full `toArray()`, which serialized the password hash, two factor secrets and remember token into the Livewire snapshot rendered in the DOM.

## Tests

New `ProfileTest` covering the profile update flow, the exact allowed form keys, and the SVG rejection on the avatar. `GeneralTest` gets an SVG rejection test for logo and cover. The SVG tests were verified to fail against the unpatched code.