### PR TITLE
feat(cart): merge the guest cart into the customer cart on sign-in

### DIFF
--- a/packages/api/src/Actions/TransferCartAction.php
+++ b/packages/api/src/Actions/TransferCartAction.php
@@ -5,35 +5,53 @@ declare(strict_types=1);
 namespace Shopper\Api\Actions;
 
 use Illuminate\Auth\Access\AuthorizationException;
+use Shopper\Cart\CartManager;
 use Shopper\Cart\Models\Cart;
+use Shopper\Cart\Models\Contracts\Cart as CartContract;
 
 final readonly class TransferCartAction
 {
     public function __construct(
+        private CartManager $cartManager,
         private RevalidateCartCouponAction $revalidateCoupon,
     ) {}
 
     /**
-     * Attach a guest cart to a customer. Transferring a cart the customer
-     * already owns is a no-op, so a retried login never fails; a cart owned
-     * by another customer is refused. Once the cart belongs to the customer,
-     * an applied coupon is re-validated against their redemption history and
-     * dropped if a per-customer limit now rejects it.
+     * Attach a guest cart to a customer, folding it into the cart the
+     * customer already owns when one exists so nothing they saved earlier is
+     * lost. Transferring a cart the customer already owns is a no-op, so a
+     * retried login never fails; a cart owned by another customer is refused.
+     * Once the cart belongs to the customer, an applied coupon is
+     * re-validated against their redemption history and dropped if a
+     * per-customer limit now rejects it.
      *
      * @throws AuthorizationException
      */
-    public function execute(Cart $cart, int $customerId): void
+    public function execute(Cart $cart, int $customerId): Cart
     {
         if ($cart->customer_id === $customerId) {
-            return;
+            return $cart;
         }
 
         if ($cart->customer_id !== null) {
             throw new AuthorizationException;
         }
 
-        $cart->update(['customer_id' => $customerId]);
+        /** @var Cart|null $existing */
+        $existing = resolve(CartContract::class)::query()
+            ->where('customer_id', $customerId)
+            ->whereNull('completed_at')
+            ->latest()
+            ->first();
+
+        if ($existing) {
+            $cart = $this->cartManager->merge($cart, $existing);
+        } else {
+            $cart->update(['customer_id' => $customerId]);
+        }
 
         $this->revalidateCoupon->execute($cart);
+
+        return $cart;
     }
 }

--- a/packages/api/src/Http/Controllers/Cart/CartTransferController.php
+++ b/packages/api/src/Http/Controllers/Cart/CartTransferController.php
@@ -21,15 +21,15 @@ final class CartTransferController
      * Transfer a guest cart to the authenticated customer.
      *
      * Used when a guest signs in mid checkout: the cart they built is attached
-     * to their account. Idempotent for a cart they already own, refused for a
-     * cart that belongs to another customer.
+     * to their account, and folded into the cart they already owned when one
+     * exists. The response carries the resulting cart; persist its id, the
+     * guest id is gone after a merge. Idempotent for a cart they already own,
+     * refused for a cart that belongs to another customer.
      */
     public function __invoke(Request $request, string $cartId): JsonApiResource
     {
-        $cart = $this->findCartOrFail($cartId);
-
-        $this->action->execute(
-            cart: $cart,
+        $cart = $this->action->execute(
+            cart: $this->findCartOrFail($cartId),
             customerId: (int) $request->user()->getAuthIdentifier(),
         );
 

--- a/packages/cart/src/CartManager.php
+++ b/packages/cart/src/CartManager.php
@@ -260,6 +260,65 @@ final readonly class CartManager
         });
     }
 
+    /**
+     * Fold a guest cart into the cart a customer already owns, the standard
+     * expectation when signing in mid shopping. Quantities of the same
+     * purchasable are summed, other lines move over re-priced in the target
+     * currency, applied code promotions carry over without duplicating, and
+     * the emptied source cart is deleted. Stock is not guarded here: the
+     * checkout reservation remains the gate, exactly as for a stale cart.
+     *
+     * @throws Throwable
+     */
+    public function merge(Cart $source, Cart $target): Cart
+    {
+        $this->guardCompleted($source);
+        $this->guardCompleted($target);
+        $this->invalidateTotals($target);
+
+        return DB::transaction(function () use ($source, $target): Cart {
+            $source->loadMissing(['lines.purchasable.prices', 'promotions']);
+
+            foreach ($source->lines as $line) {
+                $existing = $target->lines()
+                    ->where('purchasable_type', $line->purchasable_type)
+                    ->where('purchasable_id', $line->purchasable_id)
+                    ->lockForUpdate()
+                    ->first();
+
+                if ($existing) {
+                    $existing->update(['quantity' => $existing->quantity + $line->quantity]);
+                    $line->delete();
+
+                    continue;
+                }
+
+                $purchasable = $line->purchasable;
+                $price = $source->currency_code === $target->currency_code
+                    ? null
+                    : ($purchasable instanceof Priceable ? $purchasable->getPrice($target->currency_code) : null);
+
+                $line->update([
+                    'cart_id' => $target->id,
+                    ...($source->currency_code === $target->currency_code
+                        ? []
+                        : ['unit_price_amount' => $price ? $price->amount : 0]),
+                ]);
+            }
+
+            foreach ($source->promotions as $promotion) {
+                $target->promotions()->firstOrCreate(
+                    ['discount_id' => $promotion->discount_id],
+                    ['source' => $promotion->source, 'code' => $promotion->code],
+                );
+            }
+
+            $source->delete();
+
+            return $target;
+        });
+    }
+
     public function applyCoupon(Cart $cart, string $code): void
     {
         $this->guardCompleted($cart);

--- a/packages/cart/src/CartSessionManager.php
+++ b/packages/cart/src/CartSessionManager.php
@@ -60,11 +60,35 @@ final class CartSessionManager
         $this->session->forget($this->sessionKey());
     }
 
