### PR TITLE
fix(fulfillment): throw on an invalid shipment status transition

### DIFF
--- a/packages/core/src/Exceptions/InvalidShipmentStatusTransitionException.php
+++ b/packages/core/src/Exceptions/InvalidShipmentStatusTransitionException.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Core\Exceptions;
+
+use RuntimeException;
+use Shopper\Core\Enum\ShipmentStatus;
+
+final class InvalidShipmentStatusTransitionException extends RuntimeException
+{
+    public static function between(?ShipmentStatus $from, ShipmentStatus $to): self
+    {
+        return new self(sprintf(
+            'Cannot transition a shipment from "%s" to "%s".',
+            $from instanceof ShipmentStatus ? $from->value : 'none',
+            $to->value,
+        ));
+    }
+}

--- a/packages/core/src/Traits/HasFulfillmentTransitions.php
+++ b/packages/core/src/Traits/HasFulfillmentTransitions.php
@@ -7,6 +7,7 @@ namespace Shopper\Core\Traits;
 use Carbon\CarbonInterface;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Shopper\Core\Enum\ShipmentStatus;
+use Shopper\Core\Exceptions\InvalidShipmentStatusTransitionException;
 use Shopper\Core\Models\OrderShippingEvent;
 
 trait HasFulfillmentTransitions
@@ -95,7 +96,7 @@ trait HasFulfillmentTransitions
     public function transitionTo(ShipmentStatus $status, array $context = []): void
     {
         if (! $this->canTransitionTo($status)) {
-            return;
+            throw InvalidShipmentStatusTransitionException::between($this->status, $status);
         }
 
         $this->update(['status' => $status]);

--- a/tests/Core/Workflows/Order/ShipmentTransitionTest.php
+++ b/tests/Core/Workflows/Order/ShipmentTransitionTest.php
@@ -7,6 +7,7 @@ use Shopper\Core\Enum\FulfillmentStatus;
 use Shopper\Core\Enum\OrderStatus;
 use Shopper\Core\Enum\ShipmentStatus;
 use Shopper\Core\Enum\ShippingStatus;
+use Shopper\Core\Exceptions\InvalidShipmentStatusTransitionException;
 use Shopper\Core\Models\Order;
 use Shopper\Core\Models\OrderItem;
 use Shopper\Core\Models\OrderShipping;
@@ -104,6 +105,32 @@ describe('Shipment state machine — invalid transitions', function (): void {
         expect($shipment->refresh()->items)->each(
             fn ($item) => $item->fulfillment_status->toBe(FulfillmentStatus::Pending)
         );
+    });
+    it('throws on an invalid explicit transition instead of silently no-oping', function (): void {
+        $shipment = OrderShipping::query()->create([
+            'order_id' => Order::factory()->create()->id,
+            'status' => ShipmentStatus::Pending,
+            'shipped_at' => now(),
+        ]);
+
+        expect(fn () => $shipment->transitionTo(ShipmentStatus::Delivered))
+            ->toThrow(InvalidShipmentStatusTransitionException::class);
+
+        expect($shipment->refresh()->status)->toBe(ShipmentStatus::Pending)
+            ->and($shipment->events()->count())->toBe(0);
+    });
+
+    it('performs a valid explicit transition and logs the event', function (): void {
+        $shipment = OrderShipping::query()->create([
+            'order_id' => Order::factory()->create()->id,
+            'status' => ShipmentStatus::Pending,
+            'shipped_at' => now(),
+        ]);
+
+        $shipment->transitionTo(ShipmentStatus::PickedUp, ['location' => 'Douala hub']);
+
+        expect($shipment->refresh()->status)->toBe(ShipmentStatus::PickedUp)
+            ->and($shipment->events()->latest('id')->first()->location)->toBe('Douala hub');
     });
 })
     ->group('workflows', 'order-fulfillment');


### PR DESCRIPTION
## Summary

`HasFulfillmentTransitions::transitionTo()` silently returned on an invalid transition, unlike `OrderStatus::transitionTo()` and `PaymentStatus::transitionTo()` which throw. A caller (admin action, API) got a success while nothing changed, masking bugs and losing tracking events.

`transitionTo()` now throws `InvalidShipmentStatusTransitionException`, mirroring the two existing transition exceptions, so all three state machines share the same contract.

`RecordShipmentEventAction` keeps its own `canTransitionTo` guard returning null on an invalid transition: carrier events arrive out of order and an out-of-sequence update must be ignored gently, not throw. So there are two clear paths, the explicit admin/API `transitionTo()` that throws and the lenient carrier-event action.

## Tests

An invalid explicit transition throws and leaves the status and events untouched, a valid one changes the status and logs the event, and the existing shipment and order fulfillment suites are unchanged.