### PR TITLE
fix(payment): journal the payment reference atomically with the order

### DIFF
--- a/packages/api/src/Actions/CompleteCartAction.php
+++ b/packages/api/src/Actions/CompleteCartAction.php
@@ -64,12 +64,9 @@ final readonly class CompleteCartAction
             $order = $this->createOrderFromCart->execute(
                 $cart,
                 fn (CartPipelineContext $context) => $this->guardPaymentSession($cart, $context->total),
+                fn (Order $order) => $this->recordInitiatedPayment($cart, $order),
             );
         } catch (CartCompletedException) {
-            // A concurrent completion won the cart lock between our staleness
-            // check and the transaction: answer with the order it placed, the
-            // same way a sequential retry does. No payment is journalized
-            // here, the winning request already did it.
             /** @var Order $order */
             $order = $cart->refresh()->order()->firstOrFail();
 
@@ -83,8 +80,6 @@ final readonly class CompleteCartAction
                 'cart' => $exception->getMessage(),
             ]);
         }
-
-        $this->recordInitiatedPayment($cart, $order);
 
         return $order;
     }

--- a/packages/cart/src/Actions/CreateOrderFromCartAction.php
+++ b/packages/cart/src/Actions/CreateOrderFromCartAction.php
@@ -44,12 +44,16 @@ final readonly class CreateOrderFromCartAction
      * @param  Closure(CartPipelineContext): void|null  $assertTotals  Runs against
      *                                                                 the totals computed under the cart lock, right before the order
      *                                                                 freezes them. Throw to abort: the transaction rolls back.
+     * @param  Closure(Order): void|null  $afterCreate  Runs on the created order inside
+     *                                                  the same transaction, so anything it persists
+     *                                                  (like the payment reference) commits or rolls
+     *                                                  back atomically with the order.
      *
      * @throws Throwable
      */
-    public function execute(Cart $cart, ?Closure $assertTotals = null): Order
+    public function execute(Cart $cart, ?Closure $assertTotals = null, ?Closure $afterCreate = null): Order
     {
-        return DB::transaction(function () use ($cart, $assertTotals): Order {
+        return DB::transaction(function () use ($cart, $assertTotals, $afterCreate): Order {
             /** @var Cart $cart */
             $cart = resolve(CartContract::class)::query()->lockForUpdate()->findOrFail($cart->id);
 
@@ -157,6 +161,10 @@ final readonly class CreateOrderFromCartAction
             $this->reservePromotions($applied, $cart, $order);
 
             $order->refresh();
+
+            if ($afterCreate) {
+                $afterCreate($order);
+            }
 
             $cart->update([
                 'completed_at' => now(),

--- a/tests/Cart/Feature/CreateOrderFromCartTest.php
+++ b/tests/Cart/Feature/CreateOrderFromCartTest.php
@@ -393,6 +393,21 @@ describe(CreateOrderFromCartAction::class, function (): void {
             ->and((float) $taxLines->sole()->rate)->toBe(20.0);
     });
 
+    it('rolls back the whole order when the after-create hook fails', function (): void {
+        $this->cartManager->add($this->cart, $this->product, quantity: 2);
+
+        expect(fn () => $this->action->execute(
+            $this->cart,
+            afterCreate: function (): void {
+                throw new RuntimeException('payment journal failed');
+            },
+        ))->toThrow(RuntimeException::class);
+
+        expect(Order::query()->count())->toBe(0)
+            ->and($this->cart->refresh()->isCompleted())->toBeFalse()
+            ->and($this->product->refresh()->getStock())->toBe(100);
+    });
+
     it('marks the cart as completed after order creation', function (): void {
         $this->cartManager->add($this->cart, $this->product);
 


### PR DESCRIPTION
## Summary

The `Initiate` payment transaction carrying the gateway reference was inserted after the order creation transaction committed. If that insert failed (process crash, deadlock, restart), the order existed with no reference row: the payment webhook resolved the order by reference, found nothing and returned silently. The customer was charged at the gateway while the order stayed pending forever.

`CreateOrderFromCartAction::execute()` gains an optional `afterCreate` hook running on the created order inside the same transaction, following the existing `assertTotals` convention. `CompleteCartAction` journals the payment reference through it, so the reference commits or rolls back atomically with the order and no intermediate state can exist. The idempotent paths (already completed cart, lock race loser) still journal nothing, as before.

## Tests

A failing after-create hook rolls back the entire checkout: no order row, cart not completed, reserved stock returned. Full checkout and webhook suites green.