### PR TITLE
feat(orders): reclaim stale unpaid pending orders and schedule cart pruning

### DIFF
--- a/packages/cart/database/migrations/2026_07_02_000005_add_prune_index_to_carts_table.php
+++ b/packages/cart/database/migrations/2026_07_02_000005_add_prune_index_to_carts_table.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Shopper\Core\Helpers\Migration;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table($this->getTableName('carts'), static function (Blueprint $table): void {
+            $table->index(['completed_at', 'updated_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table($this->getTableName('carts'), static function (Blueprint $table): void {
+            $table->dropIndex(['completed_at', 'updated_at']);
+        });
+    }
+};

--- a/packages/cart/src/CartServiceProvider.php
+++ b/packages/cart/src/CartServiceProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Shopper\Cart;
 
+use Illuminate\Console\Scheduling\Schedule;
 use Shopper\Cart\Console\PruneCartsCommand;
 use Shopper\Cart\Discounts\DiscountValidator;
 use Shopper\Cart\Discounts\PromotionResolver;
@@ -32,6 +33,13 @@ final class CartServiceProvider extends PackageServiceProvider
         $package->name('shopper-cart')
             ->hasTranslations()
             ->hasCommand(PruneCartsCommand::class);
+    }
+
+    public function packageBooted(): void
+    {
+        $this->callAfterResolving(Schedule::class, function (Schedule $schedule): void {
+            $schedule->command('shopper:prune-carts')->daily();
+        });
     }
 
     public function packageRegistered(): void

--- a/packages/cart/src/Console/PruneCartsCommand.php
+++ b/packages/cart/src/Console/PruneCartsCommand.php
@@ -18,10 +18,17 @@ final class PruneCartsCommand extends Command
     {
         $days = (int) ($this->option('days') ?? config('shopper.cart.prune_after_days', 30));
 
-        $count = resolve(CartContract::class)::query()
-            ->whereNull('completed_at')
-            ->where('updated_at', '<', now()->subDays($days))
-            ->delete();
+        $count = 0;
+
+        do {
+            $deleted = resolve(CartContract::class)::query()
+                ->whereNull('completed_at')
+                ->where('updated_at', '<', now()->subDays($days))
+                ->limit(1000)
+                ->delete();
+
+            $count += $deleted;
+        } while ($deleted > 0);
 
         $this->components->info("{$count} abandoned cart(s) pruned.");
 

--- a/packages/core/config/orders.php
+++ b/packages/core/config/orders.php
@@ -30,4 +30,18 @@ return [
         'pad_string' => '0',
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Pending Order Reclaim
+    |--------------------------------------------------------------------------
+    |
+    | Here you may define the number of hours after which unpaid pending
+    | orders are automatically cancelled and their reserved stock released.
+    | When set, the `shopper:orders:reclaim` command runs hourly. Use null
+    | to disable. Orders paid offline (manual driver) are never reclaimed.
+    |
+    */
+
+    'reclaim_pending_after_hours' => null,
+
 ];

--- a/packages/core/src/Console/ReclaimPendingOrdersCommand.php
+++ b/packages/core/src/Console/ReclaimPendingOrdersCommand.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Core\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Collection;
+use Shopper\Core\Enum\OrderStatus;
+use Shopper\Core\Enum\PaymentStatus;
+use Shopper\Core\Events\Orders\OrderCancelled;
+use Shopper\Core\Models\Contracts\Order as OrderContract;
+use Shopper\Core\Models\Order;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+#[AsCommand(name: 'shopper:orders:reclaim')]
+final class ReclaimPendingOrdersCommand extends Command
+{
+    protected $signature = 'shopper:orders:reclaim
+                            {--hours= : Cancel unpaid pending orders older than this many hours}';
+
+    protected $description = 'Cancel unpaid pending orders past the configured window so their reserved stock returns to sale';
+
+    public function handle(): int
+    {
+        $hours = $this->option('hours') !== null
+            ? (int) $this->option('hours')
+            : config('shopper.orders.reclaim_pending_after_hours');
+
+        if (! $hours) {
+            $this->components->info('Pending order reclaim is disabled. Set `shopper.orders.reclaim_pending_after_hours` or pass --hours.');
+
+            return self::SUCCESS;
+        }
+
+        $reclaimed = 0;
+
+        resolve(OrderContract::class)::query()
+            ->where('payment_status', PaymentStatus::Pending)
+            ->where('status', OrderStatus::New)
+            ->where('created_at', '<', now()->subHours($hours))
+            ->whereHas('paymentMethod', function ($query): void {
+                $query->whereNotNull('driver')->where('driver', '<>', 'manual');
+            })
+            ->chunkById(100, function (Collection $orders) use (&$reclaimed): void {
+                /** @var Order $order */
+                foreach ($orders as $order) {
+                    if (! $order->canBeCancelled() || ! $order->canTransitionTo(OrderStatus::Cancelled)) {
+                        continue;
+                    }
+
+                    $order->transitionTo(OrderStatus::Cancelled);
+
+                    event(new OrderCancelled($order));
+
+                    $reclaimed++;
+                }
+            });
+
+        $this->components->info("{$reclaimed} unpaid pending order(s) cancelled, their stock is back on sale.");
+
+        return self::SUCCESS;
+    }
+}

--- a/packages/core/src/CoreServiceProvider.php
+++ b/packages/core/src/CoreServiceProvider.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Shopper\Core;
 
 use Carbon\Carbon;
+use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Database\Eloquent\Relations\Relation;
+use Shopper\Core\Console\ReclaimPendingOrdersCommand;
 use Shopper\Core\Console\SyncCollectionsCommand;
 use Shopper\Core\Contracts\InventoryResolver;
 use Shopper\Core\Contracts\StockAllocator;
@@ -58,6 +60,7 @@ final class CoreServiceProvider extends PackageServiceProvider
             ->name('shopper-core')
             ->hasTranslations()
             ->hasCommands([
+                ReclaimPendingOrdersCommand::class,
                 SyncCollectionsCommand::class,
             ]);
     }
