### PR TITLE
feat(core): addon extension points for routes, customer events and cart pipeline

### DIFF
--- a/packages/admin/resources/views/livewire/pages/orders/detail.blade.php
+++ b/packages/admin/resources/views/livewire/pages/orders/detail.blade.php
@@ -125,6 +125,8 @@
     {{ shopper()->getRenderHook(\Shopper\View\OrderRenderHook::DETAIL_HEADER_AFTER) }}
 
     <x-shopper::container>
+        {{ shopper()->getRenderHook(\Shopper\View\OrderRenderHook::DETAIL_CONTENT_BEFORE) }}
+
         {{ shopper()->getRenderHook(\Shopper\View\OrderRenderHook::DETAIL_MAIN_BEFORE) }}
 
         <div class="grid sm:grid-cols-6">
@@ -150,6 +152,8 @@
                 {{ shopper()->getRenderHook(\Shopper\View\OrderRenderHook::DETAIL_SIDEBAR_AFTER) }}
             </div>
         </div>
+
+        {{ shopper()->getRenderHook(\Shopper\View\OrderRenderHook::DETAIL_CONTENT_AFTER) }}
     </x-shopper::container>
 
     <x-filament-actions::modals />

--- a/packages/admin/src/Addon/AddonManager.php
+++ b/packages/admin/src/Addon/AddonManager.php
@@ -34,9 +34,6 @@ final class AddonManager
     private array $productSections = [];
 
     /** @var list<string> */
-    private array $permissions = [];
-
-    /** @var list<string> */
     private array $styles = [];
 
     /** @var list<string> */
@@ -151,22 +148,6 @@ final class AddonManager
     public function getProductSections(): array
     {
         return $this->productSections;
-    }
-
-    /**
-     * @param  list<string>  $permissions
-     */
-    public function addPermissions(array $permissions): void
-    {
-        $this->permissions = array_merge($this->permissions, $permissions);
-    }
-
-    /**
-     * @return list<string>
-     */
-    public function getPermissions(): array
-    {
-        return $this->permissions;
     }
 
     /**

--- a/packages/admin/src/Facades/Shopper.php
+++ b/packages/admin/src/Facades/Shopper.php
@@ -23,7 +23,6 @@ use Shopper\ShopperPanel;
  * @method static ShopperPanel addonLivewireComponents(array $components)
  * @method static ShopperPanel addonViews(string $namespace, string $path)
  * @method static ShopperPanel addonSettingItems(array $items)
- * @method static ShopperPanel addonPermissions(array $permissions)
  * @method static ShopperPanel addonStyles(array $styles)
  * @method static ShopperPanel addonScripts(array $scripts)
  * @method static StatefulGuard auth()

--- a/packages/admin/src/Livewire/Pages/Customers/Create.php
+++ b/packages/admin/src/Livewire/Pages/Customers/Create.php
@@ -28,6 +28,7 @@ use Shopper\Components\Form\GenderField;
 use Shopper\Components\Section;
 use Shopper\Components\Separator;
 use Shopper\Core\Enum\AddressType;
+use Shopper\Core\Events\Customers\CustomerRegistered;
 use Shopper\Core\Models\Country;
 use Shopper\Livewire\Pages\AbstractPageComponent;
 use Shopper\Models\Contracts\ShopperUser;
@@ -183,6 +184,8 @@ class Create extends AbstractPageComponent implements HasActions, HasSchemas
 
         $customer->assignRole(config('shopper.admin.roles.user'));
         $customer->addresses()->create($address);
+
+        event(new CustomerRegistered($customer));
 
         if ($sendMail) {
             $customer->notify(new CustomerSendCredentials($password));

--- a/packages/admin/src/ShopperPanel.php
+++ b/packages/admin/src/ShopperPanel.php
@@ -142,16 +142,6 @@ final class ShopperPanel
     }
 
     /**
-     * @param  list<string>  $permissions
-     */
-    public function addonPermissions(array $permissions): self
-    {
-        $this->addonManager()->addPermissions($permissions);
-
-        return $this;
-    }
-
-    /**
      * @param  list<string>  $styles
      */
     public function addonStyles(array $styles): self

--- a/packages/admin/src/ShopperServiceProvider.php
+++ b/packages/admin/src/ShopperServiceProvider.php
@@ -21,6 +21,7 @@ use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
 use Livewire\Livewire;
 use PragmaRX\Google2FA\Google2FA;
 use Shopper\Concerns\TwoFactorAuthenticationProvider;
