### PR TITLE
fix(checkout): revalidate the live line prices before placing the order

### DIFF
--- a/packages/api/src/Actions/CompleteCartAction.php
+++ b/packages/api/src/Actions/CompleteCartAction.php
@@ -10,6 +10,7 @@ use Shopper\Cart\Actions\CreateOrderFromCartAction;
 use Shopper\Cart\CartManager;
 use Shopper\Cart\Exceptions\CartCompletedException;
 use Shopper\Cart\Exceptions\InsufficientStockException;
+use Shopper\Cart\Exceptions\PriceChangedException;
 use Shopper\Cart\Models\Cart;
 use Shopper\Cart\Pipelines\CartPipelineContext;
 use Shopper\Core\Exceptions\CampaignBudgetExceededException;
@@ -75,7 +76,7 @@ final readonly class CompleteCartAction
             throw ValidationException::withMessages([
                 'promotion' => __('shopper-cart::messages.discount.campaign_budget_reached'),
             ]);
-        } catch (InsufficientStockException $exception) {
+        } catch (InsufficientStockException|PriceChangedException $exception) {
             throw ValidationException::withMessages([
                 'cart' => $exception->getMessage(),
             ]);

--- a/packages/cart/resources/lang/en/exceptions.php
+++ b/packages/cart/resources/lang/en/exceptions.php
@@ -7,6 +7,7 @@ return [
     'cart_completed' => 'Cart has already been completed.',
     'cart_not_found' => 'Cart not found.',
     'insufficient_stock' => 'Insufficient stock for this item.',
+    'price_changed' => 'The price of an item in your cart has changed. Please review your cart before checking out.',
     'quantity_minimum' => 'Quantity must be at least 1.',
     'discount_not_found' => 'Discount code not found.',
 

--- a/packages/cart/resources/lang/es/exceptions.php
+++ b/packages/cart/resources/lang/es/exceptions.php
@@ -7,6 +7,7 @@ return [
     'cart_completed' => 'El carrito ya ha sido completado.',
     'cart_not_found' => 'Carrito no encontrado.',
     'insufficient_stock' => 'Stock insuficiente para este artículo.',
+    'price_changed' => 'El precio de un artículo de tu carrito ha cambiado. Revisa tu carrito antes de finalizar la compra.',
     'quantity_minimum' => 'La cantidad debe ser al menos 1.',
     'discount_not_found' => 'Código de descuento no encontrado.',
 

--- a/packages/cart/resources/lang/fr/exceptions.php
+++ b/packages/cart/resources/lang/fr/exceptions.php
@@ -7,6 +7,7 @@ return [
     'cart_completed' => 'Le panier a déjà été finalisé.',
     'cart_not_found' => 'Panier introuvable.',
     'insufficient_stock' => 'Stock insuffisant pour cet article.',
+    'price_changed' => 'Le prix d\'un article de votre panier a changé. Veuillez vérifier votre panier avant de commander.',
     'quantity_minimum' => 'La quantité doit être d\'au moins 1.',
     'discount_not_found' => 'Code de réduction introuvable.',
 

--- a/packages/cart/src/Actions/CreateOrderFromCartAction.php
+++ b/packages/cart/src/Actions/CreateOrderFromCartAction.php
@@ -14,12 +14,14 @@ use Shopper\Cart\Events\CartCompleted;
 use Shopper\Cart\Exceptions\CartCompletedException;
 use Shopper\Cart\Exceptions\DiscountLimitReachedException;
 use Shopper\Cart\Exceptions\InsufficientStockException;
+use Shopper\Cart\Exceptions\PriceChangedException;
 use Shopper\Cart\Models\Cart;
 use Shopper\Cart\Models\CartAddress;
 use Shopper\Cart\Models\CartPromotion;
 use Shopper\Cart\Models\Contracts\Cart as CartContract;
 use Shopper\Cart\Pipelines\CartPipelineContext;
 use Shopper\Core\Actions\ReserveCampaignBudget;
+use Shopper\Core\Contracts\Priceable;
 use Shopper\Core\Contracts\StockReserver;
 use Shopper\Core\Models\CarrierOption;
 use Shopper\Core\Models\Contracts\Order;
@@ -60,6 +62,8 @@ final readonly class CreateOrderFromCartAction
             if ($cart->isCompleted()) {
                 throw new CartCompletedException;
             }
+
+            $this->revalidatePrices($cart);
 
             $context = $this->cartManager->calculate($cart);
 
@@ -175,6 +179,41 @@ final readonly class CreateOrderFromCartAction
 
             return $order;
         });
+    }
+
+    private function revalidatePrices(Cart $cart): void
+    {
+        $cart->loadMissing('lines.purchasable.prices');
+
+        foreach ($cart->lines as $line) {
+            $purchasable = $line->purchasable;
+
+            if (! $purchasable instanceof Priceable) {
+                continue;
+            }
+
+            $price = $purchasable->getPrice($cart->currency_code);
+
+            // No resolvable live price means the price cannot be revalidated,
+            // not that it dropped to zero: keep the frozen amount. A genuinely
+            // free item carries a zero-amount price row and is revalidated.
+            if ($price === null) {
+                continue;
+            }
+
+            $live = (int) $price->amount;
+            $frozen = (int) $line->unit_price_amount;
+
+            if ($live === $frozen) {
+                continue;
+            }
+
+            if ($live > $frozen) {
+                throw new PriceChangedException($purchasable, $frozen, $live);
+            }
+
+            $line->update(['unit_price_amount' => $live]);
+        }
     }
 
     /**

--- a/packages/cart/src/Exceptions/PriceChangedException.php
+++ b/packages/cart/src/Exceptions/PriceChangedException.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Cart\Exceptions;
+
+use Illuminate\Database\Eloquent\Model;
+use RuntimeException;
+
+final class PriceChangedException extends RuntimeException
+{
+    public function __construct(
+        public readonly Model $purchasable,
+        public readonly int $was,
+        public readonly int $now,
+    ) {
+        parent::__construct(__('shopper-cart::exceptions.price_changed'));
+    }
+}

--- a/tests/Cart/Feature/CreateOrderFromCartTest.php
+++ b/tests/Cart/Feature/CreateOrderFromCartTest.php
@@ -7,6 +7,7 @@ use Shopper\Cart\Actions\CreateOrderFromCartAction;
 use Shopper\Cart\CartManager;
 use Shopper\Cart\Events\CartCompleted;
 use Shopper\Cart\Exceptions\CartCompletedException;
+use Shopper\Cart\Exceptions\PriceChangedException;
 use Shopper\Cart\Models\Cart;
 use Shopper\Core\Enum\AddressType;
 use Shopper\Core\Enum\DiscountApplyTo;
@@ -391,6 +392,31 @@ describe(CreateOrderFromCartAction::class, function (): void {
             ->and($order->tax_amount)->toBe($taxLines->sum('amount'))
             ->and($orderItem->tax_amount)->toBe($taxLines->sum('amount'))
             ->and((float) $taxLines->sole()->rate)->toBe(20.0);
+    });
+
+    it('passes a price drop since add-to-cart on to the customer', function (): void {
+        $this->cartManager->add($this->cart, $this->product, quantity: 2);
+
+        $this->product->prices()->first()->update(['amount' => 20]);
+        $this->product->load('prices');
+
+        $order = $this->action->execute($this->cart->refresh());
+
+        expect($order->items->first()->unit_price_amount)->toBe(20)
+            ->and($order->price_amount)->toBe(40);
+    });
+
+    it('refuses to place the order when a line price increased since add-to-cart', function (): void {
+        $this->cartManager->add($this->cart, $this->product, quantity: 2);
+
+        $this->product->prices()->first()->update(['amount' => 30]);
+        $this->product->load('prices');
+
+        expect(fn () => $this->action->execute($this->cart->refresh()))
+            ->toThrow(PriceChangedException::class);
+
+        expect(Order::query()->count())->toBe(0)
+            ->and($this->cart->refresh()->isCompleted())->toBeFalse();
     });
 
     it('rolls back the whole order when the after-create hook fails', function (): void {


### PR DESCRIPTION
## Summary

The unit price was frozen at add-to-cart and used verbatim at checkout, never compared to the live price. An item added at 10 that the merchant raised to 15 kept selling at 10 on every dormant cart, a direct revenue leak; a price drop was likewise never passed on.

`CreateOrderFromCartAction` now revalidates every line's live price under the cart lock before computing totals, mirroring the existing shipping-quote refresh:

- A price drop since add-to-cart is passed on to the customer (the line updates to the live amount).
- A price increase is refused with `PriceChangedException` (422 on the API): the client shows the new cart and the customer re-consents.
- A line whose live price is not resolvable keeps its frozen amount, since that means the price cannot be revalidated, not that it dropped to zero. A genuinely free item carries a zero-amount price row and is revalidated.

Running under the cart lock, the existing payment-session guard still rejects any total that moved between the intent and completion.

## Tests

A price drop passed on to the order, a price increase refused with a full rollback, and the existing cart and checkout suites unchanged. Translations added in en, fr and es.