@@ -70,6 +73,7 @@ final class CoreServiceProvider extends PackageServiceProvider
         $this->registerModelBindings();
         $this->bootModelRelationName();
         $this->registerObservers();
+        $this->scheduleCommands();
     }
 
     public function packageRegistered(): void
@@ -80,6 +84,15 @@ final class CoreServiceProvider extends PackageServiceProvider
         $this->registerDatabase();
         $this->registerStockAllocator();
         $this->registerTaxCalculator();
+    }
+
+    protected function scheduleCommands(): void
+    {
+        $this->callAfterResolving(Schedule::class, function (Schedule $schedule): void {
+            if (config('shopper.orders.reclaim_pending_after_hours')) {
+                $schedule->command('shopper:orders:reclaim')->hourly();
+            }
+        });
     }
 
     protected function registerObservers(): void

--- a/tests/Core/Workflows/Order/ReclaimPendingOrdersTest.php
+++ b/tests/Core/Workflows/Order/ReclaimPendingOrdersTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+use Shopper\Core\Contracts\StockReserver;
+use Shopper\Core\Enum\OrderStatus;
+use Shopper\Core\Enum\PaymentStatus;
+use Shopper\Core\Enum\ShippingStatus;
+use Shopper\Core\Models\Inventory;
+use Shopper\Core\Models\Order;
+use Shopper\Core\Models\OrderItem;
+use Shopper\Core\Models\PaymentMethod;
+use Shopper\Core\Models\Product;
+
+uses(Tests\Core\TestCase::class);
+
+function pendingOrder(array $attributes = [], string $driver = 'stripe'): Order
+{
+    return Order::factory()->create([
+        'status' => OrderStatus::New,
+        'payment_status' => PaymentStatus::Pending,
+        'shipping_status' => ShippingStatus::Unfulfilled,
+        'payment_method_id' => PaymentMethod::factory()->create(['driver' => $driver])->id,
+        ...$attributes,
+    ]);
+}
+
+describe('shopper:orders:reclaim', function (): void {
+    it('cancels unpaid pending orders past the window and releases their stock', function (): void {
+        $inventory = Inventory::factory()->create(['is_default' => true, 'priority' => 0]);
+        $product = Product::factory()->standard()->create();
+        $product->mutateStock($inventory->id, 10, event: 'Initial');
+
+        $order = pendingOrder(['created_at' => now()->subHours(100)]);
+
+        OrderItem::factory()->create([
+            'order_id' => $order->id,
+            'product_type' => $product->getMorphClass(),
+            'product_id' => $product->id,
+            'quantity' => 4,
+        ]);
+
+        resolve(StockReserver::class)->reserve($product, 4, $order);
+        expect($product->getStock())->toBe(6);
+
+        $this->artisan('shopper:orders:reclaim', ['--hours' => 72])->assertSuccessful();
+
+        expect($order->refresh()->status)->toBe(OrderStatus::Cancelled)
+            ->and($product->getStock())->toBe(10);
+    });
+
+    it('leaves recent pending orders untouched', function (): void {
+        $order = pendingOrder(['created_at' => now()->subHours(10)]);
+
+        $this->artisan('shopper:orders:reclaim', ['--hours' => 72])->assertSuccessful();
+
+        expect($order->refresh()->status)->toBe(OrderStatus::New);
+    });
+
+    it('leaves paid and processing orders untouched regardless of age', function (): void {
+        $paid = pendingOrder([
+            'payment_status' => PaymentStatus::Paid,
+            'created_at' => now()->subHours(100),
+        ]);
+        $processing = pendingOrder([
+            'status' => OrderStatus::Processing,
+            'created_at' => now()->subHours(100),
+        ]);
+
+        $this->artisan('shopper:orders:reclaim', ['--hours' => 72])->assertSuccessful();
+
+        expect($paid->refresh()->status)->toBe(OrderStatus::New)
+            ->and($processing->refresh()->status)->toBe(OrderStatus::Processing);
+    });
+
+    it('never reclaims an offline payment order regardless of age', function (): void {
+        $cashOnDelivery = pendingOrder(['created_at' => now()->subDays(30)], driver: 'manual');
+        $noDriver = pendingOrder(['created_at' => now()->subDays(30)], driver: 'stripe');
+        $noDriver->paymentMethod->update(['driver' => null]);
+
+        $this->artisan('shopper:orders:reclaim', ['--hours' => 72])->assertSuccessful();
+
+        expect($cashOnDelivery->refresh()->status)->toBe(OrderStatus::New)
+            ->and($noDriver->refresh()->status)->toBe(OrderStatus::New);
+    });
+
+    it('does nothing when the reclaim window is not configured', function (): void {
+        config()->set('shopper.orders.reclaim_pending_after_hours', null);
+
+        $order = pendingOrder(['created_at' => now()->subHours(1000)]);
+
+        $this->artisan('shopper:orders:reclaim')->assertSuccessful();
+
+        expect($order->refresh()->status)->toBe(OrderStatus::New);
+    });
+
+    it('uses the configured window when no option is passed', function (): void {
+        config()->set('shopper.orders.reclaim_pending_after_hours', 72);
+
+        $order = pendingOrder(['created_at' => now()->subHours(100)]);
+
+        $this->artisan('shopper:orders:reclaim')->assertSuccessful();
+
+        expect($order->refresh()->status)->toBe(OrderStatus::Cancelled);
+    });
+})->group('workflows', 'orders');