@@ -190,6 +191,26 @@ final class ShopperServiceProvider extends PackageServiceProvider
         if ($productSections !== []) {
             app(ProductSectionManager::class)->register($productSections);
         }
+
+        $this->registerAddonRoutes($manager->getRoutes());
+    }
+
+    /**
+     * @param  list<Closure>  $routes
+     */
+    protected function registerAddonRoutes(array $routes): void
+    {
+        if ($routes === []) {
+            return;
+        }
+
+        Route::middleware(array_merge(['web'], (array) config('shopper.routes.middleware', [])))
+            ->prefix(shopper()->prefix())
+            ->group(function () use ($routes): void {
+                foreach ($routes as $registrar) {
+                    $registrar();
+                }
+            });
     }
 
     protected function bootLivewireComponents(): void

--- a/packages/admin/src/View/OrderRenderHook.php
+++ b/packages/admin/src/View/OrderRenderHook.php
@@ -12,6 +12,10 @@ final class OrderRenderHook
 
     public const string DETAIL_HEADER_AFTER = 'shopper::order.detail.header.after';
 
+    public const string DETAIL_CONTENT_BEFORE = 'shopper::order.detail.content.before';
+
+    public const string DETAIL_CONTENT_AFTER = 'shopper::order.detail.content.after';
+
     public const string DETAIL_MAIN_BEFORE = 'shopper::order.detail.main.before';
 
     public const string DETAIL_MAIN_AFTER = 'shopper::order.detail.main.after';

--- a/packages/api/src/Actions/RegisterCustomerAction.php
+++ b/packages/api/src/Actions/RegisterCustomerAction.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Database\DatabaseManager;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Hash;
+use Shopper\Core\Events\Customers\CustomerRegistered;
 
 final class RegisterCustomerAction
 {
@@ -36,6 +37,8 @@ final class RegisterCustomerAction
             if (method_exists($user, 'assignRole')) {
                 $user->assignRole((string) config('shopper.admin.roles.user', 'user'));
             }
+
+            event(new CustomerRegistered($user));
 
             return $user;
         });

--- a/packages/cart/src/CartServiceProvider.php
+++ b/packages/cart/src/CartServiceProvider.php
@@ -12,6 +12,7 @@ use Shopper\Cart\Models\Cart;
 use Shopper\Cart\Models\CartLine;
 use Shopper\Cart\Models\Contracts\Cart as CartContract;
 use Shopper\Cart\Models\Contracts\CartLine as CartLineContract;
+use Shopper\Cart\Pipelines\CartPipeline;
 use Shopper\Cart\Pipelines\CartPipelineRunner;
 use Shopper\Core\Traits\HasRegisterConfigAndMigrationFiles;
 use Spatie\LaravelPackageTools\Package;
@@ -48,6 +49,7 @@ final class CartServiceProvider extends PackageServiceProvider
         $this->registerDatabase();
         $this->registerModelBindings();
 
+        $this->app->singleton(CartPipeline::class);
         $this->app->singleton(CartPipelineRunner::class);
         $this->app->singleton(DiscountValidator::class);
         $this->app->singleton(PromotionResolver::class);

--- a/packages/cart/src/Pipelines/CartPipeline.php
+++ b/packages/cart/src/Pipelines/CartPipeline.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Cart\Pipelines;
+
+use InvalidArgumentException;
+
+final class CartPipeline
+{
+    /** @var list<array{position: string, anchor: class-string|null, step: class-string}> */
+    private array $insertions = [];
+
+    /**
+     * @param  class-string  $anchor
+     * @param  class-string  $step
+     */
+    public function insertAfter(string $anchor, string $step): void
+    {
+        $this->insertions[] = ['position' => 'after', 'anchor' => $anchor, 'step' => $step];
+    }
+
+    /**
+     * @param  class-string  $anchor
+     * @param  class-string  $step
+     */
+    public function insertBefore(string $anchor, string $step): void
+    {
+        $this->insertions[] = ['position' => 'before', 'anchor' => $anchor, 'step' => $step];
+    }
+
+    /**
+     * @param  class-string  $step
+     */
+    public function append(string $step): void
+    {
+        $this->insertions[] = ['position' => 'append', 'anchor' => null, 'step' => $step];
+    }
+
+    /**
+     * Build the final ordered step list from the configured base and the
+     * registered insertions. Insertions apply in registration order, so two
+     * add-ons anchoring on the same step keep a deterministic sequence. An
+     * insertion anchored on a step that is not in the pipeline fails fast at
+     * build time rather than silently dropping the add-on's behavior.
+     *
+     * @param  list<class-string>  $base
+     * @return list<class-string>
+     */
+    public function build(array $base): array
+    {
+        $steps = $base;
+
+        foreach ($this->insertions as $insertion) {
+            if ($insertion['position'] === 'append') {
+                $steps[] = $insertion['step'];
+
+                continue;
+            }
+
+            $index = array_search($insertion['anchor'], $steps, true);
+
+            if ($index === false) {
+                throw new InvalidArgumentException(sprintf(
+                    'Cannot insert the cart pipeline step [%s] %s [%s]: the anchor step is not in the pipeline.',
+                    $insertion['step'],
+                    $insertion['position'],
+                    $insertion['anchor'],
+                ));
+            }
+
+            $offset = $insertion['position'] === 'after' ? $index + 1 : $index;
+
+            array_splice($steps, $offset, 0, [$insertion['step']]);
+        }
+
+        return $steps;
+    }
+}

