### PR TITLE
feat(api): cursor pagination and a page number cap on collection endpoints

### DIFF
--- a/packages/api/config/api.php
+++ b/packages/api/config/api.php
@@ -9,12 +9,14 @@ return [
     |--------------------------------------------------------------------------
     |
     | Default page size applied by collection endpoints, with a hard ceiling
-    | a client cannot exceed through the page[size] parameter.
+    | a client cannot exceed through the page[size] parameter. The page number
+    | is capped at max_page; use page[cursor] to walk past it at a flat cost.
     |
     */
     'pagination' => [
         'per_page' => (int) env('SHOPPER_API_PER_PAGE', 15),
         'max_per_page' => 100,
+        'max_page' => 100,
     ],
 
     /*

--- a/packages/api/src/Concerns/BuildsApiQueries.php
+++ b/packages/api/src/Concerns/BuildsApiQueries.php
@@ -6,6 +6,8 @@ namespace Shopper\Api\Concerns;
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Pagination\Cursor;
+use Illuminate\Pagination\CursorPaginator;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Collection;
 use Spatie\QueryBuilder\AllowedFilter;
@@ -99,23 +101,43 @@ trait BuildsApiQueries
     /**
      * Apply the resource allowlist then paginate with the configured page size.
      *
+     * Offset pagination stays the default for classic paged storefronts, with
+     * the page number capped so a deep page can never scan the whole table.
+     * A `page[cursor]` parameter switches to cursor pagination, whose cost is
+     * flat at any depth: the way to walk a very large catalog.
+     *
      * @template TModel of Model
      *
      * @param  Builder<TModel>  $query
      */
-    protected function paginated(string $resource, Builder $query, ?string $defaultSort = null): LengthAwarePaginator
+    protected function paginated(string $resource, Builder $query, ?string $defaultSort = null): CursorPaginator|LengthAwarePaginator
     {
         $default = (int) config('shopper.api.pagination.per_page', 15);
         $max = (int) config('shopper.api.pagination.max_per_page', 100);
+        $maxPage = (int) config('shopper.api.pagination.max_page', 100);
 
         $size = min(max((int) request()->input('page.size', $default), 1), $max);
-        $page = max((int) request()->input('page.number', 1), 1);
 
         $builder = $this->apiQuery($resource, $query);
 
         if ($defaultSort !== null) {
             $builder->defaultSort($defaultSort);
         }
+
+        if (request()->has('page.cursor')) {
+            $encoded = (string) request()->input('page.cursor');
+
+            return $builder
+                ->orderBy($query->getModel()->getKeyName())
+                ->cursorPaginate(
+                    perPage: $size,
+                    cursorName: 'page[cursor]',
+                    cursor: $encoded !== '' ? Cursor::fromEncoded($encoded) : null,
+                )
+                ->withQueryString();
+        }
+
+        $page = min(max((int) request()->input('page.number', 1), 1), $maxPage);
 
         return $builder
             ->paginate(perPage: $size, pageName: 'page[number]', page: $page)

--- a/packages/sdk/src/http.ts
+++ b/packages/sdk/src/http.ts
@@ -3,13 +3,13 @@ import type { JsonApiErrorDocument } from './json-api'
 /**
  * Structured JSON:API query parameters understood by every list/retrieve call,
  * mapped to the query family the Shopper API expects (filter[], sort, include,
- * page[number], page[size], fields[type]).
+ * page[number], page[size], page[cursor], fields[type]).
  */
 export interface RequestParams {
   include?: string[]
   filter?: Record<string, string | number | boolean>
   sort?: string[]
-  page?: { number?: number; size?: number }
+  page?: { number?: number; size?: number; cursor?: string }
   fields?: Record<string, string[]>
 }
 
@@ -51,6 +51,10 @@ export function buildQuery(options?: FetchOptions): string {
 
   if (options.page?.size) {
     search.set('page[size]', String(options.page.size))
+  }
+
+  if (options.page?.cursor !== undefined) {
+    search.set('page[cursor]', options.page.cursor)
   }
 
   for (const [type, list] of Object.entries(options.fields ?? {})) {

--- a/tests/Api/Feature/ProductCatalogTest.php
+++ b/tests/Api/Feature/ProductCatalogTest.php
@@ -300,6 +300,39 @@ it('caps page[size] at the configured maximum', function (): void {
     expect($response->json('data'))->toHaveCount(1);
 });
 
+it('caps page[number] at the configured maximum page', function (): void {
+    config()->set('shopper.api.pagination.max_page', 2);
+    publishedProduct(['name' => 'DeepA']);
+    publishedProduct(['name' => 'DeepB']);
+    publishedProduct(['name' => 'DeepC']);
+
+    $capped = $this->getJson('/store/products?filter[name]=Deep&sort=name&page[size]=1&page[number]=500')->assertOk();
+
+    expect($capped->json('data'))->toHaveCount(1)
+        ->and($capped->json('data.0.attributes.name'))->toBe('DeepB');
+});
+
+it('walks the whole catalog through cursor pagination without overlap', function (): void {
+    publishedProduct(['name' => 'CursorA']);
+    publishedProduct(['name' => 'CursorB']);
+    publishedProduct(['name' => 'CursorC']);
+
+    $names = [];
+    $url = '/store/products?filter[name]=Cursor&sort=name&page[size]=2&page[cursor]=';
+
+    do {
+        $response = $this->getJson($url)->assertOk();
+
+        foreach ($response->json('data') as $product) {
+            $names[] = $product['attributes']['name'];
+        }
+
+        $url = $response->json('links.next');
+    } while ($url !== null);
+
+    expect($names)->toBe(['CursorA', 'CursorB', 'CursorC']);
+});
+
 it('filters and sorts the product list through the allowlist', function (): void {
     publishedProduct(['name' => 'ZzzCatalogBeta']);
     publishedProduct(['name' => 'ZzzCatalogAlpha']);


### PR DESCRIPTION
## Summary

Offset pagination reruns a full `COUNT(*)` on every page and `page[number]=50000` scans and discards ~750K rows to return 15 results: on a very large catalog, deep paging is O(n) per page and an easy way to melt the database.

- Offset pagination stays the default for classic paged storefronts, but `page[number]` is now capped by `shopper.api.pagination.max_page` (default 100), so a deep page can never scan the whole table.
- A `page[cursor]` parameter switches the collection endpoints to cursor pagination, whose cost is flat at any depth: the way to walk a very large catalog (feeds, ERP syncs, infinite scroll). This mirrors how the Shopify Storefront API paginates. The sort is stabilized with an automatic primary key tie-break, and the cursor is decoded explicitly since Laravel's resolver cannot read the nested JSON:API `page[cursor]` parameter.
- The SDK and TypeScript types gain `page.cursor`, so a client can follow `links.next` or pass a cursor directly.

## Tests

A full cursor walk of the catalog following `links.next` with no overlap or gap, the page number cap returning the capped page's content, and the existing offset behaviors unchanged.