### PR TITLE
feat(payment): guard payment status transitions and refund amounts

### DIFF
--- a/packages/admin/src/Livewire/Pages/Order/Detail.php
+++ b/packages/admin/src/Livewire/Pages/Order/Detail.php
@@ -19,7 +19,6 @@ use Shopper\Core\Enum\PaymentStatus;
 use Shopper\Core\Events\Orders\OrderArchived;
 use Shopper\Core\Events\Orders\OrderCancelled;
 use Shopper\Core\Events\Orders\OrderCompleted;
-use Shopper\Core\Events\Orders\OrderPaid;
 use Shopper\Core\Models\Contracts\Order;
 use Shopper\Livewire\Pages\AbstractPageComponent;
 use Shopper\Payment\Services\PaymentProcessingService;
@@ -103,7 +102,7 @@ class Detail extends AbstractPageComponent implements HasActions, HasSchemas
             ->authorize('orders.edit')
             ->visible($this->order->isPaymentPending() || $this->order->isPaymentAuthorized())
             ->action(function (): void {
-                $this->order->update(['payment_status' => PaymentStatus::Paid]);
+                $this->order->transitionPaymentTo(PaymentStatus::Paid);
 
                 if ($this->order->isNew()) {
                     $this->order->transitionTo(OrderStatus::Processing);
@@ -111,8 +110,6 @@ class Detail extends AbstractPageComponent implements HasActions, HasSchemas
 
                 $this->order->refresh();
                 $this->dispatch('order.updated');
-
-                event(new OrderPaid($this->order));
 
                 Notification::make()
                     ->title(__('shopper::pages/orders.notifications.paid'))

--- a/packages/core/src/Enum/PaymentStatus.php
+++ b/packages/core/src/Enum/PaymentStatus.php
@@ -35,6 +35,26 @@ enum PaymentStatus: string implements HasColor, HasIcon, HasLabel
 
     case Voided = 'voided';
 
+    /**
+     * @return array<string, array<int, self>>
+     */
+    public static function transitions(): array
+    {
+        return [
+            self::Pending->value => [self::Authorized, self::Paid, self::Voided],
+            self::Authorized->value => [self::Paid, self::Voided],
+            self::Paid->value => [self::PartiallyRefunded, self::Refunded],
+            self::PartiallyRefunded->value => [self::PartiallyRefunded, self::Refunded],
+            self::Refunded->value => [],
+            self::Voided->value => [],
+        ];
+    }
+
+    public function canTransitionTo(self $status): bool
+    {
+        return in_array($status, self::transitions()[$this->value] ?? [], strict: true);
+    }
+
     public function getColor(): string
     {
         return match ($this) {

--- a/packages/core/src/Exceptions/InvalidPaymentStatusTransitionException.php
+++ b/packages/core/src/Exceptions/InvalidPaymentStatusTransitionException.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Core\Exceptions;
+
+use RuntimeException;
+use Shopper\Core\Enum\PaymentStatus;
+
+final class InvalidPaymentStatusTransitionException extends RuntimeException
+{
+    public static function between(PaymentStatus $from, PaymentStatus $to): self
+    {
+        return new self(sprintf(
+            'Cannot transition a payment from "%s" to "%s".',
+            $from->value,
+            $to->value,
+        ));
+    }
+}

--- a/packages/core/src/Models/Contracts/Order.php
+++ b/packages/core/src/Models/Contracts/Order.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Shopper\Core\Enum\OrderStatus;
+use Shopper\Core\Enum\PaymentStatus;
 
 interface Order
 {
@@ -18,6 +19,10 @@ interface Order
     public function canTransitionTo(OrderStatus $status): bool;
 
     public function transitionTo(OrderStatus $status): void;
+
+    public function canTransitionPaymentTo(PaymentStatus $status): bool;
+
+    public function transitionPaymentTo(PaymentStatus $status): void;
 
     public function canBeCancelled(): bool;
 

--- a/packages/core/src/Models/Order.php
+++ b/packages/core/src/Models/Order.php
@@ -22,6 +22,7 @@ use Shopper\Core\Models\Contracts\Order as OrderContract;
 use Shopper\Core\Models\Traits\HasPublicId;
 use Shopper\Core\Traits\HasModelContract;
 use Shopper\Core\Traits\HasOrderStatusTransitions;
+use Shopper\Core\Traits\HasPaymentStatusTransitions;
 
 /**
  * @property-read int $id
@@ -72,6 +73,7 @@ class Order extends Model implements OrderContract
 
     use HasModelContract;
     use HasOrderStatusTransitions;
+    use HasPaymentStatusTransitions;
     use HasPublicId;
     use SoftDeletes;
 

--- a/packages/core/src/Traits/HasPaymentStatusTransitions.php
+++ b/packages/core/src/Traits/HasPaymentStatusTransitions.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Core\Traits;
+
+use Shopper\Core\Enum\PaymentStatus;
+use Shopper\Core\Events\Orders\OrderPaid;
+use Shopper\Core\Exceptions\InvalidPaymentStatusTransitionException;
+
+trait HasPaymentStatusTransitions
+{
+    public function canTransitionPaymentTo(PaymentStatus $status): bool
+    {
+        return $this->payment_status->canTransitionTo($status);
+    }
+
+    public function transitionPaymentTo(PaymentStatus $status): void
+    {
+        if (! $this->canTransitionPaymentTo($status)) {
+            throw InvalidPaymentStatusTransitionException::between($this->payment_status, $status);
+        }
+
+        $this->update(['payment_status' => $status]);
+
+        if ($status === PaymentStatus::Paid) {
+            event(new OrderPaid($this));
+        }
+    }
+}

--- a/packages/payment/database/migrations/2026_07_02_000001_add_user_id_to_payment_transactions_table.php
+++ b/packages/payment/database/migrations/2026_07_02_000001_add_user_id_to_payment_transactions_table.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Shopper\Core\Helpers\Migration;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table($this->getTableName('payment_transactions'), static function (Blueprint $table): void {
+            $table->unsignedBigInteger('user_id')->nullable()->after('payment_method_id');
+
+            $table->foreign('user_id')
+                ->references('id')
+                ->on('users')
+                ->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table($this->getTableName('payment_transactions'), static function (Blueprint $table): void {
+            $table->dropForeign(['user_id']);
+            $table->dropColumn('user_id');
+        });
+    }
+};

--- a/packages/payment/src/Exceptions/PaymentException.php
+++ b/packages/payment/src/Exceptions/PaymentException.php
@@ -32,4 +32,14 @@ class PaymentException extends Exception
     {
         return new self("Webhook signature verification failed for [{$driver}].");
     }
+
+    public static function refundNotAllowed(string $status): self
+    {
+        return new self("Cannot refund an order whose payment is [{$status}].");
+    }
+
+    public static function refundExceedsRefundable(int $requested, int $refundable): self
+    {
+        return new self("Cannot refund {$requested}: only {$refundable} remains refundable on this order.");
+    }
 }

--- a/packages/payment/src/Models/PaymentTransaction.php
+++ b/packages/payment/src/Models/PaymentTransaction.php
@@ -29,6 +29,7 @@ use Shopper\Payment\Enum\TransactionType;
  * @property-read array<string, mixed>|null $metadata
  * @property-read ?int $order_id
  * @property-read ?int $payment_method_id
+ * @property-read ?int $user_id
  * @property-read CarbonInterface $created_at
  * @property-read CarbonInterface $updated_at
  * @property-read ?Order $order

--- a/packages/payment/src/Services/PaymentProcessingService.php
+++ b/packages/payment/src/Services/PaymentProcessingService.php
@@ -18,6 +18,7 @@ use Shopper\Payment\DataTransferObjects\WebhookResult;
 use Shopper\Payment\Enum\TransactionStatus;
 use Shopper\Payment\Enum\TransactionType;
 use Shopper\Payment\Events\PaymentFailed;
+use Shopper\Payment\Exceptions\PaymentException;
 use Shopper\Payment\Facades\Payment;
 use Shopper\Payment\Models\PaymentTransaction;
 
@@ -108,6 +109,15 @@ final class PaymentProcessingService
      */
     public function capture(Order $order, string $reference, ?int $amount = null): PaymentResult
     {
+        if ($order->payment_status === PaymentStatus::Paid) {
+            return new PaymentResult(
+                success: true,
+                status: 'captured',
+                reference: $reference,
+                amount: $amount ?? $order->price_amount,
+            );
+        }
+
         $paymentMethod = $order->paymentMethod;
         $driver = $this->resolveDriver($paymentMethod);
 
@@ -132,6 +142,8 @@ final class PaymentProcessingService
      */
     public function refund(Order $order, string $reference, int $amount, ?string $reason = null): PaymentResult
     {
+        $this->assertRefundable($order, $amount);
+
         $paymentMethod = $order->paymentMethod;
         $driver = $this->resolveDriver($paymentMethod);
 
@@ -285,22 +297,58 @@ final class PaymentProcessingService
             default => null,
         };
 
-        if ($newPaymentStatus !== null) {
-            $order->update(['payment_status' => $newPaymentStatus]);
+        // An invalid transition is skipped, not thrown: webhooks arrive out of
+        // order, and a late `captured` must never pull a refunded order back
+        // to paid. The transaction row above keeps the full audit trail.
+        if ($newPaymentStatus !== null && $order->canTransitionPaymentTo($newPaymentStatus)) {
+            $order->transitionPaymentTo($newPaymentStatus);
         }
     }
 
     private function determineRefundStatus(Order $order): PaymentStatus
     {
-        $totalRefunded = PaymentTransaction::query()
-            ->where('order_id', $order->id)
-            ->where('type', TransactionType::Refund)
+        return $this->refundedTotal($order) >= $this->capturedTotal($order)
+            ? PaymentStatus::Refunded
+            : PaymentStatus::PartiallyRefunded;
+    }
+
+    /**
+     * The domain guard on outgoing refunds, independent of any gateway-side
+     * backstop: the payment must be in a refundable state, and the cumulative
+     * refunds can never exceed what was captured. Orders marked paid manually
+     * carry no capture transaction, so the order total is the ceiling there.
+     */
+    private function assertRefundable(Order $order, int $amount): void
+    {
+        if (! in_array($order->payment_status, [PaymentStatus::Paid, PaymentStatus::PartiallyRefunded], strict: true)) {
+            throw PaymentException::refundNotAllowed($order->payment_status->value);
+        }
+
+        $refundable = $this->capturedTotal($order) - $this->refundedTotal($order);
+
+        if ($amount > $refundable) {
+            throw PaymentException::refundExceedsRefundable($amount, $refundable);
+        }
+    }
+
+    private function capturedTotal(Order $order): int
+    {
+        $captured = (int) PaymentTransaction::query()
+            ->where('order_id', $order->getKey())
+            ->where('type', TransactionType::Capture)
             ->where('status', TransactionStatus::Success)
             ->sum('amount');
 
-        return $totalRefunded >= $order->price_amount
-            ? PaymentStatus::Refunded
-            : PaymentStatus::PartiallyRefunded;
+        return $captured ?: $order->price_amount;
+    }
+
+    private function refundedTotal(Order $order): int
+    {
+        return (int) PaymentTransaction::query()
+            ->where('order_id', $order->getKey())
+            ->where('type', TransactionType::Refund)
+            ->where('status', TransactionStatus::Success)
+            ->sum('amount');
     }
 
     private function recordTransaction(
@@ -314,6 +362,7 @@ final class PaymentProcessingService
         PaymentTransaction::query()->create([
             'order_id' => $order->id,
             'payment_method_id' => $paymentMethod->id,
+            'user_id' => auth()->id(),
             'driver' => $driverCode,
             'type' => $type,
             'status' => $result->success ? TransactionStatus::Success : TransactionStatus::Failed,

--- a/tests/Core/Models/PaymentStatusTransitionTest.php
+++ b/tests/Core/Models/PaymentStatusTransitionTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Event;
+use Shopper\Core\Enum\PaymentStatus;
+use Shopper\Core\Events\Orders\OrderPaid;
+use Shopper\Core\Exceptions\InvalidPaymentStatusTransitionException;
+use Shopper\Core\Models\Order;
+
+uses(Tests\Core\TestCase::class);
+
+describe('PaymentStatus transitions', function (): void {
+    it('allows a `Pending` payment to be authorized, paid, or voided', function (): void {
+        expect(PaymentStatus::Pending->canTransitionTo(PaymentStatus::Authorized))->toBeTrue()
+            ->and(PaymentStatus::Pending->canTransitionTo(PaymentStatus::Paid))->toBeTrue()
+            ->and(PaymentStatus::Pending->canTransitionTo(PaymentStatus::Voided))->toBeTrue()
+            ->and(PaymentStatus::Pending->canTransitionTo(PaymentStatus::Refunded))->toBeFalse();
+    });
+
+    it('only allows a `Paid` payment to move toward refunds', function (): void {
+        expect(PaymentStatus::Paid->canTransitionTo(PaymentStatus::PartiallyRefunded))->toBeTrue()
+            ->and(PaymentStatus::Paid->canTransitionTo(PaymentStatus::Refunded))->toBeTrue()
+            ->and(PaymentStatus::Paid->canTransitionTo(PaymentStatus::Paid))->toBeFalse()
+            ->and(PaymentStatus::Paid->canTransitionTo(PaymentStatus::Pending))->toBeFalse()
+            ->and(PaymentStatus::Paid->canTransitionTo(PaymentStatus::Voided))->toBeFalse();
+    });
+
+    it('allows successive partial refunds', function (): void {
+        expect(PaymentStatus::PartiallyRefunded->canTransitionTo(PaymentStatus::PartiallyRefunded))->toBeTrue()
+            ->and(PaymentStatus::PartiallyRefunded->canTransitionTo(PaymentStatus::Refunded))->toBeTrue()
+            ->and(PaymentStatus::PartiallyRefunded->canTransitionTo(PaymentStatus::Paid))->toBeFalse();
+    });
+
+    it('treats `Refunded` and `Voided` as terminal states', function (): void {
+        expect(PaymentStatus::Refunded->canTransitionTo(PaymentStatus::Paid))->toBeFalse()
+            ->and(PaymentStatus::Refunded->canTransitionTo(PaymentStatus::Pending))->toBeFalse()
+            ->and(PaymentStatus::Voided->canTransitionTo(PaymentStatus::Paid))->toBeFalse()
+            ->and(PaymentStatus::Voided->canTransitionTo(PaymentStatus::Pending))->toBeFalse();
+    });
+});
+
+describe('Order::transitionPaymentTo', function (): void {
+    it('persists a valid transition', function (): void {
+        $order = Order::factory()->create(['payment_status' => PaymentStatus::Pending]);
+
+        $order->transitionPaymentTo(PaymentStatus::Authorized);
+
+        expect($order->refresh()->payment_status)->toBe(PaymentStatus::Authorized);
+    });
+
+    it('throws on an invalid transition and leaves the status untouched', function (): void {
+        $order = Order::factory()->create(['payment_status' => PaymentStatus::Refunded]);
+
+        expect(fn () => $order->transitionPaymentTo(PaymentStatus::Paid))
+            ->toThrow(InvalidPaymentStatusTransitionException::class);
+
+        expect($order->refresh()->payment_status)->toBe(PaymentStatus::Refunded);
+    });
+
+    it('dispatches `OrderPaid` when transitioning to `Paid`', function (): void {
+        Event::fake([OrderPaid::class]);
+
+        $order = Order::factory()->create(['payment_status' => PaymentStatus::Pending]);
+
+        $order->transitionPaymentTo(PaymentStatus::Paid);
+
+        Event::assertDispatched(
+            OrderPaid::class,
+            fn (OrderPaid $event): bool => $event->order->getKey() === $order->getKey(),
+        );
+    });
+
+    it('does not dispatch `OrderPaid` for other transitions', function (): void {
+        Event::fake([OrderPaid::class]);
+
+        $order = Order::factory()->create(['payment_status' => PaymentStatus::Pending]);
+
+        $order->transitionPaymentTo(PaymentStatus::Authorized);
+
+        Event::assertNotDispatched(OrderPaid::class);
+    });
+});

--- a/tests/Payment/PaymentFailedDispatchTest.php
+++ b/tests/Payment/PaymentFailedDispatchTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Illuminate\Support\Facades\Event;
+use Shopper\Core\Enum\PaymentStatus;
 use Shopper\Core\Models\Order;
 use Shopper\Core\Models\PaymentMethod;
 use Shopper\Payment\DataTransferObjects\PaymentResult;
@@ -53,7 +54,10 @@ it('dispatches `PaymentFailed` when a capture fails', function (): void {
     Event::fake([PaymentFailed::class]);
 
     $method = PaymentMethod::factory()->create(['driver' => 'failing']);
-    $order = Order::factory()->create(['payment_method_id' => $method->id]);
+    $order = Order::factory()->create([
+        'payment_method_id' => $method->id,
+        'payment_status' => PaymentStatus::Authorized,
+    ]);
 
     resolve(PaymentProcessingService::class)->capture($order, 'ref_123', amount: 1000);
 
@@ -67,7 +71,11 @@ it('dispatches `PaymentFailed` when a refund fails', function (): void {
     Event::fake([PaymentFailed::class]);
 
     $method = PaymentMethod::factory()->create(['driver' => 'failing']);
-    $order = Order::factory()->create(['payment_method_id' => $method->id]);
+    $order = Order::factory()->create([
+        'payment_method_id' => $method->id,
+        'price_amount' => 5000,
+        'payment_status' => PaymentStatus::Paid,
+    ]);
 
     resolve(PaymentProcessingService::class)->refund($order, 'ref_123', amount: 1000);
 

--- a/tests/Payment/PaymentWebhookProcessingTest.php
+++ b/tests/Payment/PaymentWebhookProcessingTest.php
@@ -2,10 +2,12 @@
 
 declare(strict_types=1);
 
+use Illuminate\Support\Facades\Event;
 use Shopper\Core\Contracts\StockReserver;
 use Shopper\Core\Enum\OrderStatus;
 use Shopper\Core\Enum\PaymentStatus;
 use Shopper\Core\Enum\ShippingStatus;
+use Shopper\Core\Events\Orders\OrderPaid;
 use Shopper\Core\Models\Inventory;
 use Shopper\Core\Models\Order;
 use Shopper\Core\Models\OrderItem;
@@ -82,6 +84,13 @@ describe('PaymentWebhookProcessingTest', function (): void {
 
     it('marks the order `PartiallyRefunded` then `Refunded` as refunds accumulate', function (): void {
         $this->service->processWebhook('fake', new WebhookResult(
+            action: 'captured',
+            reference: 'pi_123',
+            amount: 5000,
+            eventId: 'evt_capture',
+        ));
+
+        $this->service->processWebhook('fake', new WebhookResult(
             action: 'refunded',
             reference: 'pi_123',
             amount: 2000,
@@ -139,6 +148,83 @@ describe('PaymentWebhookProcessingTest', function (): void {
 
         expect($this->order->refresh()->status)->toBe(OrderStatus::Cancelled)
             ->and($product->getStock())->toBe(10);
+    });
+
+    it('keeps a refunded order refunded when a late captured event arrives', function (): void {
+        $this->service->processWebhook('fake', new WebhookResult(
+            action: 'captured',
+            reference: 'pi_123',
+            amount: 5000,
+            eventId: 'evt_late_1',
+        ));
+
+        $this->service->processWebhook('fake', new WebhookResult(
+            action: 'refunded',
+            reference: 'pi_123',
+            amount: 5000,
+            eventId: 'evt_late_2',
+        ));
+
+        expect($this->order->refresh()->payment_status)->toBe(PaymentStatus::Refunded);
+
+        $this->service->processWebhook('fake', new WebhookResult(
+            action: 'captured',
+            reference: 'pi_123',
+            amount: 5000,
+            eventId: 'evt_late_3',
+        ));
+
+        expect($this->order->refresh()->payment_status)->toBe(PaymentStatus::Refunded);
+    });
+
+    it('keeps a paid order paid when a late failed event arrives', function (): void {
+        $inventory = Inventory::factory()->create(['is_default' => true, 'priority' => 0]);
+        $product = Product::factory()->standard()->create();
+        $product->mutateStock($inventory->id, 10, event: 'Initial');
+
+        OrderItem::factory()->create([
+            'order_id' => $this->order->id,
+            'product_type' => $product->getMorphClass(),
+            'product_id' => $product->id,
+            'quantity' => 3,
+        ]);
+
+        resolve(StockReserver::class)->reserve($product, 3, $this->order, $this->user->id);
+
+        $this->service->processWebhook('fake', new WebhookResult(
+            action: 'captured',
+            reference: 'pi_123',
+            amount: 5000,
+            eventId: 'evt_ooo_1',
+        ));
+
+        $this->service->processWebhook('fake', new WebhookResult(
+            action: 'failed',
+            reference: 'pi_123',
+            amount: 5000,
+            data: ['failure_message' => 'late failure'],
+            eventId: 'evt_ooo_2',
+        ));
+
+        expect($this->order->refresh()->payment_status)->toBe(PaymentStatus::Paid)
+            ->and($this->order->status)->not->toBe(OrderStatus::Cancelled)
+            ->and($product->getStock())->toBe(7);
+    });
+
+    it('dispatches `OrderPaid` when a captured webhook marks the order paid', function (): void {
+        Event::fake([OrderPaid::class]);
+
+        $this->service->processWebhook('fake', new WebhookResult(
+            action: 'captured',
+            reference: 'pi_123',
+            amount: 5000,
+            eventId: 'evt_paid_event',
+        ));
+
+        Event::assertDispatched(
+            OrderPaid::class,
+            fn (OrderPaid $event): bool => $event->order->getKey() === $this->order->getKey(),
+        );
     });
 
     it('does nothing when no order matches the reference', function (): void {

--- a/tests/Payment/RefundGuardTest.php
+++ b/tests/Payment/RefundGuardTest.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+use Shopper\Core\Enum\PaymentStatus;
+use Shopper\Core\Models\Order;
+use Shopper\Core\Models\PaymentMethod;
+use Shopper\Payment\DataTransferObjects\PaymentResult;
+use Shopper\Payment\Drivers\Driver;
+use Shopper\Payment\Enum\TransactionStatus;
+use Shopper\Payment\Enum\TransactionType;
+use Shopper\Payment\Exceptions\PaymentException;
+use Shopper\Payment\Facades\Payment;
+use Shopper\Payment\Models\PaymentTransaction;
+use Shopper\Payment\Services\PaymentProcessingService;
+use Tests\Core\Stubs\User;
+
+uses(Tests\Core\TestCase::class);
+
+beforeEach(function (): void {
+    $this->driverCalls = collect();
+
+    $calls = $this->driverCalls;
+
+    Payment::extend('guarded', fn (): Driver => new class($calls) extends Driver
+    {
+        public function __construct(
+            private readonly Illuminate\Support\Collection $calls,
+        ) {}
+
+        public function code(): string
+        {
+            return 'guarded';
+        }
+
+        public function name(): string
+        {
+            return 'Guarded';
+        }
+
+        public function isConfigured(): bool
+        {
+            return true;
+        }
+
+        public function initiatePayment(int $amount, string $currency, array $context = []): PaymentResult
+        {
+            return new PaymentResult(success: true, status: 'pending', reference: 'pi_guard', amount: $amount);
+        }
+
+        public function capturePayment(string $reference, ?int $amount = null): PaymentResult
+        {
+            $this->calls->push('capture');
+
+            return new PaymentResult(success: true, status: 'captured', reference: $reference, amount: $amount);
+        }
+
+        public function refundPayment(string $reference, int $amount, ?string $reason = null, array $context = []): PaymentResult
+        {
+            $this->calls->push('refund');
+
+            return new PaymentResult(success: true, status: 'refunded', reference: $reference, amount: $amount);
+        }
+    });
+
+    $this->method = PaymentMethod::factory()->create(['driver' => 'guarded']);
+    $this->service = resolve(PaymentProcessingService::class);
+});
+
+function paidOrder(PaymentMethod $method, int $amount = 5000): Order
+{
+    $order = Order::factory()->create([
+        'payment_method_id' => $method->id,
+        'price_amount' => $amount,
+        'currency_code' => 'USD',
+        'payment_status' => PaymentStatus::Paid,
+    ]);
+
+    PaymentTransaction::query()->create([
+        'order_id' => $order->id,
+        'payment_method_id' => $method->id,
+        'driver' => 'guarded',
+        'type' => TransactionType::Capture,
+        'status' => TransactionStatus::Success,
+        'amount' => $amount,
+        'currency_code' => 'USD',
+        'reference' => 'pi_guard',
+    ]);
+
+    return $order;
+}
+
+it('rejects a refund on an order that was never paid', function (): void {
+    $order = Order::factory()->create([
+        'payment_method_id' => $this->method->id,
+        'price_amount' => 5000,
+        'payment_status' => PaymentStatus::Pending,
+    ]);
+
+    expect(fn () => $this->service->refund($order, 'pi_guard', amount: 1000))
+        ->toThrow(PaymentException::class);
+
+    expect($this->driverCalls)->toBeEmpty();
+});
+
+it('rejects a refund exceeding the captured amount', function (): void {
+    $order = paidOrder($this->method);
+
+    expect(fn () => $this->service->refund($order, 'pi_guard', amount: 999999))
+        ->toThrow(PaymentException::class);
+
+    expect($this->driverCalls)->toBeEmpty();
+});
+
+it('rejects a refund exceeding what remains after previous refunds', function (): void {
+    $order = paidOrder($this->method);
+
+    $this->service->refund($order, 'pi_guard', amount: 3000);
+
+    expect(fn () => $this->service->refund($order, 'pi_guard', amount: 3000))
+        ->toThrow(PaymentException::class);
+
+    expect($this->driverCalls->all())->toBe(['refund']);
+});
+
+it('allows refunding exactly the remaining amount and marks the order refunded', function (): void {
+    $order = paidOrder($this->method);
+
+    $this->service->refund($order, 'pi_guard', amount: 3000);
+    $this->service->refund($order, 'pi_guard', amount: 2000);
+
+    expect($order->refresh()->payment_status)->toBe(PaymentStatus::Refunded);
+});
+
+it('caps the refund at the order total for a manually marked paid order', function (): void {
+    $order = Order::factory()->create([
+        'payment_method_id' => $this->method->id,
+        'price_amount' => 5000,
+        'currency_code' => 'USD',
+        'payment_status' => PaymentStatus::Paid,
+    ]);
+
+    expect(fn () => $this->service->refund($order, 'pi_guard', amount: 5001))
+        ->toThrow(PaymentException::class);
+
+    $this->service->refund($order, 'pi_guard', amount: 5000);
+
+    expect($order->refresh()->payment_status)->toBe(PaymentStatus::Refunded);
+});
+
+it('short-circuits a capture on an already paid order without calling the driver', function (): void {
+    $order = paidOrder($this->method);
+
+    $result = $this->service->capture($order, 'pi_guard');
+
+    expect($result->success)->toBeTrue()
+        ->and($this->driverCalls)->toBeEmpty()
+        ->and(PaymentTransaction::query()->where('order_id', $order->id)->where('type', TransactionType::Capture)->count())->toBe(1);
+});
+
+it('records the acting user on payment transactions', function (): void {
+    $order = paidOrder($this->method);
+    $admin = User::factory()->create();
+    $this->actingAs($admin);
+
+    $this->service->refund($order, 'pi_guard', amount: 1000);
+
+    $refund = PaymentTransaction::query()
+        ->where('order_id', $order->id)
+        ->where('type', TransactionType::Refund)
+        ->first();
+
+    expect($refund->user_id)->toBe($admin->id);
+});

--- a/tests/Payment/RefundIdempotencyTest.php
+++ b/tests/Payment/RefundIdempotencyTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Shopper\Core\Enum\PaymentStatus;
 use Shopper\Core\Models\Order;
 use Shopper\Core\Models\PaymentMethod;
 use Shopper\Payment\DataTransferObjects\PaymentResult;
@@ -59,7 +60,11 @@ beforeEach(function (): void {
     });
 
     $method = PaymentMethod::factory()->create(['driver' => 'recording']);
-    $this->order = Order::factory()->create(['payment_method_id' => $method->id, 'price_amount' => 5000]);
+    $this->order = Order::factory()->create([
+        'payment_method_id' => $method->id,
+        'price_amount' => 5000,
+        'payment_status' => PaymentStatus::Paid,
+    ]);
     $this->service = resolve(PaymentProcessingService::class);
 });
 


### PR DESCRIPTION
## Summary

`PaymentStatus` had no transition rules: every write was a raw `update(['payment_status' => ...])`, so a late `captured` webhook silently pulled a refunded order back to paid, and `refund()` forwarded any amount to the driver with no domain ceiling.

- `PaymentStatus::transitions()` + a guarded `transitionPaymentTo()` on the order, mirroring the existing `OrderStatus` state machine. `Refunded` and `Voided` are terminal; `PartiallyRefunded` allows successive partial refunds.
- `OrderPaid` is now emitted from the transition itself. It previously fired only from the manual admin action, so a real Stripe capture or webhook never triggered the paid notification or any automation keyed on it. Every path that marks an order paid now emits it exactly once.
- Webhook processing skips invalid transitions instead of applying them: out-of-order deliveries (`captured` after `refunded`, `failed` after `captured`) no longer corrupt the payment state or restore stock on a paid order. The transaction row is still journalized for the audit trail.
- `refund()` enforces a domain ceiling before calling the driver: the payment must be `Paid` or `PartiallyRefunded`, and the cumulative refunds can never exceed the captured total (the order total for manually marked paid orders). Independent of any gateway-side backstop.
- `capture()` short-circuits on an already paid order without a driver call.
- `payment_transactions` gains a nullable `user_id` recording the acting user, so refunds and captures are attributable. Webhook-driven rows stay null.

## BC breaks (3.x beta)

- `Shopper\Core\Models\Contracts\Order` gains `canTransitionPaymentTo()` and `transitionPaymentTo()`. Custom order models extending the base model inherit them; standalone implementations must add them.
- Direct `update(['payment_status' => ...])` writes still work but bypass the guard; the service and the admin panel now route through the transition.

## Tests

The transition matrix, the out-of-order webhook scenarios (late captured on a refunded order, late failed on a paid order with stock kept), the refund ceiling (over-refund, refund on a never-paid order, exact remaining amount, manual-paid cap), the capture short-circuit, the `OrderPaid` emission from webhooks, and the actor recording. Two existing tests encoding the pre-guard contract were updated: a gateway refund now requires a prior capture, and orders pin an explicit payment status instead of the factory's random one.