--- a/packages/cart/src/Pipelines/CartPipelineRunner.php
+++ b/packages/cart/src/Pipelines/CartPipelineRunner.php
@@ -7,8 +7,12 @@ namespace Shopper\Cart\Pipelines;
 use Illuminate\Pipeline\Pipeline;
 use Shopper\Cart\Models\Cart;
 
-final class CartPipelineRunner
+final readonly class CartPipelineRunner
 {
+    public function __construct(
+        private CartPipeline $pipeline,
+    ) {}
+
     public function run(Cart $cart): CartPipelineContext
     {
         $cart->loadMissing([
@@ -22,9 +26,12 @@ final class CartPipelineRunner
 
         $context = new CartPipelineContext($cart);
 
+        /** @var list<class-string> $base */
+        $base = config('shopper.cart.pipelines.cart', []);
+
         app(Pipeline::class)
             ->send($context)
-            ->through(config('shopper.cart.pipelines.cart'))
+            ->through($this->pipeline->build($base))
             ->thenReturn();
 
         return $context;

--- a/packages/core/src/Events/Customers/CustomerRegistered.php
+++ b/packages/core/src/Events/Customers/CustomerRegistered.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Core\Events\Customers;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Contracts\Events\ShouldDispatchAfterCommit;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+final class CustomerRegistered implements ShouldDispatchAfterCommit
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public function __construct(
+        public Authenticatable $customer,
+    ) {}
+}

--- a/tests/Admin/Addon/AddonRegistrationTest.php
+++ b/tests/Admin/Addon/AddonRegistrationTest.php
@@ -47,3 +47,20 @@ it('throws when the same addon is registered twice', function (): void {
         new FakeFirstAddon,
     ]))->toThrow(LogicException::class);
 });
+
+it('registers the routes an addon declares', function (): void {
+    $provider = app()->getProvider(Shopper\ShopperServiceProvider::class);
+
+    $consume = (new ReflectionMethod($provider, 'registerAddonRoutes'))
+        ->getClosure($provider);
+
+    $consume([function (): void {
+        Illuminate\Support\Facades\Route::get('/addon-probe', fn (): string => 'ok')->name('shopper.addon-probe');
+    }]);
+
+    $registered = collect(app('router')->getRoutes()->getRoutes())
+        ->contains(fn ($route): bool => $route->getName() === 'shopper.addon-probe'
+            && str_starts_with($route->uri(), shopper()->prefix()));
+
+    expect($registered)->toBeTrue();
+});

--- a/tests/Api/Feature/CustomerRegisteredEventTest.php
+++ b/tests/Api/Feature/CustomerRegisteredEventTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Event;
+use Shopper\Core\Events\Customers\CustomerRegistered;
+
+uses(Tests\Api\TestCase::class);
+
+it('dispatches `CustomerRegistered` when a customer registers through the Store API', function (): void {
+    Event::fake([CustomerRegistered::class]);
+
+    $this->postJson('/store/auth/register', [
+        'first_name' => 'Amadou',
+        'last_name' => 'Diallo',
+        'email' => 'amadou@example.com',
+        'password' => 'Password123!',
+        'password_confirmation' => 'Password123!',
+    ])->assertCreated();
+
+    Event::assertDispatched(
+        CustomerRegistered::class,
+        fn (CustomerRegistered $event): bool => $event->customer->email === 'amadou@example.com',
+    );
+});

