### PR TITLE
fix(payment): guard the Stripe webhook against a missing secret and make refunds idempotent

### DIFF
--- a/packages/api/src/Http/Controllers/Payment/WebhookController.php
+++ b/packages/api/src/Http/Controllers/Payment/WebhookController.php
@@ -20,7 +20,7 @@ final class WebhookController
 
     public function __invoke(Request $request, string $driver): JsonResponse
     {
-        if (! in_array($driver, Payment::availableDrivers(), strict: true)) {
+        if (! in_array($driver, Payment::availableDrivers(), strict: true) || ! Payment::isConfigured($driver)) {
             abort(404);
         }
 

--- a/packages/payment/src/Contracts/PaymentDriver.php
+++ b/packages/payment/src/Contracts/PaymentDriver.php
@@ -50,9 +50,13 @@ interface PaymentDriver
     public function capturePayment(string $reference, ?int $amount = null): PaymentResult;
 
     /**
-     * Refund a captured payment (full or partial).
+     * Refund a captured payment (full or partial). A caller-supplied
+     * `idempotency_key` in the context must make a retried refund collapse
+     * into a single refund at the gateway.
+     *
+     * @param  array<string, mixed>  $context
      */
-    public function refundPayment(string $reference, int $amount, ?string $reason = null): PaymentResult;
+    public function refundPayment(string $reference, int $amount, ?string $reason = null, array $context = []): PaymentResult;
 
     /**
      * Cancel a non-captured payment.

--- a/packages/payment/src/Drivers/Driver.php
+++ b/packages/payment/src/Drivers/Driver.php
@@ -42,7 +42,7 @@ abstract class Driver implements PaymentDriver
         throw PaymentException::notSupported('capturePayment', $this->code());
     }
 
-    public function refundPayment(string $reference, int $amount, ?string $reason = null): PaymentResult
+    public function refundPayment(string $reference, int $amount, ?string $reason = null, array $context = []): PaymentResult
     {
         throw PaymentException::notSupported('refundPayment', $this->code());
     }

--- a/packages/payment/src/Services/PaymentProcessingService.php
+++ b/packages/payment/src/Services/PaymentProcessingService.php
@@ -135,7 +135,9 @@ final class PaymentProcessingService
         $paymentMethod = $order->paymentMethod;
         $driver = $this->resolveDriver($paymentMethod);
 
-        $result = $driver->refundPayment($reference, $amount, $reason);
+        $result = $driver->refundPayment($reference, $amount, $reason, [
+            'idempotency_key' => $this->refundIdempotencyKey($order, $reference, $amount),
+        ]);
 
         $this->recordTransaction(
             order: $order,
@@ -247,6 +249,22 @@ final class PaymentProcessingService
     private function resolveDriver(PaymentMethod $method): PaymentDriver
     {
         return Payment::driver($method->driver ?? 'manual');
+    }
+
+    /**
+     * A retried refund reuses the same key so the gateway collapses it into
+     * one refund: a timed-out attempt is never journalized, so the sequence
+     * is unchanged on retry, while every journalized attempt (successful or
+     * declined) moves the sequence forward for the next distinct refund.
+     */
+    private function refundIdempotencyKey(Order $order, string $reference, int $amount): string
+    {
+        $sequence = PaymentTransaction::query()
+            ->where('order_id', $order->getKey())
+            ->where('type', TransactionType::Refund)
+            ->count();
+
+        return "refund:{$order->getKey()}:{$reference}:{$amount}:{$sequence}";
     }
 
     private function syncPaymentStatus(Order $order, TransactionType $type, PaymentResult $result): void

--- a/packages/stripe/src/StripeDriver.php
+++ b/packages/stripe/src/StripeDriver.php
@@ -43,7 +43,7 @@ final class StripeDriver extends Driver
 
     public function isConfigured(): bool
     {
-        return filled($this->secretKey);
+        return filled($this->secretKey) && filled($this->webhookSecret);
     }
 
     public function mode(): ?PaymentMode
@@ -151,7 +151,7 @@ final class StripeDriver extends Driver
         }
     }
 
