### PR TITLE
fix(admin): sargable dashboard queries and cached admin aggregates

### DIFF
--- a/packages/admin/src/Livewire/Components/Dashboard/StatCards.php
+++ b/packages/admin/src/Livewire/Components/Dashboard/StatCards.php
@@ -52,15 +52,13 @@ final class StatCards extends Component
         $currentMonth = (int) resolve(Order::class)::query()
             ->where('payment_status', PaymentStatus::Paid)
             ->where('currency_code', $currency)
-            ->whereMonth('created_at', $now->month)
-            ->whereYear('created_at', $now->year)
+            ->whereBetween('created_at', $this->monthRange($now))
             ->sum('price_amount');
 
         $lastMonth = (int) resolve(Order::class)::query()
             ->where('payment_status', PaymentStatus::Paid)
             ->where('currency_code', $currency)
-            ->whereMonth('created_at', $now->copy()->subMonth()->month)
-            ->whereYear('created_at', $now->copy()->subMonth()->year)
+            ->whereBetween('created_at', $this->monthRange($now->copy()->subMonth()))
             ->sum('price_amount');
 
         return [
@@ -78,13 +76,11 @@ final class StatCards extends Component
     private function buildProductsCard(Carbon $now): array
     {
         $current = resolve(ProductContract::class)::query()
-            ->whereMonth('created_at', $now->month)
-            ->whereYear('created_at', $now->year)
+            ->whereBetween('created_at', $this->monthRange($now))
             ->count();
 
         $previous = resolve(ProductContract::class)::query()
-            ->whereMonth('created_at', $now->copy()->subMonth()->month)
-            ->whereYear('created_at', $now->copy()->subMonth()->year)
+            ->whereBetween('created_at', $this->monthRange($now->copy()->subMonth()))
             ->count();
 
         return [
@@ -103,14 +99,12 @@ final class StatCards extends Component
     {
         $current = resolve(Order::class)::query()
             ->where('payment_status', PaymentStatus::Paid)
-            ->whereMonth('created_at', $now->month)
-            ->whereYear('created_at', $now->year)
+            ->whereBetween('created_at', $this->monthRange($now))
             ->count();
 
         $previous = resolve(Order::class)::query()
             ->where('payment_status', PaymentStatus::Paid)
-            ->whereMonth('created_at', $now->copy()->subMonth()->month)
-            ->whereYear('created_at', $now->copy()->subMonth()->year)
+            ->whereBetween('created_at', $this->monthRange($now->copy()->subMonth()))
             ->count();
 
         return [
@@ -133,14 +127,12 @@ final class StatCards extends Component
 
         $current = $userModel::query()
             ->scopes('customers')
-            ->whereMonth('created_at', $now->month)
-            ->whereYear('created_at', $now->year)
+            ->whereBetween('created_at', $this->monthRange($now))
             ->count();
 
         $previous = $userModel::query()
             ->scopes('customers')
-            ->whereMonth('created_at', $now->copy()->subMonth()->month)
-            ->whereYear('created_at', $now->copy()->subMonth()->year)
+            ->whereBetween('created_at', $this->monthRange($now->copy()->subMonth()))
             ->count();
 
         return [
@@ -170,5 +162,13 @@ final class StatCards extends Component
             'change' => abs($change),
             'trend' => $change > 0 ? 'up' : ($change < 0 ? 'down' : 'neutral'),
         ];
+    }
+
+    /**
+     * @return array{0: Carbon, 1: Carbon}
+     */
+    private function monthRange(Carbon $month): array
+    {
+        return [$month->copy()->startOfMonth(), $month->copy()->endOfMonth()];
     }
 }

--- a/packages/admin/src/Livewire/Components/Dashboard/TopSellingProducts.php
+++ b/packages/admin/src/Livewire/Components/Dashboard/TopSellingProducts.php
@@ -54,6 +54,7 @@ final class TopSellingProducts extends Component
                     ->where('oi.product_type', '=', $variantClass);
             })
             ->where('o.payment_status', PaymentStatus::Paid->value)
+            ->where('o.created_at', '>=', now()->subDays(90))
             ->selectRaw('COALESCE(pv.product_id, oi.product_id) as parent_product_id, SUM(oi.quantity) as total_sales')
             ->groupBy('parent_product_id')
             ->orderByDesc('total_sales')

--- a/packages/admin/src/Livewire/Pages/Customers/Create.php
+++ b/packages/admin/src/Livewire/Pages/Customers/Create.php
@@ -199,9 +199,10 @@ class Create extends AbstractPageComponent implements HasActions, HasSchemas
     public function render(): View
     {
         return view('shopper::livewire.pages.customers.create', [
-            'countries' => Cache::get(
+            'countries' => Cache::remember(
                 key: 'countries-settings',
-                default: fn (): Collection => Country::query()->orderBy('name')->get()
+                ttl: now()->addDay(),
+                callback: fn (): Collection => Country::query()->orderBy('name')->get()
             ),
         ])
             ->title(__('shopper::forms.actions.add_label', ['label' => __('shopper::pages/customers.single')]));

--- a/packages/admin/src/Livewire/Pages/Customers/Index.php
+++ b/packages/admin/src/Livewire/Pages/Customers/Index.php
@@ -19,6 +19,7 @@ use Filament\Tables\Filters\TernaryFilter;
 use Filament\Tables\Table;
 use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Cache;
 use Livewire\Attributes\Computed;
 use Mckenziearts\Icons\Untitledui\Enums\Untitledui;
 use Shopper\Core\Enum\OrderStatus;
@@ -44,58 +45,15 @@ class Index extends AbstractPageComponent implements HasActions, HasSchemas, Has
     }
 
     /**
+     * `#[Computed]` only memoizes within one Livewire lifecycle: the shared
+     * cache below is what keeps the full-table aggregate off every page view.
+     *
      * @return array{total: int, new_count: int, active_count: int, active_percent: int, avg_ltv: int}
      */
     #[Computed]
     public function stats(): array
     {
-        $userModel = config('auth.providers.users.model');
-        $usersTable = (new $userModel)->getTable();
-
-        $activeOrders = resolve(Order::class)::query()
-            ->select('customer_id')
-            ->whereIn('status', [
-                OrderStatus::Processing,
-                OrderStatus::Completed,
-            ])
-            ->where('payment_status', PaymentStatus::Paid)
-            ->groupBy('customer_id');
-
-        $currencyOrders = resolve(Order::class)::query()
-            ->select('customer_id')
-            ->selectRaw('SUM(price_amount) as per_customer_total')
-            ->whereIn('status', [
-                OrderStatus::Processing,
-                OrderStatus::Completed,
-            ])
-            ->where('payment_status', PaymentStatus::Paid)
-            ->where('currency_code', shopper_currency())
-            ->groupBy('customer_id');
-
-        /** @var object{total: int, new_count: int, active_count: int, avg_ltv: float|string|null}|null $row */
-        $row = $userModel::query()
-            ->customers()
-            ->leftJoinSub($activeOrders, 'active_orders', 'active_orders.customer_id', '=', "{$usersTable}.id")
-            ->leftJoinSub($currencyOrders, 'currency_orders', 'currency_orders.customer_id', '=', "{$usersTable}.id")
-            ->selectRaw(
-                "COUNT(DISTINCT {$usersTable}.id) as total,
-                 COUNT(DISTINCT CASE WHEN {$usersTable}.created_at >= ? THEN {$usersTable}.id END) as new_count,
-                 COUNT(DISTINCT CASE WHEN active_orders.customer_id IS NOT NULL THEN {$usersTable}.id END) as active_count,
-                 COALESCE(AVG(currency_orders.per_customer_total), 0) as avg_ltv",
-                [now()->subDays(30)->toDateTimeString()]
-            )
-            ->first();
-
-        $total = (int) ($row->total ?? 0);
-        $active = (int) ($row->active_count ?? 0);
-
-        return [
-            'total' => $total,
-            'new_count' => (int) ($row->new_count ?? 0),
-            'active_count' => $active,
-            'active_percent' => $total > 0 ? (int) round(($active / $total) * 100) : 0,
-            'avg_ltv' => (int) round((float) ($row->avg_ltv ?? 0)),
-        ];
+        return Cache::flexible('admin:customers:stats:'.shopper_currency(), [300, 1800], fn (): array => $this->computeStats());
     }
 
     public function table(Table $table): Table
@@ -180,5 +138,59 @@ class Index extends AbstractPageComponent implements HasActions, HasSchemas, Has
     {
         return view('shopper::livewire.pages.customers.index')
             ->title(__('shopper::pages/customers.menu'));
+    }
+
+    /**
+     * @return array{total: int, new_count: int, active_count: int, active_percent: int, avg_ltv: int}
+     */
+    private function computeStats(): array
+    {
+        $userModel = config('auth.providers.users.model');
+        $usersTable = (new $userModel)->getTable();
+
+        $activeOrders = resolve(Order::class)::query()
+            ->select('customer_id')
+            ->whereIn('status', [
+                OrderStatus::Processing,
+                OrderStatus::Completed,
+            ])
+            ->where('payment_status', PaymentStatus::Paid)
+            ->groupBy('customer_id');
+
+        $currencyOrders = resolve(Order::class)::query()
+            ->select('customer_id')
+            ->selectRaw('SUM(price_amount) as per_customer_total')
+            ->whereIn('status', [
+                OrderStatus::Processing,
+                OrderStatus::Completed,
+            ])
+            ->where('payment_status', PaymentStatus::Paid)
+            ->where('currency_code', shopper_currency())
+            ->groupBy('customer_id');
+
+        /** @var object{total: int, new_count: int, active_count: int, avg_ltv: float|string|null}|null $row */
+        $row = $userModel::query()
+            ->customers()
+            ->leftJoinSub($activeOrders, 'active_orders', 'active_orders.customer_id', '=', "{$usersTable}.id")
+            ->leftJoinSub($currencyOrders, 'currency_orders', 'currency_orders.customer_id', '=', "{$usersTable}.id")
+            ->selectRaw(
+                "COUNT(DISTINCT {$usersTable}.id) as total,
+                 COUNT(DISTINCT CASE WHEN {$usersTable}.created_at >= ? THEN {$usersTable}.id END) as new_count,
+                 COUNT(DISTINCT CASE WHEN active_orders.customer_id IS NOT NULL THEN {$usersTable}.id END) as active_count,
+                 COALESCE(AVG(currency_orders.per_customer_total), 0) as avg_ltv",
+                [now()->subDays(30)->toDateTimeString()]
+            )
+            ->first();
+
+        $total = (int) ($row->total ?? 0);
+        $active = (int) ($row->active_count ?? 0);
+
+        return [
+            'total' => $total,
+            'new_count' => (int) ($row->new_count ?? 0),
+            'active_count' => $active,
+            'active_percent' => $total > 0 ? (int) round(($active / $total) * 100) : 0,
+            'avg_ltv' => (int) round((float) ($row->avg_ltv ?? 0)),
+        ];
     }
 }

--- a/packages/admin/src/Livewire/Pages/Order/Index.php
+++ b/packages/admin/src/Livewire/Pages/Order/Index.php
@@ -23,6 +23,7 @@ use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Table;
 use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Cache;
 use Livewire\Attributes\Url;
 use Mckenziearts\Icons\Untitledui\Enums\Untitledui;
 use Shopper\Core\Enum\OrderStatus;
@@ -56,20 +57,13 @@ class Index extends AbstractPageComponent implements HasActions, HasSchemas, Has
      */
     public function getTabs(): array
     {
-        $orderModel = resolve(Order::class);
-
         return [
             'all' => Tab::make(__('shopper::words.all'))
                 ->icon(Untitledui::LayersThree)
-                ->badge(fn (): int => $orderModel::query()->count()),
+                ->badge(fn (): int => $this->tabCounts()['all']),
             'open' => Tab::make(__('shopper::words.open'))
                 ->icon(OrderStatus::New->getIcon())
-                ->badge(
-                    fn (): int => $orderModel::query()
-                        ->whereIn('status', [OrderStatus::New, OrderStatus::Processing])
-                        ->where('shipping_status', ShippingStatus::Unfulfilled)
-                        ->count()
-                )
+                ->badge(fn (): int => $this->tabCounts()['open'])
                 ->badgeColor('success')
                 ->query(
                     fn (Builder $query): Builder => $query
@@ -78,11 +72,7 @@ class Index extends AbstractPageComponent implements HasActions, HasSchemas, Has
                 ),
             'paid' => Tab::make(PaymentStatus::Paid->getLabel())
                 ->icon(PaymentStatus::Paid->getIcon())
-                ->badge(
-                    fn (): int => $orderModel::query()
-                        ->where('payment_status', PaymentStatus::Paid)
-                        ->count()
-                )
+                ->badge(fn (): int => $this->tabCounts()['paid'])
                 ->badgeColor('success')
                 ->query(
                     fn (Builder $query): Builder => $query
@@ -90,11 +80,7 @@ class Index extends AbstractPageComponent implements HasActions, HasSchemas, Has
                 ),
             'fulfilled' => Tab::make(__('shopper::words.fulfilled'))
                 ->icon(ShippingStatus::Shipped->getIcon())
-                ->badge(
-                    fn (): int => $orderModel::query()
-                        ->whereIn('shipping_status', [ShippingStatus::Shipped, ShippingStatus::PartiallyShipped])
-                        ->count()
-                )
+                ->badge(fn (): int => $this->tabCounts()['fulfilled'])
                 ->badgeColor('info')
                 ->query(
                     fn (Builder $query): Builder => $query
@@ -102,11 +88,7 @@ class Index extends AbstractPageComponent implements HasActions, HasSchemas, Has
                 ),
             'cancelled' => Tab::make(OrderStatus::Cancelled->getLabel())
                 ->icon(OrderStatus::Cancelled->getIcon())
-                ->badge(
-                    fn (): int => $orderModel::query()
-                        ->where('status', OrderStatus::Cancelled)
-                        ->count()
-                )
+                ->badge(fn (): int => $this->tabCounts()['cancelled'])
                 ->badgeColor('danger')
                 ->query(
                     fn (Builder $query): Builder => $query
@@ -114,17 +96,45 @@ class Index extends AbstractPageComponent implements HasActions, HasSchemas, Has
                 ),
             'archived' => Tab::make(OrderStatus::Archived->getLabel())
                 ->icon(OrderStatus::Archived->getIcon())
-                ->badge(
-                    fn (): int => $orderModel::query()
-                        ->where('status', OrderStatus::Archived)
-                        ->count()
-                )
+                ->badge(fn (): int => $this->tabCounts()['archived'])
                 ->badgeColor('gray')
                 ->query(
                     fn (Builder $query): Builder => $query
                         ->where('status', OrderStatus::Archived)
                 ),
         ];
+    }
+
+    /**
+     * One cached aggregate for every tab badge, instead of six live counts
+     * (one of them unfiltered) on every page load.
+     *
+     * @return array{all: int, open: int, paid: int, fulfilled: int, cancelled: int, archived: int}
+     */
+    public function tabCounts(): array
+    {
+        return Cache::flexible('admin:orders:tab-counts', [60, 300], function (): array {
+            $orders = resolve(Order::class)::query()
+                ->toBase()
+                ->select(['status', 'payment_status', 'shipping_status'])
+                ->selectRaw('COUNT(*) as aggregate')
+                ->groupBy('status', 'payment_status', 'shipping_status')
+                ->get();
+
+            $sum = fn (callable $matches): int => (int) $orders
+                ->filter(fn (object $row): bool => $matches($row))
+                ->sum('aggregate');
+
+            return [
+                'all' => (int) $orders->sum('aggregate'),
+                'open' => $sum(fn (object $row): bool => in_array($row->status, [OrderStatus::New->value, OrderStatus::Processing->value], true)
+                    && $row->shipping_status === ShippingStatus::Unfulfilled->value),
+                'paid' => $sum(fn (object $row): bool => $row->payment_status === PaymentStatus::Paid->value),
+                'fulfilled' => $sum(fn (object $row): bool => in_array($row->shipping_status, [ShippingStatus::Shipped->value, ShippingStatus::PartiallyShipped->value], true)),
+                'cancelled' => $sum(fn (object $row): bool => $row->status === OrderStatus::Cancelled->value),
+                'archived' => $sum(fn (object $row): bool => $row->status === OrderStatus::Archived->value),
+            ];
+        });
     }
 
     public function table(Table $table): Table

--- a/packages/core/src/CoreServiceProvider.php
+++ b/packages/core/src/CoreServiceProvider.php
@@ -22,6 +22,7 @@ use Shopper\Core\Models\Order;
 use Shopper\Core\Models\OrderItem;
 use Shopper\Core\Models\Product;
 use Shopper\Core\Models\ProductVariant;
+use Shopper\Core\Models\TaxZone;
 use Shopper\Core\Observers\AddressObserver;
 use Shopper\Core\Observers\AttributeObserver;
 use Shopper\Core\Observers\CategoryObserver;
@@ -32,6 +33,7 @@ use Shopper\Core\Observers\OrderItemObserver;
 use Shopper\Core\Observers\OrderObserver;
 use Shopper\Core\Observers\ProductObserver;
 use Shopper\Core\Observers\ProductVariantObserver;
+use Shopper\Core\Observers\TaxZoneObserver;
 use Shopper\Core\Stock\DefaultInventoryResolver;
 use Shopper\Core\Stock\LockingStockReserver;
 use Shopper\Core\Stock\PriorityStockAllocator;
@@ -93,6 +95,7 @@ final class CoreServiceProvider extends PackageServiceProvider
         Order::observeUsingConfiguredClass(OrderObserver::class);
         Product::observeUsingConfiguredClass(ProductObserver::class);
         ProductVariant::observeUsingConfiguredClass(ProductVariantObserver::class);
+        TaxZone::observeUsingConfiguredClass(TaxZoneObserver::class);
 
         Attribute::observe(AttributeObserver::class);
         Discount::observe(DiscountObserver::class);

--- a/packages/core/src/Observers/TaxZoneObserver.php
+++ b/packages/core/src/Observers/TaxZoneObserver.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Core\Observers;
+
+use Illuminate\Support\Facades\Cache;
+use Shopper\Core\Models\TaxZone;
+
+final class TaxZoneObserver
+{
+    public function saved(TaxZone $taxZone): void
+    {
+        $this->bumpZoneCacheVersion();
+    }
+
+    public function deleted(TaxZone $taxZone): void
+    {
+        $this->bumpZoneCacheVersion();
+    }
+
+    private function bumpZoneCacheVersion(): void
+    {
+        Cache::increment('shopper.tax-zones.version');
+    }
+}

--- a/packages/core/src/Taxes/TaxCalculator.php
+++ b/packages/core/src/Taxes/TaxCalculator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Shopper\Core\Taxes;
 
+use Illuminate\Support\Facades\Cache;
 use Shopper\Core\Contracts\TaxableItem;
 use Shopper\Core\Contracts\TaxCalculationProvider;
 use Shopper\Core\Models\Contracts\TaxZone;
@@ -50,6 +51,12 @@ final class TaxCalculator
         );
     }
 
