### PR TITLE
feat(stock): snapshot stock levels alongside the inventory ledger

### DIFF
--- a/packages/admin/src/Livewire/Components/Products/VariantStock.php
+++ b/packages/admin/src/Livewire/Components/Products/VariantStock.php
@@ -20,7 +20,6 @@ use Livewire\Attributes\Locked;
 use Livewire\Component;
 use Mckenziearts\Icons\Untitledui\Enums\Untitledui;
 use Shopper\Core\Models\Inventory;
-use Shopper\Core\Models\InventoryHistory;
 use Shopper\Traits\HandlesAuthorizationExceptions;
 
 /**
@@ -59,29 +58,23 @@ class VariantStock extends Component implements HasActions, HasSchemas
             ->action(function (array $data): void {
                 $inventoryId = (int) $data['inventory'];
                 $quantity = (int) $data['quantity'];
+                $currentStock = $this->variant->stockInventory($inventoryId);
 
-                $currentStock = InventoryHistory::query()
-                    ->where('inventory_id', $inventoryId)
-                    ->where('stockable_id', $this->variant->id)
-                    ->where('stockable_type', config('shopper.models.variant'))
-                    ->get()
-                    ->sum('quantity');
-
-                $realTimeStock = $currentStock + $quantity;
-
-                if ($realTimeStock >= $currentStock) {
+                if ($quantity >= 0) {
                     $this->variant->mutateStock(
                         inventoryId: $inventoryId,
                         quantity: $quantity,
-                        oldQuantity: $quantity,
+                        oldQuantity: $currentStock,
                         event: __('shopper::pages/products.inventory.add'),
+                        userId: auth()->id(),
                     );
                 } else {
                     $this->variant->decreaseStock(
                         inventoryId: $inventoryId,
                         quantity: $quantity,
-                        oldQuantity: $quantity,
+                        oldQuantity: $currentStock,
                         event: __('shopper::pages/products.inventory.remove'),
+                        userId: auth()->id(),
                     );
                 }
 

--- a/packages/admin/src/Livewire/Pages/Product/Inventory.php
+++ b/packages/admin/src/Livewire/Pages/Product/Inventory.php
@@ -151,28 +151,23 @@ class Inventory extends Component implements HasActions, HasSchemas, HasTable
                     ->action(function (array $data): void {
                         $inventoryId = (int) $data['inventory'];
                         $quantity = (int) $data['quantity'];
-                        $currentStock = InventoryHistory::query()
-                            ->where('inventory_id', $inventoryId)
-                            ->where('stockable_id', $this->product->id)
-                            ->where('stockable_type', 'product')
-                            ->get()
-                            ->sum('quantity');
+                        $currentStock = $this->product->stockInventory($inventoryId);
 
-                        $realTimeStock = $currentStock + $quantity;
-
-                        if ($realTimeStock >= $currentStock) {
+                        if ($quantity >= 0) {
                             $this->product->mutateStock(
                                 inventoryId: $inventoryId,
                                 quantity: $quantity,
-                                oldQuantity: $quantity,
+                                oldQuantity: $currentStock,
                                 event: __('shopper::pages/products.inventory.add'),
+                                userId: auth()->id(),
                             );
                         } else {
                             $this->product->decreaseStock(
                                 inventoryId: $inventoryId,
                                 quantity: $quantity,
-                                oldQuantity: $quantity,
+                                oldQuantity: $currentStock,
                                 event: __('shopper::pages/products.inventory.remove'),
+                                userId: auth()->id(),
                             );
                         }
 

--- a/packages/api/src/Concerns/LoadsStock.php
+++ b/packages/api/src/Concerns/LoadsStock.php
@@ -7,7 +7,6 @@ namespace Shopper\Api\Concerns;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Query\JoinClause;
-use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Shopper\Core\Enum\ProductType;
 use Shopper\Core\Models\Contracts\ProductVariant;
@@ -85,19 +84,18 @@ trait LoadsStock
         /** @var Model $variant */
         $variant = resolve(ProductVariant::class);
         $variantsTable = $variant->getTable();
-        $historiesTable = shopper_table('inventory_histories');
+        $levelsTable = shopper_table('stock_levels');
 
         $aggregates = $variant->newQuery()
             ->toBase()