--- a/tests/Cart/Feature/CartPipelineTest.php
+++ b/tests/Cart/Feature/CartPipelineTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+use Shopper\Cart\Pipelines\CalculateLines;
+use Shopper\Cart\Pipelines\CalculateTax;
+use Shopper\Cart\Pipelines\CartPipeline;
+
+uses(Tests\Cart\TestCase::class);
+
+const PIPELINE_BASE = [CalculateLines::class, CalculateTax::class];
+
+describe(CartPipeline::class, function (): void {
+    it('returns the base pipeline unchanged when no step is registered', function (): void {
+        $pipeline = new CartPipeline;
+
+        expect($pipeline->build(PIPELINE_BASE))->toBe(PIPELINE_BASE);
+    });
+
+    it('inserts a step after an anchor', function (): void {
+        $pipeline = new CartPipeline;
+        $pipeline->insertAfter(CalculateLines::class, 'App\\GiftCardStep');
+
+        expect($pipeline->build(PIPELINE_BASE))
+            ->toBe([CalculateLines::class, 'App\\GiftCardStep', CalculateTax::class]);
+    });
+
+    it('inserts a step before an anchor', function (): void {
+        $pipeline = new CartPipeline;
+        $pipeline->insertBefore(CalculateTax::class, 'App\\PriceListStep');
+
+        expect($pipeline->build(PIPELINE_BASE))
+            ->toBe([CalculateLines::class, 'App\\PriceListStep', CalculateTax::class]);
+    });
+
+    it('appends a step at the end', function (): void {
+        $pipeline = new CartPipeline;
+        $pipeline->append('App\\LoyaltyStep');
+
+        expect($pipeline->build(PIPELINE_BASE))
+            ->toBe([CalculateLines::class, CalculateTax::class, 'App\\LoyaltyStep']);
+    });
+
+    it('keeps a deterministic order when two add-ons anchor on the same step', function (): void {
+        $pipeline = new CartPipeline;
+        $pipeline->insertAfter(CalculateLines::class, 'App\\StepA');
+        $pipeline->insertAfter(CalculateLines::class, 'App\\StepB');
+
+        expect($pipeline->build(PIPELINE_BASE))
+            ->toBe([CalculateLines::class, 'App\\StepB', 'App\\StepA', CalculateTax::class]);
+    });
+
+    it('throws when the anchor step is not in the pipeline', function (): void {
+        $pipeline = new CartPipeline;
+        $pipeline->insertAfter('App\\Missing', 'App\\Step');
+
+        expect(fn (): array => $pipeline->build(PIPELINE_BASE))
+            ->toThrow(InvalidArgumentException::class);
+    });
+})->group('cart', 'pipeline');


### PR DESCRIPTION
## Summary

Foundation for the addon ecosystem: the extension points the core exposes so addons (customer groups, returns, gift cards, search) hook in cleanly instead of each re-building the same plumbing. Everything lives in the core packages, not in an addon. No new domain logic.

- **Addon routes are now registered.** `bootAddons()` wraps the routes an addon declares in the admin panel prefix and web middleware, so an addon gets admin routes under `/cpanel` with auth without replicating Shopper's middleware stack. Previously `getRoutes()` was collected but never consumed.
- **`CustomerRegistered` event.** A new core event dispatched from every customer-creation path (the Store API register action and the admin customer create page), `ShouldDispatchAfterCommit` so it never fires on a rolled-back creation. This is the hook gift cards, B2B onboarding, group assignment and outbound webhooks build on, since Shopper has no separate Customer model to observe.
- **Full-width content slots on the order detail page.** `OrderRenderHook::DETAIL_CONTENT_BEFORE`/`DETAIL_CONTENT_AFTER` let an addon render a full section (a returns timeline, a B2B panel) around the order grid. Not tab hooks: the order detail is a main/sidebar grid with no tab bar, so a full-width slot is the honest and more useful extension point.
- **`CartPipeline` registry.** `insertAfter`/`insertBefore`/`append` let an addon place a calculation step (gift card balance, price list override) into the cart pipeline. The configured pipeline stays the base; insertions apply deterministically so two addons never clobber each other, and an insertion anchored on a missing step fails fast at build time.

## Permissions dropped (deliberately)

The pre-existing `addonPermissions()` no-op is removed rather than wired up. An addon ships its own service provider, migrations and config, so it seeds its own permissions through its own install command, exactly as the core does with `PermissionsTableSeeder`. Seeding at boot would run a redundant query per request and force a table-exists guard for `migrate:fresh`; permissions belong to the addon, not the core.

## BC note (3.x beta)

`ShopperPanel::addonPermissions()` and `AddonManager::addPermissions()/getPermissions()` are removed. They were no-ops with no real consumer.

## Tests

The cart pipeline insertions (after/before/append, deterministic order with two addons, fail-fast on a missing anchor, unchanged base with no insertion), the `CustomerRegistered` dispatch through the Store API, and an addon route landing under the panel prefix.