### PR TITLE
feat(cart): serve cart reads from persisted totals instead of the write pipeline

### DIFF
--- a/packages/api/src/Concerns/RespondsWithCart.php
+++ b/packages/api/src/Concerns/RespondsWithCart.php
@@ -51,14 +51,14 @@ trait RespondsWithCart
     }
 
     /**
-     * Every cart response carries the totals computed by the cart pipelines,
-     * so a single GET is enough to render the cart. Relations are reloaded
-     * after the run because the pipelines rewrite adjustments and tax lines;
-     * whether they are serialized is up to the client through `include`.
+     * Every cart response carries the cart totals, so a single GET is enough
+     * to render the cart. A fresh cart is served from its persisted rows with
+     * zero writes; a mutated or aged cart runs the pipelines once, in which
+     * case the reload below picks up the rewritten adjustments and tax lines.
      */
     protected function cartResource(Cart $cart): CartResource
     {
-        $context = resolve(CartManager::class)->calculate($cart);
+        $context = resolve(CartManager::class)->totals($cart);
 
         $cart->load(['lines.purchasable', 'lines.adjustments', 'lines.taxLines', 'addresses.country', 'promotions']);
 

--- a/packages/cart/config/cart.php
+++ b/packages/cart/config/cart.php
@@ -64,6 +64,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Totals Freshness
+    |--------------------------------------------------------------------------
+    |
+    | How many minutes the persisted cart totals stay fresh. Reads within the
+    | window are served from the stored lines without running the calculation
+    | pipeline; older or invalidated carts are recalculated once on read.
+    |
+    */
+
+    'totals_ttl_minutes' => 15,
+
+    /*
+    |--------------------------------------------------------------------------
     | Cart Pruning
     |--------------------------------------------------------------------------
     |

--- a/packages/cart/database/migrations/2026_07_02_000007_add_calculated_at_to_carts_table.php
+++ b/packages/cart/database/migrations/2026_07_02_000007_add_calculated_at_to_carts_table.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Shopper\Core\Helpers\Migration;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table($this->getTableName('carts'), static function (Blueprint $table): void {
+            $table->timestamp('calculated_at')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table($this->getTableName('carts'), static function (Blueprint $table): void {
+            $table->dropColumn('calculated_at');
+        });
+    }
+};

--- a/packages/cart/src/CartManager.php
+++ b/packages/cart/src/CartManager.php
@@ -23,12 +23,15 @@ use Shopper\Core\Enum\AddressType;
 use Shopper\Core\Enum\PromotionSource;
 use Shopper\Core\Models\Contracts\Stockable;
 use Shopper\Core\Models\Discount;
+use Shopper\Core\Taxes\TaxCalculationContext;
+use Shopper\Core\Taxes\TaxCalculator;
 use Throwable;
 
 final readonly class CartManager
 {
     public function __construct(
         private CartPipelineRunner $pipelineRunner,
+        private TaxCalculator $taxCalculator,
     ) {}
 
     /**
@@ -40,6 +43,7 @@ final readonly class CartManager
     {
         $this->guardQuantity($quantity);
         $this->guardCompleted($cart);
+        $this->invalidateTotals($cart);
 
         return DB::transaction(function () use ($cart, $purchasable, $quantity, $metadata): CartLine {
             $existing = $cart->lines()
@@ -79,6 +83,7 @@ final readonly class CartManager
     public function update(Cart $cart, int $lineId, array $data): CartLine
     {
         $this->guardCompleted($cart);
+        $this->invalidateTotals($cart);
 
         return DB::transaction(function () use ($cart, $lineId, $data): CartLine {
             /** @var CartLine $line */
@@ -98,6 +103,7 @@ final readonly class CartManager
     public function remove(Cart $cart, int $lineId): void
     {
         $this->guardCompleted($cart);
+        $this->invalidateTotals($cart);
 
         $cart->lines()->findOrFail($lineId)->delete();
     }
@@ -105,13 +111,59 @@ final readonly class CartManager
     public function clear(Cart $cart): void
     {
         $this->guardCompleted($cart);
+        $this->invalidateTotals($cart);
 
         $cart->lines()->delete();
     }
 
     public function calculate(Cart $cart): CartPipelineContext
     {
-        return $this->pipelineRunner->run($cart);
+        $context = $this->pipelineRunner->run($cart);
+
+        $cart->updateQuietly(['calculated_at' => now()]);
+
+        return $context;
+    }
+
+    /**
+     * The read path of the cart totals: rebuilds the pipeline context from the
+     * rows the last calculation persisted, without a single write. A cart that
+     * was mutated since (invalidated) or whose totals aged past the freshness
+     * window is recalculated once, so a time-bound automatic promotion can
+     * never stay displayed forever. Checkout never uses this path: the money
+     * charged is always recomputed under the cart lock.
+     */
+    public function totals(Cart $cart): CartPipelineContext
+    {
+        $ttl = (int) config('shopper.cart.totals_ttl_minutes', 15);
+
+        if ($cart->calculated_at === null || $cart->calculated_at->lt(now()->subMinutes($ttl))) {
+            return $this->calculate($cart);
+        }
+
+        $cart->loadMissing(['lines.adjustments', 'lines.taxLines', 'addresses.country']);
+
+        $context = new CartPipelineContext($cart);
+
+        foreach ($cart->lines as $line) {
+            $lineSubtotal = $line->unit_price_amount * $line->quantity;
+
+            $context->lineSubtotals[$line->id] = $lineSubtotal;
+            $context->subtotal += $lineSubtotal;
+            $context->discountTotal += (int) $line->adjustments->sum('amount');
+            $context->taxTotal += (int) $line->taxLines->sum('amount');
+        }
+
+        $context->taxInclusive = $this->resolveTaxInclusive($cart);
+        $context->shippingTotal = $cart->shipping_amount ?? 0;
+
+        $goodsTotal = max(0, $context->taxInclusive
+            ? $context->subtotal - $context->discountTotal
+            : $context->subtotal - $context->discountTotal + $context->taxTotal);
+
+        $context->total = $goodsTotal + $context->shippingTotal;
+
+        return $context;
     }
 
     /**
@@ -120,6 +172,7 @@ final readonly class CartManager
     public function addAddress(Cart $cart, AddressType $type, array $data): void
     {
         $this->guardCompleted($cart);
+        $this->invalidateTotals($cart);
 
         $cart->addresses()->updateOrCreate(
             ['type' => $type],
@@ -135,6 +188,7 @@ final readonly class CartManager
     public function setShippingMethod(Cart $cart, string $optionId, int $amount): void
     {
         $this->guardCompleted($cart);
+        $this->invalidateTotals($cart);
 
         $cart->update([
             'shipping_option_id' => $optionId,
@@ -184,6 +238,7 @@ final readonly class CartManager
     public function changeCurrency(Cart $cart, string $currencyCode): void
     {
         $this->guardCompleted($cart);
+        $this->invalidateTotals($cart);
 
         DB::transaction(function () use ($cart, $currencyCode): void {
             $cart->loadMissing('lines.purchasable.prices');
@@ -208,6 +263,7 @@ final readonly class CartManager
     public function applyCoupon(Cart $cart, string $code): void
     {
         $this->guardCompleted($cart);
+        $this->invalidateTotals($cart);
 
         $discount = Discount::query()->where('code', $code)->first();
 
@@ -215,9 +271,6 @@ final readonly class CartManager
             throw new InvalidDiscountException(__('shopper-cart::exceptions.discount_not_found'));
         }
 
-        // A cart can carry several code promotions; the resolver decides which
-        // actually apply. The unique (cart_id, discount_id) row keeps re-applying
-        // the same code a no-op instead of a doubled discount.
         $cart->promotions()->firstOrCreate(
             ['discount_id' => $discount->id],
             ['source' => PromotionSource::Code->value, 'code' => $code],
@@ -233,6 +286,7 @@ final readonly class CartManager
     public function removeCoupon(Cart $cart, ?string $code = null): void
     {
         $this->guardCompleted($cart);
+        $this->invalidateTotals($cart);
 
         $cart->promotions()
             ->where('source', PromotionSource::Code->value)
@@ -251,6 +305,29 @@ final readonly class CartManager
         if ($cart->isCompleted()) {
             throw new CartCompletedException;
         }
+    }
+
+    private function invalidateTotals(Cart $cart): void
+    {
+        $cart->updateQuietly(['calculated_at' => null]);
+    }
+
+    private function resolveTaxInclusive(Cart $cart): bool
+    {
+        $shippingAddress = $cart->shippingAddress();
+        $countryCode = $shippingAddress?->country?->cca2;
+
+        if (! $countryCode) {
+            return false;
+        }
+
+        $zone = $this->taxCalculator->resolveZone(new TaxCalculationContext(
+            countryCode: $countryCode,
+            provinceCode: $shippingAddress->state,
+            customerId: $cart->customer_id,
+        ));
+
+        return $zone->is_tax_inclusive ?? false;
     }
 
     private function guardQuantity(int $quantity): void

--- a/packages/cart/src/Models/Cart.php
+++ b/packages/cart/src/Models/Cart.php
@@ -25,6 +25,7 @@ use Shopper\Core\Traits\HasModelContract;
  * @property-read ?string $public_id
  * @property-read string $currency_code
  * @property-read ?string $email
+ * @property-read ?CarbonInterface $calculated_at
  * @property-read ?CarbonInterface $completed_at
  * @property-read ?array<string, mixed> $metadata
  * @property-read ?int $customer_id
@@ -156,6 +157,7 @@ class Cart extends Model implements CartContract
     protected function casts(): array
     {
         return [
+            'calculated_at' => 'datetime',
             'completed_at' => 'datetime',
             'metadata' => 'array',
             'payment_session' => 'array',

--- a/tests/Cart/Feature/CartTotalsReadPathTest.php
+++ b/tests/Cart/Feature/CartTotalsReadPathTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Shopper\Cart\CartManager;
+use Shopper\Cart\Models\Cart;
+use Shopper\Core\Enum\AddressType;
+use Shopper\Core\Enum\DiscountApplyTo;
+use Shopper\Core\Enum\DiscountEligibility;
+use Shopper\Core\Enum\DiscountRequirement;
+use Shopper\Core\Enum\DiscountType;
+use Shopper\Core\Models\Country;
+use Shopper\Core\Models\Currency;
+use Shopper\Core\Models\Discount;
+use Shopper\Core\Models\Inventory;
+use Shopper\Core\Models\Product;
+use Shopper\Core\Models\TaxRate;
+use Shopper\Core\Models\TaxZone;
+
+uses(Tests\Cart\TestCase::class);
+
+beforeEach(function (): void {
+    setupCurrencies();
+
+    $this->currency = Currency::query()->where('code', 'USD')->first();
+    $this->cartManager = resolve(CartManager::class);
+    $this->inventory = Inventory::factory()->create();
+
+    $this->product = Product::factory()->standard()->create();
+    $this->product->prices()->create([
+        'amount' => 10000,
+        'currency_id' => $this->currency->id,
+    ]);
+    $this->product->load('prices');
+    $this->product->mutateStock($this->inventory->id, 100);
+
+    $this->cart = Cart::factory()->create(['currency_code' => 'USD']);
+
+    $this->country = Country::query()->where('cca2', 'US')->first()
+        ?? Country::factory()->create(['cca2' => 'US', 'name' => 'United States']);
+
+    $taxZone = TaxZone::factory()->create([
+        'country_id' => $this->country->id,
+        'is_tax_inclusive' => false,
+    ]);
+
+    TaxRate::factory()->create([
+        'tax_zone_id' => $taxZone->id,
+        'rate' => 20.00,
+        'is_default' => true,
+    ]);
+
+    $this->cartManager->add($this->cart, $this->product);
+    $this->cartManager->addAddress($this->cart, AddressType::Shipping, [
+        'first_name' => 'John',
+        'last_name' => 'Doe',
+        'address_1' => '123 Main St',
+        'city' => 'New York',
+        'postal_code' => '10001',
+        'country_id' => $this->country->id,
+    ]);
+});
+
+describe('Cart totals read path', function (): void {
+    it('serves fresh totals without a single write statement', function (): void {
+        $this->cartManager->calculate($this->cart->refresh());
+
+        $cart = Cart::query()->findOrFail($this->cart->id);
+
+        DB::enableQueryLog();
+        $context = $this->cartManager->totals($cart);
+        $queries = collect(DB::getQueryLog())->pluck('query');
+        DB::disableQueryLog();
+
+        $writes = $queries->filter(
+            fn (string $sql): bool => (bool) preg_match('/^\s*(insert|update|delete)/i', $sql),
+        );
+
+        expect($writes)->toBeEmpty()
+            ->and($context->subtotal)->toBe(10000)
+            ->and($context->taxTotal)->toBe(2000)
+            ->and($context->total)->toBe(12000);
+    });
+
+    it('returns the same totals from the read path and the pipeline', function (): void {
+        $calculated = $this->cartManager->calculate($this->cart->refresh());
+        $read = $this->cartManager->totals(Cart::query()->findOrFail($this->cart->id));
+
+        expect($read->subtotal)->toBe($calculated->subtotal)
+            ->and($read->discountTotal)->toBe($calculated->discountTotal)
+            ->and($read->taxTotal)->toBe($calculated->taxTotal)
+            ->and($read->taxInclusive)->toBe($calculated->taxInclusive)
+            ->and($read->total)->toBe($calculated->total);
+    });
+
+    it('recalculates once after a mutation invalidated the totals', function (): void {
+        $this->cartManager->calculate($this->cart->refresh());
+
+        $other = Product::factory()->standard()->create();
+        $other->prices()->create(['amount' => 5000, 'currency_id' => $this->currency->id]);
+        $other->load('prices');
+        $other->mutateStock($this->inventory->id, 50);
+
+        $this->cartManager->add($this->cart, $other);
+
+        expect($this->cart->refresh()->calculated_at)->toBeNull();
+
+        $context = $this->cartManager->totals($this->cart->refresh());
+
+        expect($context->subtotal)->toBe(15000)
+            ->and($context->taxTotal)->toBe(3000)
+            ->and($this->cart->refresh()->calculated_at)->not->toBeNull();
+    });
+
+    it('recalculates a cart whose totals aged past the freshness window and drops an expired promotion', function (): void {
+        Discount::factory()->create([
+            'code' => 'FLASH',
+            'is_active' => true,
+            'type' => DiscountType::Percentage,
+            'value' => 50,
+            'apply_to' => DiscountApplyTo::Order,
+            'eligibility' => DiscountEligibility::Everyone,
+            'min_required' => DiscountRequirement::None,
+            'start_at' => now()->subDay(),
+            'end_at' => now()->addMinutes(5),
+        ]);
+
+        $this->cartManager->applyCoupon($this->cart->refresh(), 'FLASH');
+        $context = $this->cartManager->calculate($this->cart->refresh());
+
+        expect($context->discountTotal)->toBe(5000);
+
+        $this->travel(30)->minutes();
+
+        $stale = $this->cartManager->totals(Cart::query()->findOrFail($this->cart->id));
+
+        expect($stale->discountTotal)->toBe(0)
+            ->and($stale->total)->toBe(12000);
+
+        $this->travelBack();
+    });
+})->group('cart', 'totals');


### PR DESCRIPTION
## Summary

Every cart response, including a plain `GET /store/carts/{id}`, ran the full calculation pipeline: automatic promotions synced with creates and deletes, every line's adjustments deleted and reinserted, every tax line deleted and recreated. A storefront mini-cart that reloads on each navigation turned pure browsing into checkout-grade write volume, made the GET uncacheable, and held write locks to change nothing.

- `CartManager::totals()` is the new read path: it rebuilds the pipeline context (subtotal, discounts, taxes, inclusive mode, total) from the rows the last calculation persisted, with zero write statements. The cart GET endpoint uses it.
- `calculate()` is unchanged as the write path and now stamps a `calculated_at` timestamp. Every mutation affecting the totals (line add/update/remove/clear, address, shipping method, currency, coupon apply/remove) invalidates the stamp, so the mutation's own response recalculates once and re-stamps: one mechanism covers both correctness and freshness.
- A freshness window (`shopper.cart.totals_ttl_minutes`, default 15) bounds staleness for dormant carts: a time-bound automatic promotion can never stay displayed past the window. The cart is an availability domain; a few minutes of display staleness is the intended trade-off.
- Checkout is untouched: order placement, payment sessions and coupon revalidation still recompute under the cart lock, so the money charged never comes from a stored read.

## Tests

A fresh cart GET produces zero insert/update/delete statements (asserted on the query log), the read path returns strictly identical totals to the pipeline on a discounted and taxed cart, a mutation invalidates and the next read recalculates with the new totals, and a cart aged past the window drops an expired 50% promotion from its displayed totals.