-            ->leftJoin($historiesTable, function (JoinClause $join) use ($historiesTable, $variantsTable, $variant): void {
-                $join->on($historiesTable.'.stockable_id', '=', $variantsTable.'.id')
-                    ->where($historiesTable.'.stockable_type', $variant->getMorphClass())
-                    ->where($historiesTable.'.created_at', '<=', Carbon::now());
+            ->leftJoin($levelsTable, function (JoinClause $join) use ($levelsTable, $variantsTable, $variant): void {
+                $join->on($levelsTable.'.stockable_id', '=', $variantsTable.'.id')
+                    ->where($levelsTable.'.stockable_type', $variant->getMorphClass());
             })
             ->whereIn($variantsTable.'.product_id', $products->map(fn (Model $product) => $product->getKey()))
             ->groupBy($variantsTable.'.product_id')
             ->selectRaw($variantsTable.'.product_id as product_id')
-            ->selectRaw('COALESCE(SUM('.$historiesTable.'.quantity), 0) as variants_stock')
+            ->selectRaw('COALESCE(SUM('.$levelsTable.'.quantity), 0) as variants_stock')
             ->selectRaw('MAX(CASE WHEN '.$variantsTable.'.allow_backorder THEN 1 ELSE 0 END) as variants_allow_backorder')
             ->get()
             ->keyBy('product_id');

--- a/packages/cart/src/Actions/CreateOrderFromCartAction.php
+++ b/packages/cart/src/Actions/CreateOrderFromCartAction.php
@@ -101,7 +101,12 @@ final readonly class CreateOrderFromCartAction
             $cart->lines->load('taxLines');
             $orderTaxLines = [];
 
-            foreach ($cart->lines as $line) {
+            $lines = $cart->lines->sortBy([
+                ['purchasable_type', 'asc'],
+                ['purchasable_id', 'asc'],
+            ])->values();
+
+            foreach ($lines as $line) {
                 $discountAmount = $line->adjustments->sum('amount');
                 $purchasable = $line->purchasable;
                 $taxLines = $line->taxLines;
@@ -117,9 +122,6 @@ final readonly class CreateOrderFromCartAction
                     'product_id' => $line->purchasable_id,
                 ]);
 
-                // The order's tax lines are the exact rows the pipelines wrote
-                // under the cart lock, never a recomputation: the invoice
-                // breakdown always reconciles with the total charged.
                 foreach ($taxLines as $taxLine) {
                     $orderTaxLines[] = [
                         'taxable_type' => $item->getMorphClass(),
@@ -134,9 +136,6 @@ final readonly class CreateOrderFromCartAction
                     ];
                 }
 
-                // Reserve stock under a row lock inside the order transaction:
-                // a shortfall aborts the whole checkout so two buyers can never
-                // both claim the last unit. Back-ordered lines always reserve.
                 if ($purchasable instanceof Stockable && $purchasable->tracksInventory()) {
                     $reserved = $this->stockReserver->reserve(
                         $purchasable,

--- a/packages/core/database/migrations/2026_07_02_000003_create_stock_levels_table.php
+++ b/packages/core/database/migrations/2026_07_02_000003_create_stock_levels_table.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Shopper\Core\Helpers\Migration;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create($this->getTableName('stock_levels'), function (Blueprint $table): void {
+            $table->id();
+            $table->string('stockable_type');
+            $table->unsignedBigInteger('stockable_id');
+            $table->integer('quantity')->default(0);
+            $table->timestamps();
+
+            $this->addForeignKey($table, 'inventory_id', $this->getTableName('inventories'));
+
+            $table->unique(['stockable_type', 'stockable_id', 'inventory_id']);
+        });
+
+        $this->backfillFromLedger();
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists($this->getTableName('stock_levels'));
+    }
+
+    private function backfillFromLedger(): void
+    {
+        $now = now();
+
+        DB::table($this->getTableName('inventory_histories'))
+            ->selectRaw('stockable_type, stockable_id, inventory_id, SUM(quantity) as quantity')
+            ->groupBy('stockable_type', 'stockable_id', 'inventory_id')
+            ->orderBy('stockable_type')
+            ->orderBy('stockable_id')
+            ->orderBy('inventory_id')
+            ->chunk(1000, function ($levels) use ($now): void {
+                DB::table($this->getTableName('stock_levels'))->insert(
+                    $levels->map(fn (object $level): array => [
+                        'stockable_type' => $level->stockable_type,
+                        'stockable_id' => $level->stockable_id,
+                        'inventory_id' => $level->inventory_id,
+                        'quantity' => (int) $level->quantity,
+                        'created_at' => $now,
+                        'updated_at' => $now,
+                    ])->all(),
+                );
+            });
+    }
+};

--- a/packages/core/database/migrations/2026_07_02_000004_add_released_at_to_inventory_histories_table.php
+++ b/packages/core/database/migrations/2026_07_02_000004_add_released_at_to_inventory_histories_table.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Shopper\Core\Helpers\Migration;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table($this->getTableName('inventory_histories'), static function (Blueprint $table): void {
+            $table->timestamp('released_at')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table($this->getTableName('inventory_histories'), static function (Blueprint $table): void {
+            $table->dropColumn('released_at');
+        });
+    }
+};

--- a/packages/core/src/Console/ReconcileStockLevelsCommand.php
+++ b/packages/core/src/Console/ReconcileStockLevelsCommand.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Core\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Shopper\Core\Models\StockLevel;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+#[AsCommand(name: 'shopper:stock:reconcile')]
+final class ReconcileStockLevelsCommand extends Command
+{
+    protected $signature = 'shopper:stock:reconcile
+                            {--fix : Rewrite the drifted snapshot rows from the ledger}';
+
+    protected $description = 'Compare the stock level snapshot against the inventory ledger and report any drift';
+
+    public function handle(): int
+    {
+        $ledger = DB::table(shopper_table('inventory_histories'))
+            ->selectRaw('stockable_type, stockable_id, inventory_id, SUM(quantity) as quantity')
+            ->groupBy('stockable_type', 'stockable_id', 'inventory_id')
+            ->get()
+            ->keyBy(fn (object $row): string => "{$row->stockable_type}:{$row->stockable_id}:{$row->inventory_id}");
+
+        $levels = StockLevel::query()
+            ->get()
+            ->keyBy(fn (StockLevel $level): string => "{$level->stockable_type}:{$level->stockable_id}:{$level->inventory_id}");
+
+        $drifted = 0;
+
+        foreach ($ledger as $key => $row) {
+            $level = $levels->get($key);
+            $snapshot = $level instanceof StockLevel ? $level->quantity : 0;
+
+            if ($snapshot === (int) $row->quantity) {
+                continue;
+            }
+
+            $drifted++;
+            $this->components->warn("[{$key}] snapshot {$snapshot}, ledger {$row->quantity}");
+
+            if ($this->option('fix')) {
+                StockLevel::query()->updateOrCreate(
+                    [
+                        'stockable_type' => $row->stockable_type,
+                        'stockable_id' => $row->stockable_id,
+                        'inventory_id' => $row->inventory_id,
+                    ],
+                    ['quantity' => (int) $row->quantity],
+                );
+            }
+        }
+
+        foreach ($levels as $key => $level) {
+            if ($ledger->has($key) || $level->quantity === 0) {
+                continue;
+            }
+
+            $drifted++;
+            $this->components->warn("[{$key}] snapshot {$level->quantity}, ledger 0");
+
+            if ($this->option('fix')) {
+                $level->update(['quantity' => 0]);
+            }
+        }
+
+        if ($drifted === 0) {
+            $this->components->info('The stock snapshot matches the ledger.');
+
+            return self::SUCCESS;
+        }
+
+        $this->components->{$this->option('fix') ? 'info' : 'error'}(
+            $this->option('fix')
+                ? "{$drifted} drifted rows rewritten from the ledger."
+                : "{$drifted} drifted rows found. Run with --fix to rewrite them from the ledger.",
+        );
+
+        return $this->option('fix') ? self::SUCCESS : self::FAILURE;
+    }
+}

--- a/packages/core/src/CoreServiceProvider.php
+++ b/packages/core/src/CoreServiceProvider.php
@@ -6,6 +6,7 @@ namespace Shopper\Core;
 
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Relations\Relation;
+use Shopper\Core\Console\ReconcileStockLevelsCommand;
 use Shopper\Core\Console\SyncCollectionsCommand;
 use Shopper\Core\Contracts\InventoryResolver;
 use Shopper\Core\Contracts\StockAllocator;
@@ -58,6 +59,7 @@ final class CoreServiceProvider extends PackageServiceProvider
             ->name('shopper-core')
             ->hasTranslations()
             ->hasCommands([
+                ReconcileStockLevelsCommand::class,
                 SyncCollectionsCommand::class,
             ]);
     }

--- a/packages/core/src/Listeners/Orders/RestoreOrderStockListener.php
+++ b/packages/core/src/Listeners/Orders/RestoreOrderStockListener.php
@@ -5,11 +5,18 @@ declare(strict_types=1);
 namespace Shopper\Core\Listeners\Orders;
 
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Support\Facades\DB;
 use Shopper\Core\Events\Orders\OrderCancelled;
 use Shopper\Core\Models\Contracts\Stockable;
 
 final class RestoreOrderStockListener implements ShouldQueue
 {
+    /**
+     * Each reservation row is stamped `released_at` in the same transaction
+     * as its compensation, under a row lock: a queue retry after a partial
+     * run only compensates the rows the previous attempt never stamped, so
+     * the restock can never be applied twice.
+     */
     public function handle(OrderCancelled $event): void
     {
         $order = $event->order->load('items.product');
@@ -19,22 +26,27 @@ final class RestoreOrderStockListener implements ShouldQueue
                 continue;
             }
 
-            $reservations = $item->product->inventoryHistories()
-                ->where('reference_type', $order->getMorphClass())
-                ->where('reference_id', $order->getKey())
-                ->where('quantity', '<', 0)
-                ->get();
+            DB::transaction(function () use ($order, $item): void {
+                $reservations = $item->product->inventoryHistories()
+                    ->where('reference_type', $order->getMorphClass())
+                    ->where('reference_id', $order->getKey())
+                    ->where('quantity', '<', 0)
+                    ->whereNull('released_at')
+                    ->lockForUpdate()
+                    ->get();
 
-            foreach ($reservations as $reservation) {
-                $item->product->mutateStock(
-                    inventoryId: $reservation->inventory_id,
-                    quantity: abs($reservation->quantity),
-                    oldQuantity: $item->product->stockInventory($reservation->inventory_id),
-                    event: __('shopper-core::status.stock.cancelled'),
-                    userId: $order->customer_id,
-                    reference: $order,
-                );
-            }
+                foreach ($reservations as $reservation) {
+                    $item->product->mutateStock(
+                        inventoryId: $reservation->inventory_id,
+                        quantity: abs($reservation->quantity),
+                        oldQuantity: $item->product->stockInventory($reservation->inventory_id),
+                        event: __('shopper-core::status.stock.cancelled'),
+                        reference: $order,
+                    );
+
+                    $reservation->updateQuietly(['released_at' => now()]);
+                }
+            });
         }
     }
 }

