### PR TITLE
fix(orders): derive order numbers from the row id and enforce uniqueness

### DIFF
--- a/packages/core/database/migrations/2026_07_02_000002_enforce_unique_order_numbers.php
+++ b/packages/core/database/migrations/2026_07_02_000002_enforce_unique_order_numbers.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Shopper\Core\Helpers\Migration;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $ordersTable = $this->getTableName('orders');
+
+        $duplicatedNumbers = DB::table($ordersTable)
+            ->select('number')
+            ->groupBy('number')
+            ->havingRaw('COUNT(*) > 1')
+            ->pluck('number');
+
+        foreach ($duplicatedNumbers as $number) {
+            DB::table($ordersTable)
+                ->where('number', $number)
+                ->orderBy('id')
+                ->skip(1)
+                ->take(PHP_INT_MAX)
+                ->pluck('id')
+                ->each(function (int $orderId) use ($ordersTable, $number): void {
+                    DB::table($ordersTable)
+                        ->where('id', $orderId)
+                        ->update(['number' => "{$number}-{$orderId}"]);
+                });
+        }
+
+        Schema::table($ordersTable, static function (Blueprint $table): void {
+            $table->string('number', 32)->nullable()->change();
+            $table->unique('number');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table($this->getTableName('orders'), static function (Blueprint $table): void {
+            $table->dropUnique(['number']);
+            $table->string('number', 32)->nullable(false)->change();
+        });
+    }
+};

--- a/packages/core/src/Models/Order.php
+++ b/packages/core/src/Models/Order.php
@@ -26,7 +26,7 @@ use Shopper\Core\Traits\HasOrderStatusTransitions;
 /**
  * @property-read int $id
  * @property-read ?string $public_id
- * @property-read string $number
+ * @property-read ?string $number
  * @property-read int $price_amount
  * @property-read ?int $tax_amount
  * @property-read ?int $shipping_amount
@@ -302,9 +302,12 @@ class Order extends Model implements OrderContract
 
     protected static function booted(): void
     {
-        static::creating(function (Order $order): void {
+        // The number derives from the row's own id after insert, so two
+        // concurrent checkouts can never generate the same number the way a
+        // max-plus-one read in `creating` could. The unique index backs it up.
+        static::created(function (Order $order): void {
             if (blank($order->getAttribute('number'))) {
-                $order->setAttribute('number', generate_number());
+                $order->updateQuietly(['number' => generate_number($order->id)]);
             }
         });
     }

--- a/packages/core/src/helpers.php
+++ b/packages/core/src/helpers.php
@@ -5,21 +5,19 @@ declare(strict_types=1);
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Number;
 use Shopper\Core\Models\Currency;
-use Shopper\Core\Models\Order;
 use Shopper\Core\Models\Setting;
 
 if (! function_exists('generate_number')) {
-    function generate_number(): string
+    /**
+     * Formats an order number from a caller-supplied sequence. The sequence
+     * must come from a source that is unique under concurrency, such as the
+     * order's own auto-increment id, never from a max-plus-one read.
+     */
+    function generate_number(int $sequence): string
     {
-        /** @var ?Order $lastOrder */
-        $lastOrder = Order::query()->orderBy('id', 'desc')
-            ->limit(1)
-            ->first();
-
         $generator = config('shopper.orders.generator');
 
-        $last = $lastOrder ? $lastOrder->id : 0;
-        $next = $generator['start_sequence_from'] + $last;
+        $next = $generator['start_sequence_from'] + $sequence;
 
         $separator = $generator['separator'];
         $sequence = mb_str_pad((string) $next, $generator['pad_length'], $generator['pad_string'], \STR_PAD_LEFT);

--- a/tests/Core/Models/OrderNumberTest.php
+++ b/tests/Core/Models/OrderNumberTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\QueryException;
+use Shopper\Core\Models\Order;
+
+uses(Tests\Core\TestCase::class);
+
+describe('Order number generation', function (): void {
+    it('fills a formatted number from the order own id on creation', function (): void {
+        $order = Order::factory()->create(['number' => null]);
+
+        $generator = config('shopper.orders.generator');
+        $sequence = mb_str_pad(
+            (string) ($generator['start_sequence_from'] + $order->id),
+            $generator['pad_length'],
+            $generator['pad_string'],
+            STR_PAD_LEFT,
+        );
+
+        expect($order->refresh()->number)
+            ->toBe(implode($generator['separator'], [$generator['prefix'], date($generator['date_format']), $sequence]));
+    });
+
+    it('generates distinct numbers for successive orders', function (): void {
+        $first = Order::factory()->create(['number' => null]);
+        $second = Order::factory()->create(['number' => null]);
+
+        expect($first->refresh()->number)->not->toBe($second->refresh()->number);
+    });
+
+    it('keeps an explicitly provided number untouched', function (): void {
+        $order = Order::factory()->create(['number' => 'CUSTOM-001']);
+
+        expect($order->refresh()->number)->toBe('CUSTOM-001');
+    });
+
+    it('rejects a duplicate number at the database level', function (): void {
+        Order::factory()->create(['number' => 'DUP-001']);
+
+        expect(fn () => Order::factory()->create(['number' => 'DUP-001']))
+            ->toThrow(QueryException::class);
+    });
+})->group('core', 'orders');


### PR DESCRIPTION
## Summary

`generate_number()` read `MAX(id) + offset` in the `creating` hook: two concurrent checkouts read the same last id and produced the same invoice number, and nothing at the database level prevented storing the duplicate. Order numbers are financial record identifiers, so a silent collision under load corrupts accounting and order lookups.

- The number now derives from the row's own auto-increment id in the `created` hook, so it is unique by construction with no read-then-write window. The format is unchanged.
- `orders.number` gains a unique index as the database backstop, including for explicitly provided numbers. The migration deduplicates existing rows first (a `-{id}` suffix on later duplicates, keeping the oldest untouched) and makes the column nullable since the number only exists after the insert.

## BC breaks (3.x beta)

- `generate_number()` now requires the sequence as a parameter instead of reading the last order itself; its only caller was the order model hook.
- `orders.number` becomes nullable at the schema level; it is filled in the same transaction as the insert on every creation path.

## Tests

The generated format from the row id, distinct numbers for successive orders, an explicit number kept untouched, and a duplicate number rejected by the unique index.