+    /**
+     * Zone resolution is memoized for the request, then shared across
+     * requests through a versioned cache: tax zones almost never change,
+     * yet every cart calculation used to re-run this lookup. Saving or
+     * deleting a zone bumps the version and orphans every cached entry.
+     */
     public function resolveZone(TaxCalculationContext $context): ?TaxZone
     {
         $key = $context->cacheKey();
@@ -58,6 +65,20 @@ final class TaxCalculator
             return $this->zoneCache[$key];
         }
 
+        $version = (int) Cache::get('shopper.tax-zones.version', 0);
+
+        /** @var array{zone: ?TaxZone} $cached */
+        $cached = Cache::flexible(
+            "shopper.tax-zone.{$version}.{$key}",
+            [3600, 86400],
+            fn (): array => ['zone' => $this->lookupZone($context)],
+        );
+
+        return $this->zoneCache[$key] = $cached['zone'];
+    }
+
+    private function lookupZone(TaxCalculationContext $context): ?TaxZone
+    {
         if ($context->provinceCode) {
             $zone = resolve(TaxZone::class)::query()
                 ->whereHas('country', fn ($q) => $q->where('cca2', $context->countryCode))
@@ -65,11 +86,11 @@ final class TaxCalculator
                 ->first();
 
             if ($zone) {
-                return $this->zoneCache[$key] = $zone;
+                return $zone;
             }
         }
 
-        return $this->zoneCache[$key] = resolve(TaxZone::class)::query()
+        return resolve(TaxZone::class)::query()
             ->whereHas('country', fn ($q) => $q->where('cca2', $context->countryCode))
             ->whereNull('province_code')
             ->first();

--- a/tests/Admin/Livewire/Pages/Order/OrderTabCountsTest.php
+++ b/tests/Admin/Livewire/Pages/Order/OrderTabCountsTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+use Livewire\Livewire;
+use Shopper\Core\Enum\OrderStatus;
+use Shopper\Core\Enum\PaymentStatus;
+use Shopper\Core\Enum\ShippingStatus;
+use Shopper\Core\Models\Order;
+use Shopper\Livewire\Pages\Order\Index;
+use Tests\Core\Stubs\User;
+
+uses(Tests\Admin\TestCase::class);
+
+beforeEach(function (): void {
+    $this->user = User::factory()->create();
+    $this->user->assignRole(config('shopper.admin.roles.admin'));
+    $this->actingAs($this->user);
+});
+
+it('aggregates every tab badge from a single cached query', function (): void {
+    Order::factory()->create([
+        'status' => OrderStatus::New,
+        'payment_status' => PaymentStatus::Pending,
+        'shipping_status' => ShippingStatus::Unfulfilled,
+    ]);
+    Order::factory()->create([
+        'status' => OrderStatus::Processing,
+        'payment_status' => PaymentStatus::Paid,
+        'shipping_status' => ShippingStatus::Unfulfilled,
+    ]);
+    Order::factory()->create([
+        'status' => OrderStatus::Completed,
+        'payment_status' => PaymentStatus::Paid,
+        'shipping_status' => ShippingStatus::Shipped,
+    ]);
+    Order::factory()->create([
+        'status' => OrderStatus::Cancelled,
+        'payment_status' => PaymentStatus::Voided,
+        'shipping_status' => ShippingStatus::Unfulfilled,
+    ]);
+
+    $counts = Livewire::test(Index::class)->instance()->tabCounts();
+
+    expect($counts['all'])->toBe(4)
+        ->and($counts['open'])->toBe(2)
+        ->and($counts['paid'])->toBe(2)
+        ->and($counts['fulfilled'])->toBe(1)
+        ->and($counts['cancelled'])->toBe(1)
+        ->and($counts['archived'])->toBe(0);
+})->group('livewire', 'orders');

--- a/tests/Core/Workflows/Taxes/TaxZoneCacheTest.php
+++ b/tests/Core/Workflows/Taxes/TaxZoneCacheTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+use Shopper\Core\Models\Country;
+use Shopper\Core\Models\TaxZone;
+use Shopper\Core\Taxes\TaxCalculationContext;
+use Shopper\Core\Taxes\TaxCalculator;
+
+uses(Tests\Core\TestCase::class);
+
+it('serves the resolved tax zone from the cache and invalidates it when a zone changes', function (): void {
+    $country = Country::query()->where('cca2', 'US')->first()
+        ?? Country::factory()->create(['cca2' => 'US', 'name' => 'United States']);
+
+    $zone = TaxZone::factory()->create([
+        'country_id' => $country->id,
+        'is_tax_inclusive' => false,
+    ]);
+
+    $context = new TaxCalculationContext(countryCode: 'US');
+
+    $resolved = resolve(TaxCalculator::class)->resolveZone($context);
+    expect($resolved->is_tax_inclusive)->toBeFalse();
+
+    $zone->update(['is_tax_inclusive' => true]);
+
+    app()->forgetInstance(TaxCalculator::class);
+
+    $fresh = resolve(TaxCalculator::class)->resolveZone($context);
+    expect($fresh->is_tax_inclusive)->toBeTrue();
+})->group('core', 'taxes');


### PR DESCRIPTION
## Summary

The admin panel carried several aggregate queries that stop scaling on a large order book:

- The dashboard stat cards wrapped `created_at` in `whereMonth()`/`whereYear()`, which defeats the composite indexes that already exist on `orders`. They now use `whereBetween` with precomputed month boundaries, so the cached refresh is index-served.
- The orders list ran six live `COUNT(*)` queries for its tab badges on every page load, one of them with no WHERE clause at all. A single grouped aggregate now feeds all six badges from one short-lived flexible cache entry.
- The customers page statistics (a full-table double aggregate through two join subqueries) ran on every visit since `#[Computed]` only memoizes within one Livewire lifecycle. They now use the same flexible cache pattern as the dashboard widgets.
- The top selling products widget aggregated the entire order items history; it is now bounded to the last 90 days, which is also the honest meaning of a top sellers widget.
- The countries list on the customer creation page used `Cache::get` with a default closure, which never writes back: the query ran on every render. It is a real day-long `Cache::remember` now.
- Tax zone resolution, which runs on every cart calculation for data that almost never changes, is now shared across requests through a versioned flexible cache. Saving or deleting a tax zone bumps the version, instantly orphaning every cached entry with no flush.

## Tests

The six tab counts asserted against a mixed set of orders through the single aggregate, and the tax zone cache invalidation on zone update. Full Core, Cart and admin order suites green.