### PR DESCRIPTION
## Summary

Stock is reserved when the order is created, before the payment confirms. A customer who never pays leaves the order pending forever with its stock locked out of sale: in a flash sale of 100 units with 60 completed payments, 40 units silently disappear from the sellable inventory until someone cancels each abandoned order by hand.

- New `shopper:orders:reclaim` command: cancels, in chunks, the orders still `New` with a `Pending` payment past a configurable window, through the guarded state machine and the `OrderCancelled` event, so the stock returns to sale via the existing idempotent restore listener.
- Opt-in by design: `shopper.orders.reclaim_pending_after_hours` is null by default. When set, the command is scheduled hourly automatically.
- Offline payments are never reclaimed, regardless of age. Cash on delivery, wire transfers and any manual-driver method have legitimately long pending phases (the customer pays on delivery, days later); auto-cancelling them would cancel real orders. The window only applies to online payment drivers, where an unpaid order past a few hours is an abandoned payment intent.
- `shopper:prune-carts` existed but nothing ever ran it: it is now scheduled daily, deletes in chunks of 1000 instead of one unbounded statement holding locks against checkout traffic, and gets a `(completed_at, updated_at)` index on `carts` so the prune stops scanning the whole table.

## Tests

Reclaim past the window with the stock effectively released, recent orders untouched, paid and processing orders untouched at any age, offline-payment orders (manual driver or no driver) never reclaimed even after 30 days, disabled when unconfigured, and the window read from the config.