--- a/packages/core/src/Models/InventoryHistory.php
+++ b/packages/core/src/Models/InventoryHistory.php
@@ -26,6 +26,7 @@ use Shopper\Core\Models\Contracts\InventoryHistory as InventoryHistoryContract;
  * @property-read int $stockable_id
  * @property-read string $reference_type
  * @property-read int $reference_id
+ * @property-read ?CarbonInterface $released_at
  * @property-read CarbonInterface $created_at
  * @property-read CarbonInterface $updated_at
  * @property-read Inventory $inventory

--- a/packages/core/src/Models/StockLevel.php
+++ b/packages/core/src/Models/StockLevel.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Core\Models;
+
+use Carbon\CarbonInterface;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+
+/**
+ * @property-read int $id
+ * @property-read string $stockable_type
+ * @property-read int $stockable_id
+ * @property-read int $inventory_id
+ * @property-read int $quantity
+ * @property-read CarbonInterface $created_at
+ * @property-read CarbonInterface $updated_at
+ * @property-read Inventory $inventory
+ */
+class StockLevel extends Model
+{
+    protected $guarded = [];
+
+    public function getTable(): string
+    {
+        return shopper_table('stock_levels');
+    }
+
+    /**
+     * @return MorphTo<Model, $this>
+     */
+    public function stockable(): MorphTo
+    {
+        return $this->morphTo();
+    }
+
+    /**
+     * @return BelongsTo<Inventory, $this>
+     */
+    public function inventory(): BelongsTo
+    {
+        return $this->belongsTo(Inventory::class);
+    }
+
+    protected function casts(): array
+    {
+        return [
+            'quantity' => 'integer',
+        ];
+    }
+}