-    public function refundPayment(string $reference, int $amount, ?string $reason = null): PaymentResult
+    public function refundPayment(string $reference, int $amount, ?string $reason = null, array $context = []): PaymentResult
     {
         try {
             $params = [
@@ -164,7 +164,7 @@ final class StripeDriver extends Driver
             }
 
             $refund = $this->getClient()->refunds->create($params, [
-                'idempotency_key' => Str::uuid()->toString(),
+                'idempotency_key' => $context['idempotency_key'] ?? Str::uuid()->toString(),
             ]);
 
             return new PaymentResult(
@@ -223,6 +223,10 @@ final class StripeDriver extends Driver
 
     public function handleWebhook(array $payload, array $headers = []): WebhookResult
     {
+        if (! filled($this->webhookSecret)) {
+            throw StripeException::invalidWebhookPayload('The webhook secret is not configured.');
+        }
+
         $rawBody = $payload['_raw_body'] ?? '';
         $signature = $headers['stripe-signature'] ?? $headers['Stripe-Signature'] ?? '';
 

--- a/tests/Api/Feature/PaymentWebhookTest.php
+++ b/tests/Api/Feature/PaymentWebhookTest.php
@@ -44,6 +44,13 @@ it('returns 404 for an unknown driver', function (): void {
         ->assertNotFound();
 });
 
+it('returns 404 for a registered driver that is not configured', function (): void {
+    Payment::extend('unconfigured', fn (): FakePaymentDriver => new FakePaymentDriver(configured: false));
+
+    $this->postJson('/store/webhooks/unconfigured', ['action' => 'captured'])
+        ->assertNotFound();
+});
+
 it('rejects an unverified payload with a 400', function (): void {
     $this->postJson('/store/webhooks/fake', ['action' => 'invalid'])
         ->assertStatus(400);

--- a/tests/Api/Stubs/FakePaymentDriver.php
+++ b/tests/Api/Stubs/FakePaymentDriver.php
@@ -29,6 +29,10 @@ final class FakePaymentDriver extends Driver
     /** @var array<int, string> */
     public array $idempotencyKeys = [];
 
+    public function __construct(
+        private readonly bool $configured = true,
+    ) {}
+
     public function code(): string
     {
         return 'fake';
@@ -41,7 +45,7 @@ final class FakePaymentDriver extends Driver
 
     public function isConfigured(): bool
     {
-        return true;
+        return $this->configured;
     }
 
     public function initiatePayment(int $amount, string $currency, array $context = []): PaymentResult

--- a/tests/Payment/PaymentFailedDispatchTest.php
+++ b/tests/Payment/PaymentFailedDispatchTest.php
@@ -42,7 +42,7 @@ beforeEach(function (): void {
             return PaymentResult::failed('card_declined', $reference);
         }
 
-        public function refundPayment(string $reference, int $amount, ?string $reason = null): PaymentResult
+        public function refundPayment(string $reference, int $amount, ?string $reason = null, array $context = []): PaymentResult
         {
             return PaymentResult::failed('insufficient_funds', $reference);
         }

--- a/tests/Payment/RefundIdempotencyTest.php
+++ b/tests/Payment/RefundIdempotencyTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+use Shopper\Core\Models\Order;
+use Shopper\Core\Models\PaymentMethod;
+use Shopper\Payment\DataTransferObjects\PaymentResult;
+use Shopper\Payment\Drivers\Driver;
+use Shopper\Payment\Exceptions\PaymentException;
+use Shopper\Payment\Facades\Payment;
+use Shopper\Payment\Services\PaymentProcessingService;
+
+uses(Tests\Core\TestCase::class);
+
+beforeEach(function (): void {
+    $this->keys = collect();
+    $this->shouldTimeout = false;
+
+    $keys = $this->keys;
+    $shouldTimeout = fn (): bool => $this->shouldTimeout;
+
+    Payment::extend('recording', fn (): Driver => new class($keys, $shouldTimeout) extends Driver
+    {
+        public function __construct(
+            private readonly Illuminate\Support\Collection $keys,
+            private readonly Closure $shouldTimeout,
+        ) {}
+
+        public function code(): string
+        {
+            return 'recording';
+        }
+
+        public function name(): string
+        {
+            return 'Recording';
+        }
+
+        public function isConfigured(): bool
+        {
+            return true;
+        }
+
+        public function initiatePayment(int $amount, string $currency, array $context = []): PaymentResult
+        {
+            return new PaymentResult(success: true, status: 'pending', reference: 'pi_abc', amount: $amount);
+        }
+
+        public function refundPayment(string $reference, int $amount, ?string $reason = null, array $context = []): PaymentResult
+        {
+            $this->keys->push($context['idempotency_key'] ?? null);
+
+            if (($this->shouldTimeout)()) {
+                throw PaymentException::notSupported('timeout', $this->code());
+            }
+
+            return new PaymentResult(success: true, status: 'refunded', reference: $reference, amount: $amount);
+        }
+    });
+
+    $method = PaymentMethod::factory()->create(['driver' => 'recording']);
+    $this->order = Order::factory()->create(['payment_method_id' => $method->id, 'price_amount' => 5000]);
+    $this->service = resolve(PaymentProcessingService::class);
+});
+
+it('moves the refund idempotency key forward once a refund is journalized', function (): void {
+    $this->service->refund($this->order, 'pi_abc', amount: 1000);
+    $this->service->refund($this->order, 'pi_abc', amount: 1000);
+
+    expect($this->keys->all())->toBe([
+        "refund:{$this->order->id}:pi_abc:1000:0",
+        "refund:{$this->order->id}:pi_abc:1000:1",
+    ]);
+});
+
+it('reuses the same idempotency key when the previous attempt was never journalized', function (): void {
+    $this->shouldTimeout = true;
+
+    expect(fn () => $this->service->refund($this->order, 'pi_abc', amount: 1000))
+        ->toThrow(PaymentException::class);
+
+    $this->shouldTimeout = false;
+
+    $this->service->refund($this->order, 'pi_abc', amount: 1000);
+
+    expect($this->keys->unique()->count())->toBe(1);
+});

--- a/tests/Stripe/StripeDriverTest.php
+++ b/tests/Stripe/StripeDriverTest.php
@@ -89,6 +89,10 @@ describe(StripeDriver::class, function (): void {
             expect(createDriver(secretKey: '')->isConfigured())->toBeFalse();
         });
 
+        it('is not configured when webhook secret is empty', function (): void {
+            expect(createDriver(webhookSecret: '')->isConfigured())->toBeFalse();
+        });
+
         it('reports test mode when secret key starts with `sk_test_`', function (): void {
             expect(createDriver(secretKey: 'sk_test_abcdef')->mode())->toBe(PaymentMode::Test);
         });
@@ -398,6 +402,27 @@ describe(StripeDriver::class, function (): void {
                 ->and($result->data['payment_intent'])->toBe('pi_test_123');
         });
 
+        it('forwards the caller idempotency key so a retried refund collapses at Stripe', function (): void {
+            $driver = createDriver();
+            $mocks = injectMockClient($driver);
+
+            $refund = Refund::constructFrom([
+                'id' => 're_test_123',
+                'status' => 'succeeded',
+                'amount' => 5000,
+            ]);
+
+            $mocks->refunds->shouldReceive('create')
+                ->twice()
+                ->with(Mockery::type('array'), Mockery::on(
+                    fn (array $opts): bool => $opts['idempotency_key'] === 'refund:1:pi_test_123:5000:0'
+                ))
+                ->andReturn($refund);
+
+            $driver->refundPayment('pi_test_123', 5000, null, ['idempotency_key' => 'refund:1:pi_test_123:5000:0']);
+            $driver->refundPayment('pi_test_123', 5000, null, ['idempotency_key' => 'refund:1:pi_test_123:5000:0']);
+        });
+
         it('creates a partial refund with reason', function (): void {
             $driver = createDriver();
             $mocks = injectMockClient($driver);
@@ -609,6 +634,20 @@ describe(StripeDriver::class, function (): void {
     });
 
     describe('`handleWebhook()` method', function (): void {
+        it('rejects a webhook forged against an empty webhook secret', function (): void {
+            $driver = createDriver(webhookSecret: '');
+
+            $forged = webhookPayload('payment_intent.succeeded', [
+                'id' => 'pi_test_123',
+                'object' => 'payment_intent',
+                'amount' => 5000,
+                'amount_received' => 5000,
+            ], secret: '');
+
+            expect(fn () => $driver->handleWebhook($forged['payload'], $forged['headers']))
+                ->toThrow(StripeException::class);
+        });
+
         it('handles `payment_intent.succeeded` event', function (): void {
             $driver = createDriver();
             $webhook = webhookPayload('payment_intent.succeeded', [

--- a/tests/Stripe/StripeServiceProviderTest.php
+++ b/tests/Stripe/StripeServiceProviderTest.php
@@ -37,15 +37,23 @@ describe(StripeServiceProvider::class, function (): void {
         expect(Payment::isConfigured('stripe'))->toBeFalse();
     });
 
-    it('is configured when secret key is set', function (): void {
-        config()->set('shopper.stripe.secret_key', 'sk_test_123');
-
+    it('is configured when the secret key and the webhook secret are set', function (): void {
         $driver = new StripeDriver(
-            secretKey: (string) config('shopper.stripe.secret_key'),
+            secretKey: 'sk_test_123',
+            publishableKey: '',
+            webhookSecret: 'whsec_test_123',
+        );
+
+        expect($driver->isConfigured())->toBeTrue();
+    });
+
+    it('is not configured when the webhook secret is missing', function (): void {
+        $driver = new StripeDriver(
+            secretKey: 'sk_test_123',
             publishableKey: '',
             webhookSecret: '',
         );
 
-        expect($driver->isConfigured())->toBeTrue();
+        expect($driver->isConfigured())->toBeFalse();
     });
 })->group('stripe', 'payment');


### PR DESCRIPTION
## Summary

When `STRIPE_WEBHOOK_SECRET` is not set, the config silently resolves to an empty string and `Webhook::constructEvent()` verifies signatures against a publicly computable `hash_hmac(..., '')`. A merchant who configured the API keys but skipped the webhook endpoint setup was exposed: anyone holding a `payment_intent` id could forge a `payment_intent.succeeded` event and mark their order as paid.

Three layers close it:

- `StripeDriver::isConfigured()` now also requires the webhook secret. Fail closed by design: without it, payments could never be confirmed anyway since money movement is confirmed through webhooks.
- `StripeDriver::handleWebhook()` refuses to verify a signature against a blank secret, as defense in depth for custom drivers bypassing `isConfigured()`.
- `WebhookController` answers 404 for a registered but unconfigured driver, so the webhook route does not exist until the configuration is complete.

## Refund idempotency

The refund idempotency key was a random UUID, so a refund retried after a timeout created a second refund at Stripe. `PaymentProcessingService::refund()` now derives a deterministic key `refund:{order}:{reference}:{amount}:{sequence}` where the sequence counts the journalized refund transactions: a retry after a timed-out attempt (never journalized) reuses the same key and collapses at the gateway, while a legitimate second refund of the same amount moves the sequence forward.

## BC break (3.x beta)

`PaymentDriver::refundPayment()` gains an `array $context = []` parameter, mirroring `initiatePayment()`. Custom drivers overriding `refundPayment()` must add the parameter to their signature.

## Tests

The exact forgery scenario (signature computed against an empty secret) is asserted rejected, along with the unconfigured driver 404, the `isConfigured()` contract, and the idempotency key sequence behavior on retry and on distinct refunds.