+    /**
+     * Attach the session cart to the user who just signed in, folding it into
+     * the cart they already owned when one exists and repointing the session
+     * to the surviving cart.
+     */
     public function associate(Authenticatable $user): void
     {
         $cart = $this->current();
 
         if (! $cart) {
+            return;
+        }
+
+        if ($cart->customer_id === $user->getAuthIdentifier()) {
+            return;
+        }
+
+        /** @var Cart|null $existing */
+        $existing = resolve(CartContract::class)::query()
+            ->where('customer_id', $user->getAuthIdentifier())
+            ->whereNull('completed_at')
+            ->latest()
+            ->first();
+
+        if ($existing) {
+            $merged = resolve(CartManager::class)->merge($cart, $existing);
+
+            $this->use($merged);
+
             return;
         }
 

--- a/tests/Api/Feature/CartEndpointsTest.php
+++ b/tests/Api/Feature/CartEndpointsTest.php
@@ -545,6 +545,28 @@ it('transfers a guest cart to the authenticated customer', function (): void {
     expect($cart->refresh()->customer_id)->toBe($customer->id);
 });
 
+it('folds the guest cart into the cart the customer already owns on transfer', function (): void {
+    $customer = User::factory()->create();
+
+    $guestCart = Cart::factory()->create(['currency_code' => 'USD']);
+    $ownedCart = Cart::factory()->create(['currency_code' => 'USD', 'customer_id' => $customer->id]);
+
+    $cartManager = resolve(CartManager::class);
+    $cartManager->add($guestCart, $this->product, quantity: 2);
+    $cartManager->add($ownedCart, $this->product, quantity: 1);
+
+    Sanctum::actingAs($customer, ['store']);
+
+    $this->postJson("/store/carts/{$guestCart->public_id}/transfer")
+        ->assertOk()
+        ->assertJsonPath('data.id', (string) $ownedCart->public_id);
+
+    expect($ownedCart->lines()->first()->quantity)->toBe(3)
+        ->and(Cart::query()->find($guestCart->id))->toBeNull();
+
+    $this->getJson("/store/carts/{$guestCart->public_id}")->assertNotFound();
+});
+
 it('is idempotent when transferring an already owned cart', function (): void {
     $customer = User::factory()->create();
     $cart = Cart::factory()->create(['currency_code' => 'USD', 'customer_id' => $customer->id]);

--- a/tests/Cart/Feature/CartMergeTest.php
+++ b/tests/Cart/Feature/CartMergeTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+use Shopper\Cart\CartManager;
+use Shopper\Cart\CartSessionManager;
+use Shopper\Cart\Models\Cart;
+use Shopper\Core\Enum\PromotionSource;
+use Shopper\Core\Models\Currency;
+use Shopper\Core\Models\Discount;
+use Shopper\Core\Models\Inventory;
+use Shopper\Core\Models\Product;
+use Tests\Core\Stubs\User;
+
+uses(Tests\Cart\TestCase::class);
+
+beforeEach(function (): void {
+    setupCurrencies();
+
+    $this->currency = Currency::query()->where('code', 'USD')->first();
+    $this->cartManager = resolve(CartManager::class);
+    $this->inventory = Inventory::factory()->create();
+    $this->user = User::factory()->create();
+
+    $this->product = Product::factory()->standard()->create();
+    $this->product->prices()->create(['amount' => 1000, 'currency_id' => $this->currency->id]);
+    $this->product->load('prices');
+    $this->product->mutateStock($this->inventory->id, 100);
+
+    $this->guestCart = Cart::factory()->create(['currency_code' => 'USD']);
+    $this->userCart = Cart::factory()->create(['currency_code' => 'USD', 'customer_id' => $this->user->id]);
+});
+
+describe('CartManager::merge', function (): void {
+    it('sums the quantities of a purchasable present in both carts', function (): void {
+        $this->cartManager->add($this->guestCart, $this->product, quantity: 2);
+        $this->cartManager->add($this->userCart, $this->product, quantity: 3);
+
+        $merged = $this->cartManager->merge($this->guestCart, $this->userCart);
+
+        expect($merged->id)->toBe($this->userCart->id)
+            ->and($merged->lines()->count())->toBe(1)
+            ->and($merged->lines()->first()->quantity)->toBe(5)
+            ->and(Cart::query()->find($this->guestCart->id))->toBeNull();
+    });
+
+    it('moves lines the customer cart did not have', function (): void {
+        $other = Product::factory()->standard()->create();
+        $other->prices()->create(['amount' => 500, 'currency_id' => $this->currency->id]);
+        $other->load('prices');
+        $other->mutateStock($this->inventory->id, 50);
+
+        $this->cartManager->add($this->guestCart, $other, quantity: 1);
+        $this->cartManager->add($this->userCart, $this->product, quantity: 1);
+
+        $merged = $this->cartManager->merge($this->guestCart, $this->userCart);
+
+        expect($merged->lines()->count())->toBe(2)
+            ->and($merged->lines()->pluck('purchasable_id'))->toContain($other->id);
+    });
+
+    it('re-prices moved lines when the carts use different currencies', function (): void {
+        $eur = Currency::query()->where('code', 'EUR')->first();
+        $this->product->prices()->create(['amount' => 900, 'currency_id' => $eur->id]);
+        $this->product->load('prices');
+
+        $eurCart = Cart::factory()->create(['currency_code' => 'EUR', 'customer_id' => $this->user->id]);
+
+        $this->cartManager->add($this->guestCart, $this->product, quantity: 1);
+
+        $merged = $this->cartManager->merge($this->guestCart, $eurCart);
+
+        expect($merged->lines()->first()->unit_price_amount)->toBe(900);
+    });
+
+    it('carries applied promotions over without duplicating', function (): void {
+        $discount = Discount::factory()->create(['code' => 'WELCOME', 'is_active' => true]);
+
+        $this->guestCart->promotions()->create([
+            'discount_id' => $discount->id,
+            'source' => PromotionSource::Code->value,
+            'code' => 'WELCOME',
+        ]);
+        $this->userCart->promotions()->create([
+            'discount_id' => $discount->id,
+            'source' => PromotionSource::Code->value,
+            'code' => 'WELCOME',
+        ]);
+
+        $merged = $this->cartManager->merge($this->guestCart, $this->userCart);
+
+        expect($merged->promotions()->count())->toBe(1);
+    });
+});
+
+describe('CartSessionManager::associate', function (): void {
+    it('merges the session cart into the cart the user already owns', function (): void {
+        $session = resolve(CartSessionManager::class);
+        $session->use($this->guestCart);
+
+        $this->cartManager->add($this->guestCart, $this->product, quantity: 2);
+        $this->cartManager->add($this->userCart, $this->product, quantity: 1);
+
+        $session->associate($this->user);
+
+        expect($session->current()->id)->toBe($this->userCart->id)
+            ->and($this->userCart->lines()->first()->quantity)->toBe(3);
+    });
+
+    it('attaches the session cart when the user owns no cart', function (): void {
+        $freshUser = User::factory()->create();
+        $session = resolve(CartSessionManager::class);
+        $session->use($this->guestCart);
+
+        $session->associate($freshUser);
+
+        expect($this->guestCart->refresh()->customer_id)->toBe($freshUser->id);
+    });
+});


### PR DESCRIPTION
## Summary

A customer with a saved cart who built a guest cart while signed out lost their saved items on sign-in: the transfer endpoint attached the guest cart to the account without any reconciliation, leaving the older cart stranded. The standard expectation on Shopify and Medusa is a quantity merge.

- `CartManager::merge(source, target)` is the new primitive: quantities of a purchasable present in both carts are summed under a row lock, lines the target did not have move over and are re-priced when the currencies differ, applied code promotions carry over without duplicating, the emptied guest cart is deleted and the target totals are invalidated. Stock is deliberately not guarded at merge time: the checkout reservation remains the gate, exactly as for a stale cart.
- The Store API transfer endpoint folds the guest cart into the customer's active cart when one exists and responds with the surviving cart, so the client persists the right id; without an existing cart the attach behavior is unchanged, and the coupon revalidation still runs.
- `CartSessionManager::associate()` applies the same logic for host apps using the session flow, repointing the session to the merged cart.

## Tests

Quantity summing with the source cart deleted, distinct lines moved over, cross-currency re-pricing, promotions carried without duplication, the session flow merging and repointing, the plain attach when the customer owns no cart, and the API transfer answering with the owned cart while the guest id turns 404. The five existing transfer tests pass unchanged.