--- a/packages/core/src/Models/Traits/HasStock.php
+++ b/packages/core/src/Models/Traits/HasStock.php
@@ -9,9 +9,12 @@ use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Database\QueryException;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
 use Shopper\Core\Exceptions\LazyStockLoadingException;
 use Shopper\Core\Models\InventoryHistory;
+use Shopper\Core\Models\StockLevel;
 
 trait HasStock
 {
@@ -36,11 +39,10 @@ trait HasStock
 
         $first = $models->first();
 
-        $stocks = InventoryHistory::query()
+        $stocks = StockLevel::query()
             ->selectRaw('stockable_id, SUM(quantity) as aggregate')
             ->where('stockable_type', $first->getMorphClass())
             ->whereIn('stockable_id', $models->pluck($first->getKeyName()))
-            ->where('created_at', '<=', Carbon::now())
             ->groupBy('stockable_id')
             ->pluck('aggregate', 'stockable_id');
 
@@ -62,14 +64,11 @@ trait HasStock
 
         $first = $models->first();
 
-        $stocks = InventoryHistory::query()
-            ->selectRaw('stockable_id, SUM(quantity) as aggregate')
+        $stocks = StockLevel::query()
             ->where('stockable_type', $first->getMorphClass())
             ->whereIn('stockable_id', $models->pluck($first->getKeyName()))
             ->where('inventory_id', $inventoryId)
-            ->where('created_at', '<=', Carbon::now())
-            ->groupBy('stockable_id')
-            ->pluck('aggregate', 'stockable_id');
+            ->pluck('quantity', 'stockable_id');
 
         $models->each(function (Model $model) use ($stocks): void {
             $model->setAttribute('real_stock', (int) ($stocks[$model->getKey()] ?? 0));
@@ -81,9 +80,16 @@ trait HasStock
         return $this->stock > 0 && $this->stock >= $quantity;
     }
 
+    /**
+     * The current stock is a single indexed read on the snapshot; the ledger
+     * is only replayed for point-in-time queries, so the cost of a stock read
+     * stays flat no matter how much movement history a product accumulates.
+     */
     public function getStock(string|DateTimeInterface|null $date = null): int
     {
-        $date = $date ?: Carbon::now();
+        if ($date === null) {
+            return (int) $this->stockLevels()->sum('quantity');
+        }
 
         if (! $date instanceof DateTimeInterface) {
             $date = Carbon::create($date);
@@ -96,14 +102,14 @@ trait HasStock
 
     public function stockInventory(int $inventoryId, ?string $date = null): int
     {
-        $date = $date ?: Carbon::now();
-
-        if (! $date instanceof DateTimeInterface) {
-            $date = Carbon::create($date);
+        if ($date === null) {
+            return (int) $this->stockLevels()
+                ->where('inventory_id', $inventoryId)
+                ->value('quantity');
         }
 
         return (int) $this->inventoryHistories()
-            ->where('created_at', '<=', $date->format('Y-m-d H:i:s'))
+            ->where('created_at', '<=', Carbon::create($date)->format('Y-m-d H:i:s'))
             ->where('inventory_id', $inventoryId)
             ->sum('quantity');
     }
@@ -142,6 +148,7 @@ trait HasStock
         ?Model $reference = null,
     ): bool {
         $this->inventoryHistories()->delete();
+        $this->stockLevels()->delete();
 
         if ($inventoryId && $newQuantity) {
             $this->createStockMutation($newQuantity, $inventoryId, $oldQuantity, $event, $description, $userId, $reference);
@@ -192,7 +199,13 @@ trait HasStock
             $createArguments['reference_id'] = $reference->getKey();
         }
 
-        return $this->inventoryHistories()->create($createArguments);
+        return DB::transaction(function () use ($createArguments, $inventoryId, $quantity): InventoryHistory {
+            $history = $this->inventoryHistories()->create($createArguments);
+
+            $this->applyToStockLevel($inventoryId, $quantity);
+
+            return $history;
+        });
     }
 
     /**
@@ -201,6 +214,40 @@ trait HasStock
     public function inventoryHistories(): MorphMany
     {
         return $this->morphMany(InventoryHistory::class, 'stockable');
+    }
+
+    /**
+     * @return MorphMany<StockLevel, $this>
+     */
+    public function stockLevels(): MorphMany
+    {
+        return $this->morphMany(StockLevel::class, 'stockable');
+    }
+
+    /**
+     * The snapshot moves with every ledger write, atomically: an increment on
+     * the existing row, or an insert raced against the unique index with one
+     * increment retry when another writer created the row first.
+     */
+    protected function applyToStockLevel(int $inventoryId, int $delta): void
+    {
+        $constraint = [
+            'stockable_type' => $this->getMorphClass(),
+            'stockable_id' => $this->getKey(),
+            'inventory_id' => $inventoryId,
+        ];
+
+        $updated = StockLevel::query()->where($constraint)->increment('quantity', $delta);
+
+        if ($updated > 0) {
+            return;
+        }
+
+        try {
+            StockLevel::query()->create([...$constraint, 'quantity' => $delta]);
+        } catch (QueryException) {
+            StockLevel::query()->where($constraint)->increment('quantity', $delta);
+        }
     }
 
     protected function stock(): Attribute

--- a/packages/upgrade/src/Console/UpgradeCommand.php
+++ b/packages/upgrade/src/Console/UpgradeCommand.php
@@ -41,17 +41,20 @@ final class UpgradeCommand extends Command
             }
         }
 
-        info('Step 1/4 — Running database migrations');
+        info('Step 1/5 — Running database migrations');
         $this->call('migrate', ['--force' => true]);
 
-        info('Step 2/4 — Renaming classes with Rector');
+        info('Step 2/5 — Renaming classes with Rector');
         $this->runRector();
 
-        info('Step 3/4 — Migrating permissions to dot notation');
+        info('Step 3/5 — Migrating permissions to dot notation');
         $this->call('shopper:upgrade:permissions', ['--force' => true]);
 
-        info('Step 4/4 — Fixing zero-decimal currency amounts');
+        info('Step 4/5 — Fixing zero-decimal currency amounts');
         $this->call('shopper:upgrade:fix-zero-decimal-currencies', ['--force' => true]);
+
+        info('Step 5/5 — Reconciling the stock snapshot against the inventory ledger');
+        $this->call('shopper:stock:reconcile', ['--fix' => true]);
 
         $this->printNextSteps();
 

--- a/tests/Core/Workflows/Stock/StockLevelTest.php
+++ b/tests/Core/Workflows/Stock/StockLevelTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+use Shopper\Core\Events\Orders\OrderCancelled;
+use Shopper\Core\Listeners\Orders\RestoreOrderStockListener;
+use Shopper\Core\Models\Inventory;
+use Shopper\Core\Models\Order;
+use Shopper\Core\Models\OrderItem;
+use Shopper\Core\Models\Product;
+use Shopper\Core\Models\StockLevel;
+
+uses(Tests\Core\TestCase::class);
+
+beforeEach(function (): void {
+    $this->inventory = Inventory::factory()->create(['is_default' => true, 'priority' => 0]);
+    $this->product = Product::factory()->standard()->create();
+});
+
+describe('Stock levels snapshot', function (): void {
+    it('keeps the snapshot in sync with every ledger mutation', function (): void {
+        $this->product->mutateStock($this->inventory->id, 10, event: 'Initial');
+        $this->product->decreaseStock($this->inventory->id, 3);
+        $this->product->mutateStock($this->inventory->id, 5);
+
+        $level = StockLevel::query()
+            ->where('stockable_type', $this->product->getMorphClass())
+            ->where('stockable_id', $this->product->id)
+            ->where('inventory_id', $this->inventory->id)
+            ->sole();
+
+        expect($level->quantity)->toBe(12)
+            ->and($this->product->getStock())->toBe(12)
+            ->and($this->product->stockInventory($this->inventory->id))->toBe(12);
+    });
+
+    it('reads the current stock without touching the ledger', function (): void {
+        $this->product->mutateStock($this->inventory->id, 10, event: 'Initial');
+
+        $this->product->inventoryHistories()->delete();
+
+        expect($this->product->getStock())->toBe(10);
+    });
+
+    it('still replays the ledger for point-in-time queries', function (): void {
+        $this->product->mutateStock($this->inventory->id, 10, event: 'Initial');
+        $this->product->inventoryHistories()->update(['created_at' => now()->subDays(10)]);
+        $this->product->decreaseStock($this->inventory->id, 4);
+
+        expect($this->product->getStock(now()->subDays(5)->toDateTimeString()))->toBe(10)
+            ->and($this->product->getStock())->toBe(6);
+    });
+
+    it('tracks one snapshot row per inventory location', function (): void {
+        $secondInventory = Inventory::factory()->create(['priority' => 1]);
+
+        $this->product->mutateStock($this->inventory->id, 10);
+        $this->product->mutateStock($secondInventory->id, 7);
+
+        expect($this->product->stockInventory($this->inventory->id))->toBe(10)
+            ->and($this->product->stockInventory($secondInventory->id))->toBe(7)
+            ->and($this->product->getStock())->toBe(17);
+    });
+
+    it('clears the snapshot together with the ledger', function (): void {
+        $this->product->mutateStock($this->inventory->id, 10);
+
+        $this->product->clearStock();
+
+        expect(StockLevel::query()->where('stockable_id', $this->product->id)->count())->toBe(0)
+            ->and($this->product->getStock())->toBe(0);
+    });
+
+    it('batch-loads the current stock from the snapshot', function (): void {
+        $other = Product::factory()->standard()->create();
+        $this->product->mutateStock($this->inventory->id, 10);
+        $other->mutateStock($this->inventory->id, 4);
+
+        $models = Product::query()->whereIn('id', [$this->product->id, $other->id])->get();
+        Product::loadCurrentStock($models);
+
+        expect($models->firstWhere('id', $this->product->id)->stock)->toBe(10)
+            ->and($models->firstWhere('id', $other->id)->stock)->toBe(4);
+    });
+});
+
+describe('Stock reconciliation', function (): void {
+    it('reports and fixes a drifted snapshot from the ledger', function (): void {
+        $this->product->mutateStock($this->inventory->id, 10, event: 'Initial');
+
+        StockLevel::query()
+            ->where('stockable_id', $this->product->id)
+            ->update(['quantity' => 99]);
+
+        $this->artisan('shopper:stock:reconcile')->assertFailed();
+        $this->artisan('shopper:stock:reconcile', ['--fix' => true])->assertSuccessful();
+
+        expect($this->product->getStock())->toBe(10);
+
+        $this->artisan('shopper:stock:reconcile')->assertSuccessful();
+    });
+});
+
+describe('Stock restore idempotence', function (): void {
+    it('restores the stock only once when the listener runs twice', function (): void {
+        $this->product->mutateStock($this->inventory->id, 10, event: 'Initial');
+
+        $order = Order::factory()->create();
+        OrderItem::factory()->create([
+            'order_id' => $order->id,
+            'product_type' => $this->product->getMorphClass(),
+            'product_id' => $this->product->id,
+            'quantity' => 3,
+        ]);
+
+        resolve(Shopper\Core\Contracts\StockReserver::class)->reserve($this->product, 3, $order);
+        expect($this->product->getStock())->toBe(7);
+
+        $listener = new RestoreOrderStockListener;
+        $listener->handle(new OrderCancelled($order));
+        $listener->handle(new OrderCancelled($order));
+
+        expect($this->product->refresh()->getStock())->toBe(10);
+    });
+});

--- a/tests/Core/Workflows/Stock/StockRestorationTest.php
+++ b/tests/Core/Workflows/Stock/StockRestorationTest.php
@@ -135,12 +135,12 @@ describe('StockRestorationTest', function (): void {
             ->orderBy('id')
             ->get();
 
-        // One reservation (-6) + one restoration (+6)
+        // One reservation (-6) by the customer + one system restoration (+6)
         expect($histories)->toHaveCount(2)
             ->and($histories[0]->quantity)->toBe(-6)
             ->and($histories[0]->user_id)->toBe($this->user->id)
             ->and($histories[1]->quantity)->toBe(6)
-            ->and($histories[1]->user_id)->toBe($this->user->id);
+            ->and($histories[1]->user_id)->toBeNull();
     });
 
     it('restores stock to the correct inventories after a split reservation is cancelled', function (): void {

--- a/tests/Upgrade/UpgradeCommandTest.php
+++ b/tests/Upgrade/UpgradeCommandTest.php
@@ -26,5 +26,37 @@ describe('shopper:upgrade', function (): void {
         expect(DB::table($table)->where('name', 'brands.browse')->value('group_name'))->toBe('catalog')
             ->and(DB::table($table)->where('name', 'browse_brands')->exists())->toBeFalse();
     });
+
+    it('reconciles a drifted stock snapshot as part of the upgrade', function (): void {
+        DB::table(shopper_table('inventory_histories'))->insert([
+            'quantity' => 10,
+            'old_quantity' => 0,
+            'inventory_id' => DB::table(shopper_table('inventories'))->insertGetId([
+                'name' => 'Main',
+                'code' => 'main',
+                'email' => 'main@shop.test',
+                'city' => 'Douala',
+                'street_address' => 'Akwa Avenue 34',
+                'postal_code' => '00237',
+                'is_default' => true,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]),
+            'stockable_type' => 'product',
+            'stockable_id' => 1,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $this->artisan('shopper:upgrade', ['--force' => true, '--path' => 'rector-target-that-does-not-exist'])
+            ->assertSuccessful();
+
+        expect(
+            DB::table(shopper_table('stock_levels'))
+                ->where('stockable_type', 'product')
+                ->where('stockable_id', 1)
+                ->value('quantity')
+        )->toBe(10);
+    });
 })
     ->group('upgrade');


### PR DESCRIPTION
## Summary

Every stock read ran `SUM(quantity)` over the append-only `inventory_histories` ledger, so the cost of a product page, an add-to-cart or an admin listing grew without bound with a product's movement history. This aligns Shopper with how Shopify models inventory (current quantities per location, plus an adjustment history for audit) rather than Medusa v2 (current quantities only, no native ledger): both structures, each doing its job.

- New `stock_levels` table: one row per stockable and inventory location, unique-indexed, holding the current quantity. Every ledger write now updates the snapshot in the same database transaction (atomic increment, unique-index-guarded insert on the first movement), so the two can never diverge through the trait's methods.
- Reads are O(1): `getStock()`, `stockInventory()`, the batch loaders and the Store API variant aggregate all read the snapshot. Point-in-time queries (`getStock($date)`) still replay the ledger, which remains the audit source of truth.
- The migration backfills the snapshot from the existing ledger in chunks; `shopper:upgrade` gains a final step running the new `shopper:stock:reconcile --fix` command, which recomputes every snapshot row from the ledger and rewrites drift (direct-SQL ledger writes from 2.x code, concurrent writes during migration). The command also works standalone as a diagnostic.

## Concurrency fixes from the audit

- `RestoreOrderStockListener` is now idempotent: each reservation row is stamped `released_at` in the same locked transaction as its compensation, so a queue retry can never double-restore stock. The restock is attributed to the system instead of the customer.
- Checkout lines are walked in a stable global order (purchasable type, then id), so two carts sharing hot SKUs acquire their stock row locks in the same sequence and cannot deadlock.
- The two admin stock adjustment pages stop loading the entire ledger into memory to compute the current stock, and finally record the acting user on manual adjustments.

## BC notes (3.x beta)

- Code that inserted rows directly into `inventory_histories` without going through the `HasStock` methods no longer moves the snapshot: all stock movements must use `mutateStock()`/`decreaseStock()`/`setStock()`/`clearStock()`. `shopper:stock:reconcile` repairs any resulting drift.
- `getStock()` with no date reads the snapshot; with a date it replays the ledger as before.
- The Store API payload is unchanged (`stock`, `in_stock`), so no TypeScript type changes.

## Tests

Snapshot sync across every mutation type, current reads decoupled from the ledger (proven by deleting the ledger), point-in-time reads still ledger-based, per-location rows, clear, batch loading, reconcile report and fix, double-run of the restore listener restoring stock exactly once, and the upgrade command reconciling a drifted 2.x dataset end to end.