### PR TITLE
fix(catalog): sargable publish scope, indexed order search and async customer filter

### DIFF
--- a/packages/admin/src/Livewire/Pages/Order/Index.php
+++ b/packages/admin/src/Livewire/Pages/Order/Index.php
@@ -217,18 +217,17 @@ class Index extends AbstractPageComponent implements HasActions, HasSchemas, Has
                     ->schema([
                         TextInput::make('number')
                             ->label(__('shopper::words.number'))
-                            ->placeholder('SHP-XXXXX'),
+                            ->placeholder('ORD-XXXXX'),
                     ])
                     ->query(fn (Builder $query, array $data): Builder => $query
                         ->when(
                             $data['number'],
-                            fn (Builder $query, string $number): Builder => $query->where('number', 'like', "%{$number}%"),
+                            fn (Builder $query, string $number): Builder => $query->where('number', 'like', "{$number}%"),
                         )),
                 SelectFilter::make('customer_id')
                     ->label(__('shopper::words.customer'))
                     ->relationship('customer', 'first_name')
-                    ->searchable()
-                    ->preload(),
+                    ->searchable(),
                 SelectFilter::make('status')
                     ->label(__('shopper::forms.label.status'))
                     ->options(OrderStatus::options())

--- a/packages/core/database/migrations/2026_07_02_000006_add_publish_index_to_products_table.php
+++ b/packages/core/database/migrations/2026_07_02_000006_add_publish_index_to_products_table.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Shopper\Core\Helpers\Migration;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table($this->getTableName('products'), static function (Blueprint $table): void {
+            $table->index(['is_visible', 'published_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table($this->getTableName('products'), static function (Blueprint $table): void {
+            $table->dropIndex(['is_visible', 'published_at']);
+        });
+    }
+};

--- a/packages/core/src/Models/Product.php
+++ b/packages/core/src/Models/Product.php
@@ -319,7 +319,7 @@ class Product extends Model implements HasReviews, Priceable, ProductContract, S
     #[Scope]
     protected function publish(Builder $query): void
     {
-        $query->whereDate('published_at', '<=', now())
+        $query->where('published_at', '<=', now())
             ->where('is_visible', true);
     }
 

--- a/tests/Core/Models/ProductTest.php
+++ b/tests/Core/Models/ProductTest.php
@@ -366,6 +366,16 @@ describe(Product::class, function (): void {
             ->and($results->first()->id)->toBe($publishedProduct->id);
     });
 
+    it('keeps a product scheduled for later today out of the publish scope', function (): void {
+        $scheduled = Product::factory()->create([
+            'published_at' => now()->addHour(),
+            'is_visible' => true,
+        ]);
+
+        expect(Product::publish()->whereKey($scheduled->id)->exists())->toBeFalse()
+            ->and($scheduled->isPublished())->toBeFalse();
+    });
+
     it('filters products by channel scope', function (): void {
         $channel1 = Channel::factory()->create();
         $channel2 = Channel::factory()->create();


### PR DESCRIPTION
## Summary

Three read paths that stop scaling past a small catalog:

- `Product::publish()` runs on nearly every storefront read but wrapped the column in `whereDate()`, defeating any index, and no index existed. The scope now compares the raw datetime and `products` gains an `(is_visible, published_at)` composite index. This also fixes a semantic divergence: `whereDate` made a product scheduled for later today visible from midnight, while `isPublished()` compares the exact time. Scope and method now agree, so scheduled publishing is respected to the hour.
- The admin order number search used a leading-wildcard `LIKE`, which cannot use the unique index on `orders.number`: every keystroke was a full table scan. It is now a prefix search, which the index serves.
- The customer filter on the orders list combined `preload()` with `searchable()`, loading the entire customer list when the filter modal opened. The async search alone remains.

## Tests

A product scheduled for later today stays out of the publish scope (and out of `isPublished()`), plus the full Core and Api suites confirming the semantic change breaks nothing.