### PR TITLE
feat(core): outbound webhooks

### DIFF
--- a/packages/admin/config/components/setting.php
+++ b/packages/admin/config/components/setting.php
@@ -28,6 +28,7 @@ return [
         'zones' => Pages\Settings\Zones::class,
         'taxes' => Pages\Settings\Taxes::class,
         'currencies' => Pages\Settings\Currencies::class,
+        'webhooks' => Pages\Settings\Webhooks::class,
     ],
 
     /*

--- a/packages/admin/config/settings.php
+++ b/packages/admin/config/settings.php
@@ -30,6 +30,7 @@ return [
         Items\ZoneSetting::class => true,
         Items\TaxSetting::class => true,
         Items\CurrencySetting::class => true,
+        Items\WebhookSetting::class => true,
     ],
 
 ];

--- a/packages/admin/resources/lang/en/pages/settings/menu.php
+++ b/packages/admin/resources/lang/en/pages/settings/menu.php
@@ -28,5 +28,7 @@ return [
     'currency_description' => 'Enable currencies and manage exchange rates.',
     'sales' => 'Sales channels',
     'sales_description' => 'Manage the online and offline channels you sell products on.',
+    'webhooks' => 'Webhooks',
+    'webhooks_description' => 'Notify external systems when events happen in your store.',
 
 ];

--- a/packages/admin/resources/lang/en/pages/settings/webhooks.php
+++ b/packages/admin/resources/lang/en/pages/settings/webhooks.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'title' => 'Webhooks',
+    'add_webhook' => 'Add webhook',
+    'no_webhook' => 'No webhook subscription yet. Add one to notify an external system when events happen in your store.',
+    'events' => 'Events',
+    'deliveries' => 'Deliveries',
+    'no_delivery' => 'No delivery yet for this webhook.',
+    'attempt' => 'Attempt :number',
+    'redeliver' => 'Redeliver',
+    'redelivered' => 'The delivery has been queued again.',
+    'redeliver_refused' => 'The resource of this event no longer exists, the payload cannot be redelivered.',
+    'created' => 'Webhook created',
+    'updated' => 'Webhook updated',
+    'unsafe_url' => 'The webhook url must use https and resolve to a public address.',
+    'regenerate_secret' => 'Regenerate secret',
+    'regenerate_secret_warning' => 'The current secret stops working immediately. Update your receiving endpoint with the new one.',
+    'secret_regenerated' => 'Secret regenerated',
+    'secret_reveal' => 'Signing secret (copy it now, it will not be shown again): :secret',
+    'cap_reached' => 'The maximum number of webhook subscriptions has been reached.',
+];

--- a/packages/admin/resources/lang/es/pages/settings/menu.php
+++ b/packages/admin/resources/lang/es/pages/settings/menu.php
@@ -28,5 +28,7 @@ return [
     'currency_description' => 'Activa divisas y gestiona los tipos de cambio.',
     'sales' => 'Canales de venta',
     'sales_description' => 'Gestiona los canales en línea y fuera de línea en los que vendes productos.',
+    'webhooks' => 'Webhooks',
+    'webhooks_description' => 'Notifica a sistemas externos cuando ocurren eventos en tu tienda.',
 
 ];

--- a/packages/admin/resources/lang/es/pages/settings/webhooks.php
+++ b/packages/admin/resources/lang/es/pages/settings/webhooks.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'title' => 'Webhooks',
+    'add_webhook' => 'Añadir webhook',
+    'no_webhook' => 'Aún no hay suscripciones de webhook. Añade una para notificar a un sistema externo cuando ocurran eventos en tu tienda.',
+    'events' => 'Eventos',
+    'deliveries' => 'Entregas',
+    'no_delivery' => 'Aún no hay entregas para este webhook.',
+    'attempt' => 'Intento :number',
+    'redeliver' => 'Reenviar',
+    'redelivered' => 'La entrega se ha vuelto a poner en cola.',
+    'redeliver_refused' => 'El recurso de este evento ya no existe, el payload no puede reenviarse.',
+    'created' => 'Webhook creado',
+    'updated' => 'Webhook actualizado',
+    'unsafe_url' => 'La url del webhook debe usar https y resolver a una dirección pública.',
+    'regenerate_secret' => 'Regenerar el secreto',
+    'regenerate_secret_warning' => 'El secreto actual deja de funcionar inmediatamente. Actualiza tu endpoint receptor con el nuevo.',
+    'secret_regenerated' => 'Secreto regenerado',
+    'secret_reveal' => 'Secreto de firma (cópialo ahora, no se mostrará de nuevo): :secret',
+    'cap_reached' => 'Se ha alcanzado el número máximo de suscripciones de webhook.',
+];

--- a/packages/admin/resources/lang/fr/pages/settings/menu.php
+++ b/packages/admin/resources/lang/fr/pages/settings/menu.php
@@ -28,5 +28,7 @@ return [
     'currency_description' => 'Activez les devises et gérez les taux de change.',
     'sales' => 'Cannaux de vente',
     'sales_description' => 'Gérez les canaux en ligne et hors ligne sur lesquels vous vendez vos produits.',
+    'webhooks' => 'Webhooks',
+    'webhooks_description' => 'Notifiez des systèmes externes lorsque des événements se produisent dans votre boutique.',
 
 ];

--- a/packages/admin/resources/lang/fr/pages/settings/webhooks.php
+++ b/packages/admin/resources/lang/fr/pages/settings/webhooks.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'title' => 'Webhooks',
+    'add_webhook' => 'Ajouter un webhook',
+    'no_webhook' => 'Aucun abonnement webhook pour le moment. Ajoutez-en un pour notifier un système externe lorsque des événements se produisent dans votre boutique.',
+    'events' => 'Événements',
+    'deliveries' => 'Livraisons',
+    'no_delivery' => 'Aucune livraison pour ce webhook.',
+    'attempt' => 'Tentative :number',
+    'redeliver' => 'Renvoyer',
+    'redelivered' => 'La livraison a été remise en file d\'attente.',
+    'redeliver_refused' => 'La ressource de cet événement n\'existe plus, le payload ne peut pas être renvoyé.',
+    'created' => 'Webhook créé',
+    'updated' => 'Webhook mis à jour',
+    'unsafe_url' => 'L\'url du webhook doit utiliser https et pointer vers une adresse publique.',
+    'regenerate_secret' => 'Regénérer le secret',
+    'regenerate_secret_warning' => 'Le secret actuel cesse de fonctionner immédiatement. Mettez à jour votre endpoint avec le nouveau.',
+    'secret_regenerated' => 'Secret regénéré',
+    'secret_reveal' => 'Secret de signature (copiez-le maintenant, il ne sera plus affiché) : :secret',
+    'cap_reached' => 'Le nombre maximum d\'abonnements webhook est atteint.',
+];

--- a/packages/admin/resources/views/livewire/pages/settings/partials/webhook-deliveries.blade.php
+++ b/packages/admin/resources/views/livewire/pages/settings/partials/webhook-deliveries.blade.php
@@ -1,0 +1,25 @@
+<div class="divide-y divide-sh-border">
+    @forelse ($deliveries as $delivery)
+        <div class="flex items-center justify-between gap-4 py-3">
+            <div class="min-w-0">
+                <p class="text-sm font-medium text-sh-fg">{{ $delivery->event->name }}</p>
+                <p class="text-xs text-sh-fg-muted">
+                    {{ $delivery->created_at->translatedFormat('M j, Y H:i') }}
+                    &middot; {{ __('shopper::pages/settings/webhooks.attempt', ['number' => $delivery->attempt_number]) }}
+                </p>
+            </div>
+            <div class="flex shrink-0 items-center gap-2">
+                @if ($delivery->response_code)
+                    <span class="text-xs text-sh-fg-muted">HTTP {{ $delivery->response_code }}</span>
+                @endif
+                <x-filament::badge :color="$delivery->status->getColor()">
+                    {{ $delivery->status->getLabel() }}
+                </x-filament::badge>
+            </div>
+        </div>
+    @empty
+        <p class="py-6 text-center text-sm text-sh-fg-muted">
+            {{ __('shopper::pages/settings/webhooks.no_delivery') }}
+        </p>
+    @endforelse
+</div>

--- a/packages/admin/resources/views/livewire/pages/settings/webhooks.blade.php
+++ b/packages/admin/resources/views/livewire/pages/settings/webhooks.blade.php
@@ -1,0 +1,13 @@
+<div>
+    <x-shopper::container class="space-y-8">
+        <x-shopper::heading :title="__('shopper::pages/settings/webhooks.title')">
+            <x-slot name="action">
+                {{ $this->createWebhookAction }}
+            </x-slot>
+        </x-shopper::heading>
+
+        {{ $this->table }}
+    </x-shopper::container>
+
+    <x-filament-actions::modals />
+</div>

--- a/packages/admin/routes/admin/setting.php
+++ b/packages/admin/routes/admin/setting.php
@@ -20,6 +20,7 @@ Route::livewire('/carriers', config('shopper.components.setting.pages.carriers')
 Route::livewire('/zones', config('shopper.components.setting.pages.zones'))->name('zones');
 Route::livewire('/taxes', config('shopper.components.setting.pages.taxes'))->name('taxes');
 Route::livewire('/currencies', config('shopper.components.setting.pages.currencies'))->name('currencies');
+Route::livewire('/webhooks', config('shopper.components.setting.pages.webhooks'))->name('webhooks');
 
 Route::prefix('team')->group(function (): void {
     Route::livewire('/', config('shopper.components.setting.pages.team-index'))->name('users');

--- a/packages/admin/routes/web.php
+++ b/packages/admin/routes/web.php
@@ -41,61 +41,60 @@ Route::domain(config('shopper.admin.domain'))
         DispatchShopper::class,
         SetLocale::class,
     ])
+    ->prefix(shopper()->prefix())
     ->group(function (): void {
-        Route::prefix(shopper()->prefix())->group(function (): void {
-            Route::middleware([RedirectIfAuthenticated::class])
-                ->as('shopper.')->group(function (): void {
-                    require __DIR__.'/auth.php';
-                });
-
-            Route::get('/assets/{file}', AssetController::class)
-                ->where('file', '.*')
-                ->name('shopper.asset');
-
-            Route::post('/logout', function (Request $request): RedirectResponse {
-                shopper()->auth()->logout();
-
-                $request->session()->invalidate();
-                $request->session()->regenerateToken();
-
-                return redirect()->route('shopper.login');
-            })->name('shopper.logout');
-
-            Route::get('/csrf-token', fn (): JsonResponse => response()->json([
-                'token' => csrf_token(),
-            ]))->name('shopper.csrf-token');
-
-            Route::middleware([
-                Authenticate::class,
-                HasConfiguration::class,
-                ResolveSidebars::class,
-            ])->group(function (): void {
-                Route::livewire('/initialize', Initialization::class)->name('shopper.initialize');
+        Route::middleware([RedirectIfAuthenticated::class])
+            ->as('shopper.')->group(function (): void {
+                require __DIR__.'/auth.php';
             });
 
-            Route::middleware([
-                Authenticate::class,
-                ResolveSidebars::class,
-            ])->group(function (): void {
-                Route::livewire('/forbidden', Forbidden::class)->name('shopper.forbidden');
+        Route::get('/assets/{file}', AssetController::class)
+            ->where('file', '.*')
+            ->name('shopper.asset');
+
+        Route::post('/logout', function (Request $request): RedirectResponse {
+            shopper()->auth()->logout();
+
+            $request->session()->invalidate();
+            $request->session()->regenerateToken();
+
+            return redirect()->route('shopper.login');
+        })->name('shopper.logout');
+
+        Route::get('/csrf-token', fn (): JsonResponse => response()->json([
+            'token' => csrf_token(),
+        ]))->name('shopper.csrf-token');
+
+        Route::middleware([
+            Authenticate::class,
+            HasConfiguration::class,
+            ResolveSidebars::class,
+        ])->group(function (): void {
+            Route::livewire('/initialize', Initialization::class)->name('shopper.initialize');
+        });
+
+        Route::middleware([
+            Authenticate::class,
+            ResolveSidebars::class,
+        ])->group(function (): void {
+            Route::livewire('/forbidden', Forbidden::class)->name('shopper.forbidden');
+        });
+
+        Route::middleware(array_merge([
+            Authenticate::class,
+            Dashboard::class,
+            ResolveSidebars::class,
+        ], config('shopper.routes.middleware', [])))->group(function (): void {
+            Route::as('shopper.')->group(function (): void {
+                require __DIR__.'/cpanel.php';
             });
 
-            Route::middleware(array_merge([
-                Authenticate::class,
-                Dashboard::class,
-                ResolveSidebars::class,
-            ], config('shopper.routes.middleware', [])))->group(function (): void {
-                Route::as('shopper.')->group(function (): void {
-                    require __DIR__.'/cpanel.php';
-                });
+            if (config('shopper.routes.custom_file')) {
+                Route::as('shopper.')->group(config('shopper.routes.custom_file'));
+            }
 
-                if (config('shopper.routes.custom_file')) {
-                    Route::as('shopper.')->group(config('shopper.routes.custom_file'));
-                }
-
-                foreach (shopper()->addonManager()->getRoutes() as $addonRoutes) {
-                    Route::as('shopper.')->group($addonRoutes);
-                }
-            });
+            foreach (shopper()->addonManager()->getRoutes() as $addonRoutes) {
+                Route::as('shopper.')->group($addonRoutes);
+            }
         });
     });

--- a/packages/admin/src/Livewire/Pages/Settings/Webhooks.php
+++ b/packages/admin/src/Livewire/Pages/Settings/Webhooks.php
@@ -1,0 +1,275 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Livewire\Pages\Settings;
+
+use Closure;
+use Filament\Actions\Action;
+use Filament\Actions\Concerns\InteractsWithActions;
+use Filament\Actions\Contracts\HasActions;
+use Filament\Actions\DeleteAction;
+use Filament\Actions\EditAction;
+use Filament\Forms\Components\CheckboxList;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Notifications\Notification;
+use Filament\Schemas\Concerns\InteractsWithSchemas;
+use Filament\Schemas\Contracts\HasSchemas;
+use Filament\Support\Enums\Width;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Columns\ToggleColumn;
+use Filament\Tables\Concerns\InteractsWithTable;
+use Filament\Tables\Contracts\HasTable;
+use Filament\Tables\Table;
+use Illuminate\Contracts\View\View;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Support\Str;
+use Livewire\Attributes\Layout;
+use Livewire\Component;
+use Mckenziearts\Icons\Untitledui\Enums\Untitledui;
+use Shopper\Core\Enum\WebhookDeliveryStatus;
+use Shopper\Core\Jobs\DeliverWebhookJob;
+use Shopper\Core\Models\Traits\HasPublicId;
+use Shopper\Core\Models\WebhookDelivery;
+use Shopper\Core\Models\WebhookSubscription;
+use Shopper\Core\Webhooks\WebhookUrl;
+use Shopper\Livewire\Concerns\WithSettingsBreadcrumbs;
+use Shopper\Sidebar\Breadcrumbs\Breadcrumb;
+use Shopper\Traits\HandlesAuthorizationExceptions;
+
+#[Layout('shopper::components.layouts.setting')]
+class Webhooks extends Component implements HasActions, HasSchemas, HasTable
+{
+    use HandlesAuthorizationExceptions;
+    use InteractsWithActions;
+    use InteractsWithSchemas;
+    use InteractsWithTable;
+    use WithSettingsBreadcrumbs;
+
+    public function settingsPageBreadcrumbs(): array
+    {
+        return [
+            new Breadcrumb(text: __('shopper::pages/settings/webhooks.title')),
+        ];
+    }
+
+    public function mount(): void
+    {
+        $this->authorize('system.settings');
+    }
+
+    public function createWebhookAction(): Action
+    {
+        return Action::make('createWebhook')
+            ->label(__('shopper::pages/settings/webhooks.add_webhook'))
+            ->authorize('system.settings')
+            ->modalWidth(Width::ExtraLarge)
+            ->modalHeading(__('shopper::pages/settings/webhooks.add_webhook'))
+            ->modalSubmitActionLabel(__('shopper::forms.actions.save'))
+            ->schema($this->getWebhookFormSchema())
+            ->disabled(fn (): bool => $this->hasReachedSubscriptionCap())
+            ->action(function (array $data): void {
+                if ($this->hasReachedSubscriptionCap()) {
+                    Notification::make()
+                        ->title(__('shopper::pages/settings/webhooks.cap_reached'))
+                        ->danger()
+                        ->send();
+
+                    return;
+                }
+
+                $secret = Str::random(40);
+
+                WebhookSubscription::query()->create(array_merge($data, [
+                    'secret' => $secret,
+                ]));
+
+                Notification::make()
+                    ->title(__('shopper::pages/settings/webhooks.created'))
+                    ->body(__('shopper::pages/settings/webhooks.secret_reveal', ['secret' => $secret]))
+                    ->persistent()
+                    ->success()
+                    ->send();
+            });
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->query(WebhookSubscription::query()->latest())
+            ->columns([
+                TextColumn::make('url')
+                    ->label(__('shopper::forms.label.url'))
+                    ->searchable()
+                    ->limit(50),
+                TextColumn::make('events')
+                    ->label(__('shopper::pages/settings/webhooks.events'))
+                    ->badge(),
+                ToggleColumn::make('is_active')
+                    ->label(__('shopper::forms.label.status'))
+                    ->beforeStateUpdated(fn (): mixed => $this->authorize('system.settings')),
+                TextColumn::make('updated_at')
+                    ->label(__('shopper::forms.label.updated_at'))
+                    ->date(),
+            ])
+            ->recordActions([
+                Action::make('deliveries')
+                    ->label(__('shopper::pages/settings/webhooks.deliveries'))
+                    ->icon(Untitledui::List)
+                    ->color('gray')
+                    ->iconButton()
+                    ->authorize('system.settings')
+                    ->modalHeading(__('shopper::pages/settings/webhooks.deliveries'))
+                    ->modalWidth(Width::TwoExtraLarge)
+                    ->modalContent(fn (WebhookSubscription $record): View => view(
+                        'shopper::livewire.pages.settings.partials.webhook-deliveries',
+                        ['deliveries' => $record->deliveries()->with('event')->latest('id')->limit(25)->get()],
+                    ))
+                    ->modalSubmitAction(false)
+                    ->modalCancelActionLabel(__('shopper::forms.actions.close')),
+                Action::make('redeliver')
+                    ->label(__('shopper::pages/settings/webhooks.redeliver'))
+                    ->icon(Untitledui::RefreshCcw)
+                    ->color('gray')
+                    ->iconButton()
+                    ->authorize('system.settings')
+                    ->action(fn (WebhookSubscription $record) => $this->redeliver($record)),
+                Action::make('regenerateSecret')
+                    ->label(__('shopper::pages/settings/webhooks.regenerate_secret'))
+                    ->icon(Untitledui::Key)
+                    ->color('success')
+                    ->iconButton()
+                    ->authorize('system.settings')
+                    ->requiresConfirmation()
+                    ->modalDescription(__('shopper::pages/settings/webhooks.regenerate_secret_warning'))
+                    ->action(function (WebhookSubscription $record): void {
+                        $secret = Str::random(40);
+
+                        $record->update(['secret' => $secret]);
+
+                        Notification::make()
+                            ->title(__('shopper::pages/settings/webhooks.secret_regenerated'))
+                            ->body(__('shopper::pages/settings/webhooks.secret_reveal', ['secret' => $secret]))
+                            ->persistent()
+                            ->success()
+                            ->send();
+                    }),
+                EditAction::make('edit')
+                    ->label(__('shopper::forms.actions.edit'))
+                    ->icon(Untitledui::Edit03)
+                    ->iconButton()
+                    ->authorize('system.settings')
+                    ->modalWidth(Width::ExtraLarge)
+                    ->schema($this->getWebhookFormSchema())
+                    ->successNotificationTitle(__('shopper::pages/settings/webhooks.updated')),
+                DeleteAction::make('delete')
+                    ->label(__('shopper::forms.actions.delete'))
+                    ->icon(Untitledui::Trash03)
+                    ->authorize('system.settings')
+                    ->iconButton(),
+            ])
+            ->emptyStateIcon(Untitledui::Share07)
+            ->emptyStateDescription(__('shopper::pages/settings/webhooks.no_webhook'));
+    }
+
+    public function render(): View
+    {
+        return view('shopper::livewire.pages.settings.webhooks')
+            ->title(__('shopper::pages/settings/webhooks.title'));
+    }
+
+    protected function hasReachedSubscriptionCap(): bool
+    {
+        $cap = (int) config('shopper.webhooks.max_subscriptions', 50);
+
+        return $cap > 0 && WebhookSubscription::query()->count() >= $cap;
+    }
+
+    /**
+     * Queue a new delivery for the subscription's most recent event.
+     *
+     * Refused when the event's resource no longer exists: replaying a
+     * stored snapshot after the subject was deleted would re-emit data the
+     * erasure was meant to remove (GDPR right to erasure).
+     */
+    protected function redeliver(WebhookSubscription $subscription): void
+    {
+        $lastDelivery = $subscription->deliveries()
+            ->with('event')
+            ->latest('id')
+            ->first();
+
+        if ($lastDelivery === null) {
+            return;
+        }
+
+        $event = $lastDelivery->event;
+
+        if ($event->resource_type !== null && ! $this->resourceStillExists($event->resource_type, (string) $event->resource_id)) {
+            Notification::make()
+                ->title(__('shopper::pages/settings/webhooks.redeliver_refused'))
+                ->danger()
+                ->send();
+
+            return;
+        }
+
+        $delivery = WebhookDelivery::query()->create([
+            'webhook_event_id' => $event->id,
+            'webhook_subscription_id' => $subscription->id,
+            'status' => WebhookDeliveryStatus::Pending,
+        ]);
+
+        DeliverWebhookJob::dispatch($delivery->id)
+            ->onQueue((string) config('shopper.webhooks.queue', 'webhooks'));
+
+        Notification::make()
+            ->title(__('shopper::pages/settings/webhooks.redelivered'))
+            ->success()
+            ->send();
+    }
+
+    protected function resourceStillExists(string $morphClass, string $resourceId): bool
+    {
+        $model = Relation::getMorphedModel($morphClass) ?? $morphClass;
+
+        if (! class_exists($model)) {
+            return false;
+        }
+
+        return in_array(HasPublicId::class, class_uses_recursive($model), true)
+            ? $model::query()->where('public_id', $resourceId)->exists()
+            : $model::query()->whereKey($resourceId)->exists();
+    }
+
+    /**
+     * @return array<int, \Filament\Schemas\Components\Component>
+     */
+    protected function getWebhookFormSchema(): array
+    {
+        return [
+            TextInput::make('url')
+                ->label(__('shopper::forms.label.url'))
+                ->placeholder('https://example.com/webhooks/shopper')
+                ->url()
+                ->required()
+                ->rule(fn (): Closure => function (string $attribute, mixed $value, Closure $fail): void {
+                    if (! WebhookUrl::isSafe((string) $value)) {
+                        $fail(__('shopper::pages/settings/webhooks.unsafe_url'));
+                    }
+                }),
+            CheckboxList::make('events')
+                ->label(__('shopper::pages/settings/webhooks.events'))
+                ->options(collect(config('shopper.webhooks.events', []))
+                    ->values()
+                    ->mapWithKeys(fn (string $name): array => [$name => $name])
+                    ->all())
+                ->columns()
+                ->required(),
+            Textarea::make('description')
+                ->label(__('shopper::forms.label.description'))
+                ->rows(2),
+        ];
+    }
+}

--- a/packages/admin/src/Navigation/Setting/Items/WebhookSetting.php
+++ b/packages/admin/src/Navigation/Setting/Items/WebhookSetting.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Navigation\Setting\Items;
+
+use Shopper\Enum\SettingGroup;
+use Shopper\Navigation\Setting\Setting;
+
+final class WebhookSetting extends Setting
+{
+    public function name(): string
+    {
+        return __('shopper::pages/settings/menu.webhooks');
+    }
+
+    public function description(): string
+    {
+        return __('shopper::pages/settings/menu.webhooks_description');
+    }
+
+    public function icon(): string
+    {
+        return 'phosphor-webhooks-logo';
+    }
+
+    public function url(): string
+    {
+        return route('shopper.settings.webhooks');
+    }
+
+    public function order(): int
+    {
+        return 8;
+    }
+
+    public function group(): string
+    {
+        return SettingGroup::Store->value;
+    }
+}

--- a/packages/admin/src/ShopperServiceProvider.php
+++ b/packages/admin/src/ShopperServiceProvider.php
@@ -21,7 +21,6 @@ use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Route;
 use Livewire\Livewire;
 use PragmaRX\Google2FA\Google2FA;
 use Shopper\Concerns\TwoFactorAuthenticationProvider;
@@ -191,26 +190,6 @@ final class ShopperServiceProvider extends PackageServiceProvider
         if ($productSections !== []) {
             app(ProductSectionManager::class)->register($productSections);
         }
-
-        $this->registerAddonRoutes($manager->getRoutes());
-    }
-
-    /**
-     * @param  list<Closure>  $routes
-     */
-    protected function registerAddonRoutes(array $routes): void
-    {
-        if ($routes === []) {
-            return;
-        }
-
-        Route::middleware(array_merge(['web'], (array) config('shopper.routes.middleware', [])))
-            ->prefix(shopper()->prefix())
-            ->group(function () use ($routes): void {
-                foreach ($routes as $registrar) {
-                    $registrar();
-                }
-            });
     }
 
     protected function bootLivewireComponents(): void

--- a/packages/cart/src/CartServiceProvider.php
+++ b/packages/cart/src/CartServiceProvider.php
@@ -8,12 +8,14 @@ use Illuminate\Console\Scheduling\Schedule;
 use Shopper\Cart\Console\PruneCartsCommand;
 use Shopper\Cart\Discounts\DiscountValidator;
 use Shopper\Cart\Discounts\PromotionResolver;
+use Shopper\Cart\Events\CartCompleted;
 use Shopper\Cart\Models\Cart;
 use Shopper\Cart\Models\CartLine;
 use Shopper\Cart\Models\Contracts\Cart as CartContract;
 use Shopper\Cart\Models\Contracts\CartLine as CartLineContract;
 use Shopper\Cart\Pipelines\CartPipeline;
 use Shopper\Cart\Pipelines\CartPipelineRunner;
+use Shopper\Core\Enum\WebhookEventType;
 use Shopper\Core\Traits\HasRegisterConfigAndMigrationFiles;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
@@ -41,6 +43,11 @@ final class CartServiceProvider extends PackageServiceProvider
         $this->callAfterResolving(Schedule::class, function (Schedule $schedule): void {
             $schedule->command('shopper:prune-carts')->daily();
         });
+
+        $this->app['config']->set(
+            'shopper.webhooks.events.'.CartCompleted::class,
+            WebhookEventType::CartCompleted->value,
+        );
     }
 
     public function packageRegistered(): void

--- a/packages/cart/src/Events/CartCompleted.php
+++ b/packages/cart/src/Events/CartCompleted.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 
 namespace Shopper\Cart\Events;
 
+use Illuminate\Contracts\Events\ShouldDispatchAfterCommit;
 use Illuminate\Foundation\Events\Dispatchable;
 use Shopper\Cart\Models\Contracts\Cart;
 use Shopper\Core\Models\Contracts\Order;
 
-final readonly class CartCompleted
+final readonly class CartCompleted implements ShouldDispatchAfterCommit
 {
     use Dispatchable;
 

--- a/packages/core/config/webhooks.php
+++ b/packages/core/config/webhooks.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+use Shopper\Core\Enum\WebhookEventType;
+use Shopper\Core\Events\Customers\CustomerRegistered;
+use Shopper\Core\Events\Orders\OrderCancelled;
+use Shopper\Core\Events\Orders\OrderCompleted;
+use Shopper\Core\Events\Orders\OrderCreated;
+use Shopper\Core\Events\Orders\OrderPaid;
+use Shopper\Core\Events\Orders\OrderShipped;
+use Shopper\Core\Events\Products\ProductCreated;
+use Shopper\Core\Events\Products\ProductDeleted;
+use Shopper\Core\Events\Products\ProductUpdated;
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Webhook Events
+    |--------------------------------------------------------------------------
+    |
+    | Here you may map internal event classes to the public names webhook
+    | subscriptions listen to. Packages and addons append their own entries.
+    | The public name is the wire contract and must stay stable.
+    |
+    */
+
+    'events' => [
+        OrderCreated::class => WebhookEventType::OrderCreated->value,
+        OrderPaid::class => WebhookEventType::OrderPaid->value,
+        OrderCancelled::class => WebhookEventType::OrderCancelled->value,
+        OrderShipped::class => WebhookEventType::OrderShipped->value,
+        OrderCompleted::class => WebhookEventType::OrderCompleted->value,
+        ProductCreated::class => WebhookEventType::ProductCreated->value,
+        ProductUpdated::class => WebhookEventType::ProductUpdated->value,
+        ProductDeleted::class => WebhookEventType::ProductDeleted->value,
+        CustomerRegistered::class => WebhookEventType::CustomerRegistered->value,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Database Connection
+    |--------------------------------------------------------------------------
+    |
+    | Here you may configure the database connection used to store webhook
+    | subscriptions, events and deliveries. High-volume stores can point
+    | this to a dedicated database so webhook traffic never competes with
+    | commerce data. When null, the default connection is used.
+    |
+    */
+
+    'database' => [
+        'connection' => env('SHOPPER_WEBHOOKS_DB_CONNECTION'),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Endpoint Restrictions
+    |--------------------------------------------------------------------------
+    |
+    | Here you may restrict where webhooks may be sent. An empty allowed_hosts
+    | list permits any public host; add hosts to lock deliveries down to known
+    | integrations, so a compromised admin cannot turn the store into a data
+    | exfiltration or amplification channel. A subscription cap bounds the
+    | fan-out an attacker could create.
+    |
+    */
+
+    'allowed_hosts' => array_filter(explode(',', (string) env('SHOPPER_WEBHOOKS_ALLOWED_HOSTS', ''))),
+
+    'max_subscriptions' => (int) env('SHOPPER_WEBHOOKS_MAX_SUBSCRIPTIONS', 50),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Delivery
+    |--------------------------------------------------------------------------
+    |
+    | Deliveries run on their own queue so webhook traffic never starves the
+    | order and payment jobs. The backoff schedule drives the retry delays,
+    | and a subscription is disabled after this many consecutive failures.
+    | Signatures older than the tolerance window are rejected by receivers.
+    |
+    */
+
+    'queue' => env('SHOPPER_WEBHOOKS_QUEUE', 'webhooks'),
+
+    'backoff' => [10, 30, 60, 300, 1800, 3600, 7200, 14400, 28800, 43200],
+
+    'disable_after_failures' => 15,
+
+    'timeout' => 10,
+
+    'signature_tolerance' => 300,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Retention
+    |--------------------------------------------------------------------------
+    |
+    | Succeeded deliveries are pruned quickly, failed ones are kept longer
+    | for diagnostics. Used by the Prunable models with `model:prune`.
+    |
+    */
+
+    'prune' => [
+        'succeeded_after_days' => 7,
+        'failed_after_days' => 90,
+    ],
+];

--- a/packages/core/database/factories/WebhookSubscriptionFactory.php
+++ b/packages/core/database/factories/WebhookSubscriptionFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Core\Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+use Shopper\Core\Models\WebhookSubscription;
+
+/**
+ * @extends Factory<WebhookSubscription>
+ */
+class WebhookSubscriptionFactory extends Factory
+{
+    protected $model = WebhookSubscription::class;
+
+    public function definition(): array
+    {
+        return [
+            'url' => 'https://'.$this->faker->domainName().'/webhooks',
+            'events' => ['order.paid'],
+            'secret' => Str::random(32),
+            'is_active' => true,
+        ];
+    }
+
+    public function inactive(): static
+    {
+        return $this->state(['is_active' => false]);
+    }
+}

--- a/packages/core/database/migrations/2026_07_02_000008_create_webhook_tables.php
+++ b/packages/core/database/migrations/2026_07_02_000008_create_webhook_tables.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Shopper\Core\Helpers\Migration;
+
+return new class extends Migration
+{
+    public function getConnection(): ?string
+    {
+        return config('shopper.webhooks.database.connection') ?? parent::getConnection();
+    }
+
+    public function up(): void
+    {
+        Schema::create($this->getTableName('webhook_subscriptions'), static function (Blueprint $table): void {
+            $table->id();
+            $table->string('url');
+            $table->json('events');
+            $table->text('secret');
+            $table->boolean('is_active')->default(true);
+            $table->text('description')->nullable();
+            $table->timestamps();
+
+            $table->index('is_active');
+        });
+
+        Schema::create($this->getTableName('webhook_events'), static function (Blueprint $table): void {
+            $table->id();
+            $table->string('public_id', 26)->nullable()->unique();
+            $table->string('name');
+            $table->string('resource_type')->nullable();
+            $table->string('resource_id')->nullable();
+            $table->longText('payload');
+            $table->timestamps();
+
+            $table->index(['name', 'created_at']);
+        });
+
+        Schema::create($this->getTableName('webhook_deliveries'), function (Blueprint $table): void {
+            $table->id();
+            $table->string('public_id', 26)->nullable()->unique();
+            $table->foreignId('webhook_event_id')
+                ->constrained($this->getTableName('webhook_events'))
+                ->cascadeOnDelete();
+            $table->foreignId('webhook_subscription_id')
+                ->constrained($this->getTableName('webhook_subscriptions'))
+                ->cascadeOnDelete();
+            $table->unsignedInteger('attempt_number')->default(1);
+            $table->string('status');
+            $table->unsignedSmallInteger('response_code')->nullable();
+            $table->text('response_body')->nullable();
+            $table->timestamp('completed_at')->nullable();
+            $table->timestamps();
+
+            $table->index('webhook_event_id');
+            $table->index(['webhook_subscription_id', 'status', 'id']);
+            $table->index(['status', 'created_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists($this->getTableName('webhook_deliveries'));
+        Schema::dropIfExists($this->getTableName('webhook_events'));
+        Schema::dropIfExists($this->getTableName('webhook_subscriptions'));
+    }
+};

--- a/packages/core/resources/lang/en/enum/webhook.php
+++ b/packages/core/resources/lang/en/enum/webhook.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'pending' => 'Pending',
+    'succeeded' => 'Succeeded',
+    'failed' => 'Failed',
+    'rejected' => 'Rejected',
+    'dispatch_failed' => 'Dispatch failed',
+];

--- a/packages/core/resources/lang/es/enum/webhook.php
+++ b/packages/core/resources/lang/es/enum/webhook.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'pending' => 'Pendiente',
+    'succeeded' => 'Exitosa',
+    'failed' => 'Fallida',
+    'rejected' => 'Rechazada',
+    'dispatch_failed' => 'Envío imposible',
+];

--- a/packages/core/resources/lang/fr/enum/webhook.php
+++ b/packages/core/resources/lang/fr/enum/webhook.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'pending' => 'En attente',
+    'succeeded' => 'Réussie',
+    'failed' => 'Échouée',
+    'rejected' => 'Rejetée',
+    'dispatch_failed' => 'Envoi impossible',
+];

--- a/packages/core/src/Console/RedispatchWebhooksCommand.php
+++ b/packages/core/src/Console/RedispatchWebhooksCommand.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Core\Console;
+
+use Illuminate\Console\Command;
+use Shopper\Core\Enum\WebhookDeliveryStatus;
+use Shopper\Core\Jobs\DeliverWebhookJob;
+use Shopper\Core\Models\WebhookDelivery;
+
+final class RedispatchWebhooksCommand extends Command
+{
+    protected $signature = 'shopper:webhooks:redispatch';
+
+    protected $description = 'Requeue webhook deliveries that never reached the queue or were lost by a dead worker';
+
+    /**
+     * Closes the at-least-once gap left by infrastructure failures: a
+     * delivery is reclaimed when its job was never queued (`dispatch_failed`,
+     * queue broker down at push time) or when it sat `pending` past the
+     * stale window (worker died after reserving the job). `failed` rows
+     * without `completed_at` are NOT reclaimed — those have a live retry
+     * scheduled through the job's own backoff.
+     */
+    public function handle(): int
+    {
+        $reclaimed = 0;
+
+        WebhookDelivery::query()
+            ->where('status', WebhookDeliveryStatus::DispatchFailed)
+            ->orWhere(fn ($query) => $query
+                ->where('status', WebhookDeliveryStatus::Pending)
+                ->where('created_at', '<', now()->subMinutes(15)))
+            ->orderBy('id')
+            ->each(function (WebhookDelivery $delivery) use (&$reclaimed): void {
+                $delivery->update(['status' => WebhookDeliveryStatus::Pending]);
+
+                DeliverWebhookJob::dispatch($delivery->id)
+                    ->onQueue((string) config('shopper.webhooks.queue', 'webhooks'));
+
+                $reclaimed++;
+            });
+
+        $this->info("Requeued {$reclaimed} webhook deliveries.");
+
+        return self::SUCCESS;
+    }
+}

--- a/packages/core/src/Contracts/WebhookPayloadSerializer.php
+++ b/packages/core/src/Contracts/WebhookPayloadSerializer.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Core\Contracts;
+
+interface WebhookPayloadSerializer
+{
+    /**
+     * Build the wire payload for a domain event, at dispatch time.
+     *
+     * Called synchronously by `DispatchWebhooksListener` before the resource
+     * can change or be deleted; the result is persisted on `WebhookEvent`
+     * and posted as-is by `DeliverWebhookJob`. Implementations must only
+     * emit explicitly safelisted attributes — no secrets, tokens or card
+     * data. Rebind this contract to change the payload shape.
+     *
+     * @return array{resource_type: ?string, resource_id: ?string, data: array<string, mixed>}
+     */
+    public function serialize(object $event): array;
+}

--- a/packages/core/src/CoreServiceProvider.php
+++ b/packages/core/src/CoreServiceProvider.php
@@ -9,11 +9,14 @@ use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Shopper\Core\Console\ReclaimPendingOrdersCommand;
 use Shopper\Core\Console\ReconcileStockLevelsCommand;
+use Shopper\Core\Console\RedispatchWebhooksCommand;
 use Shopper\Core\Console\SyncCollectionsCommand;
 use Shopper\Core\Contracts\InventoryResolver;
 use Shopper\Core\Contracts\StockAllocator;
 use Shopper\Core\Contracts\StockReserver;
 use Shopper\Core\Contracts\TaxCalculationProvider;
+use Shopper\Core\Contracts\WebhookPayloadSerializer;
+use Shopper\Core\Listeners\DispatchWebhooksListener;
 use Shopper\Core\Models\Address;
 use Shopper\Core\Models\Attribute;
 use Shopper\Core\Models\Category;
@@ -42,6 +45,7 @@ use Shopper\Core\Stock\PriorityStockAllocator;
 use Shopper\Core\Taxes\SystemTaxProvider;
 use Shopper\Core\Taxes\TaxCalculator;
 use Shopper\Core\Traits\HasRegisterConfigAndMigrationFiles;
+use Shopper\Core\Webhooks\DefaultWebhookPayloadSerializer;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 
@@ -53,6 +57,7 @@ final class CoreServiceProvider extends PackageServiceProvider
     protected array $configFiles = [
         'core',
         'orders',
+        'webhooks',
     ];
 
     protected string $root = __DIR__.'/..';
@@ -65,6 +70,7 @@ final class CoreServiceProvider extends PackageServiceProvider
             ->hasCommands([
                 ReclaimPendingOrdersCommand::class,
                 ReconcileStockLevelsCommand::class,
+                RedispatchWebhooksCommand::class,
                 SyncCollectionsCommand::class,
             ]);
     }
@@ -78,6 +84,7 @@ final class CoreServiceProvider extends PackageServiceProvider
         $this->bootModelRelationName();
         $this->registerObservers();
         $this->scheduleCommands();
+        $this->registerWebhookListener();
     }
 
     public function packageRegistered(): void
@@ -88,6 +95,20 @@ final class CoreServiceProvider extends PackageServiceProvider
         $this->registerDatabase();
         $this->registerStockAllocator();
         $this->registerTaxCalculator();
+
+        $this->app->singleton(WebhookPayloadSerializer::class, DefaultWebhookPayloadSerializer::class);
+    }
+
+    protected function registerWebhookListener(): void
+    {
+        $this->app->booted(function (): void {
+            /** @var array<class-string, string> $events */
+            $events = (array) config('shopper.webhooks.events', []);
+
+            if ($events !== []) {
+                $this->app['events']->listen(array_keys($events), DispatchWebhooksListener::class);
+            }
+        });
     }
 
     protected function scheduleCommands(): void
@@ -96,6 +117,12 @@ final class CoreServiceProvider extends PackageServiceProvider
             if (config('shopper.orders.reclaim_pending_after_hours')) {
                 $schedule->command('shopper:orders:reclaim')->hourly();
             }
+
+            $schedule->command('shopper:webhooks:redispatch')->everyFifteenMinutes();
+
+            $schedule->command('model:prune', [
+                '--model' => [Models\WebhookDelivery::class, Models\WebhookEvent::class],
+            ])->daily();
         });
     }
 

--- a/packages/core/src/Enum/WebhookDeliveryStatus.php
+++ b/packages/core/src/Enum/WebhookDeliveryStatus.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Core\Enum;
+
+use Shopper\Core\Contracts\HasColor;
+use Shopper\Core\Contracts\HasLabel;
+use Shopper\Core\Traits\ArrayableEnum;
+use Shopper\Core\Traits\HasEnumStaticMethods;
+
+enum WebhookDeliveryStatus: string implements HasColor, HasLabel
+{
+    use ArrayableEnum;
+    use HasEnumStaticMethods;
+
+    case Pending = 'pending';
+
+    case Succeeded = 'succeeded';
+
+    case Failed = 'failed';
+
+    case Rejected = 'rejected';
+
+    case DispatchFailed = 'dispatch_failed';
+
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::Pending => __('shopper-core::enum/webhook.pending'),
+            self::Succeeded => __('shopper-core::enum/webhook.succeeded'),
+            self::Failed => __('shopper-core::enum/webhook.failed'),
+            self::Rejected => __('shopper-core::enum/webhook.rejected'),
+            self::DispatchFailed => __('shopper-core::enum/webhook.dispatch_failed'),
+        };
+    }
+
+    public function getColor(): string
+    {
+        return match ($this) {
+            self::Pending => 'gray',
+            self::Succeeded => 'success',
+            self::Failed, self::Rejected, self::DispatchFailed => 'danger',
+        };
+    }
+}

--- a/packages/core/src/Enum/WebhookEventType.php
+++ b/packages/core/src/Enum/WebhookEventType.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Core\Enum;
+
+use Shopper\Core\Contracts\HasLabel;
+use Shopper\Core\Traits\ArrayableEnum;
+use Shopper\Core\Traits\HasEnumStaticMethods;
+
+enum WebhookEventType: string implements HasLabel
+{
+    use ArrayableEnum;
+    use HasEnumStaticMethods;
+
+    case OrderCreated = 'order.created';
+
+    case OrderPaid = 'order.paid';
+
+    case OrderCancelled = 'order.cancelled';
+
+    case OrderShipped = 'order.shipped';
+
+    case OrderCompleted = 'order.completed';
+
+    case ProductCreated = 'product.created';
+
+    case ProductUpdated = 'product.updated';
+
+    case ProductDeleted = 'product.deleted';
+
+    case CustomerRegistered = 'customer.registered';
+
+    case CartCompleted = 'cart.completed';
+
+    public function getLabel(): string
+    {
+        return $this->value;
+    }
+}

--- a/packages/core/src/Jobs/DeliverWebhookJob.php
+++ b/packages/core/src/Jobs/DeliverWebhookJob.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Core\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Support\Facades\Http;
+use Shopper\Core\Enum\WebhookDeliveryStatus;
+use Shopper\Core\Models\WebhookDelivery;
+use Shopper\Core\Webhooks\WebhookSignature;
+use Shopper\Core\Webhooks\WebhookUrl;
+use Throwable;
+
+final class DeliverWebhookJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable;
+
+    public function __construct(
+        private readonly int $deliveryId,
+    ) {}
+
+    /**
+     * Hard ceiling on the job so a slow DNS resolution or a stalled TLS
+     * handshake cannot pin a worker: the HTTP call is bounded by its own
+     * timeout, this bounds everything around it (DNS included, which has no
+     * portable per-call timeout of its own).
+     */
+    public function timeout(): int
+    {
+        return (int) config('shopper.webhooks.timeout', 10) + 20;
+    }
+
+    /**
+     * @return array<int, int>
+     */
+    public function backoff(): array
+    {
+        return (array) config('shopper.webhooks.backoff', [10, 30, 60]);
+    }
+
+    public function tries(): int
+    {
+        return count($this->backoff()) + 1;
+    }
+
+    public function handle(): void
+    {
+        $delivery = WebhookDelivery::query()
+            ->with(['event', 'subscription'])
+            ->find($this->deliveryId);
+
+        if ($delivery === null || $delivery->status === WebhookDeliveryStatus::Succeeded) {
+            return;
+        }
+
+        $subscription = $delivery->subscription;
+
+        if (! $subscription->is_active) {
+            return;
+        }
+
+        $pinnedAddress = WebhookUrl::safeAddressFor($subscription->url);
+
+        if ($pinnedAddress === null) {
+            $delivery->update([
+                'status' => WebhookDeliveryStatus::Rejected,
+                'response_body' => 'The webhook url resolves to a forbidden address.',
+                'completed_at' => now(),
+            ]);
+
+            return;
+        }
+
+        $body = (string) json_encode($this->payloadFor($delivery), JSON_UNESCAPED_SLASHES);
+
+        try {
+            $response = Http::withHeaders([
+                'Content-Type' => 'application/json',
+                'X-Shopper-Event' => $delivery->event->name,
+                'X-Shopper-Event-Id' => (string) $delivery->event->public_id,
+                'X-Shopper-Delivery-Id' => (string) $delivery->public_id,
+                'X-Shopper-Signature' => WebhookSignature::sign($body, $subscription->secret),
+            ])
+                ->timeout((int) config('shopper.webhooks.timeout', 10))
+                ->withOptions([
+                    'allow_redirects' => false,
+                    'curl' => WebhookUrl::pinnedResolveOptions($subscription->url, $pinnedAddress),
+                ])
+                ->withBody($body)
+                ->post($subscription->url);
+        } catch (ConnectionException) {
+            $this->recordFailure($delivery, null, 'Connection failed or timed out.');
+
+            return;
+        }
+
+        if ($response->successful()) {
+            $delivery->update([
+                'status' => WebhookDeliveryStatus::Succeeded,
+                'attempt_number' => $this->attempts(),
+                'response_code' => $response->status(),
+                'completed_at' => now(),
+            ]);
+
+            return;
+        }
+
+        if ($response->clientError()) {
+            $delivery->update([
+                'status' => WebhookDeliveryStatus::Rejected,
+                'attempt_number' => $this->attempts(),
+                'response_code' => $response->status(),
+                'response_body' => mb_substr($response->body(), 0, 1000),
+                'completed_at' => now(),
+            ]);
+
+            return;
+        }
+
+        $this->recordFailure($delivery, $response->status(), mb_substr($response->body(), 0, 1000));
+    }
+
+    /**
+     * Terminal safety net for exceptions the delivery flow does not handle
+     * itself (a DB blip during an update, an unexpected client error).
+     * Without it the delivery row would stay `pending` forever and the
+     * failing endpoint would never count toward auto-disable.
+     */
+    public function failed(?Throwable $exception): void
+    {
+        $delivery = WebhookDelivery::query()
+            ->with('subscription')
+            ->find($this->deliveryId);
+
+        if ($delivery === null || $delivery->status === WebhookDeliveryStatus::Succeeded) {
+            return;
+        }
+
+        $delivery->update([
+            'status' => WebhookDeliveryStatus::Failed,
+            'response_body' => mb_substr($exception?->getMessage() ?? 'The delivery job failed.', 0, 1000),
+            'completed_at' => now(),
+        ]);
+
+        $delivery->subscription->disableWhenFailing();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function payloadFor(WebhookDelivery $delivery): array
+    {
+        return [
+            'id' => $delivery->event->public_id,
+            'event' => $delivery->event->name,
+            'created_at' => $delivery->event->created_at->toIso8601String(),
+            'attempt' => $this->attempts(),
+            'resource' => [
+                'type' => $delivery->event->resource_type,
+                'id' => $delivery->event->resource_id,
+            ],
+            'data' => $delivery->event->payload,
+        ];
+    }
+
+    /**
+     * Record a transport-level failure (5xx or timeout) and schedule the
+     * next attempt.
+     *
+     * While attempts remain, releases the job with the backoff delay for
+     * the current attempt (`shopper.webhooks.backoff`). On the final
+     * attempt, stamps `completed_at` and calls
+     * `WebhookSubscription::disableWhenFailing()`. 4xx responses never
+     * reach this method: they are terminal `rejected` and are not retried.
+     */
+    private function recordFailure(WebhookDelivery $delivery, ?int $code, string $body): void
+    {
+        $exhausted = $this->attempts() >= $this->tries();
+
+        $delivery->update([
+            'status' => WebhookDeliveryStatus::Failed,
+            'attempt_number' => $this->attempts(),
+            'response_code' => $code,
+            'response_body' => $body,
+            'completed_at' => $exhausted ? now() : null,
+        ]);
+
+        if ($exhausted) {
+            $delivery->subscription->disableWhenFailing();
+
+            return;
+        }
+
+        $this->release($this->backoff()[$this->attempts() - 1] ?? 3600);
+    }
+}

--- a/packages/core/src/Listeners/DispatchWebhooksListener.php
+++ b/packages/core/src/Listeners/DispatchWebhooksListener.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Core\Listeners;
+
+use Illuminate\Support\Facades\Log;
+use Shopper\Core\Contracts\WebhookPayloadSerializer;
+use Shopper\Core\Enum\WebhookDeliveryStatus;
+use Shopper\Core\Jobs\DeliverWebhookJob;
+use Shopper\Core\Models\WebhookDelivery;
+use Shopper\Core\Models\WebhookEvent;
+use Shopper\Core\Models\WebhookSubscription;
+use Throwable;
+
+/**
+ * Fans a domain event out to the webhook subscriptions listening to it.
+ *
+ * Runs synchronously in the dispatching request. Do not make this listener
+ * queued: domain events use `SerializesModels`, so a queued listener
+ * re-fetches the model on wake-up and throws `ModelNotFoundException` for
+ * every `*Deleted` event. The payload is therefore snapshotted here, and
+ * the queued `DeliverWebhookJob` only posts the frozen JSON.
+ *
+ * Per event: resolves the public name from `shopper.webhooks.events`,
+ * reads the cached active-subscription list (no query on stores without
+ * webhooks), creates one `WebhookEvent` row (payload stored once), then one
+ * pending `WebhookDelivery` plus one queued job per matching subscription.
+ *
+ * Every failure path is contained: a failing subscription never aborts the
+ * remaining ones, and no exception escapes `handle()` — the listener runs
+ * in an after-commit callback of a business transaction (checkout, payment)
+ * and must never turn a committed order into a 500.
+ */
+final readonly class DispatchWebhooksListener
+{
+    public function __construct(
+        private WebhookPayloadSerializer $serializer,
+    ) {}
+
+    public function handle(object $event): void
+    {
+        try {
+            $this->dispatchWebhooks($event);
+        } catch (Throwable $exception) {
+            Log::error('Webhook fan-out failed.', [
+                'event' => $event::class,
+                'exception' => $exception->getMessage(),
+            ]);
+        }
+    }
+
+    private function dispatchWebhooks(object $event): void
+    {
+        $name = config('shopper.webhooks.events.'.$event::class);
+
+        if (! is_string($name)) {
+            return;
+        }
+
+        $subscriptions = WebhookSubscription::active()
+            ->filter(fn (WebhookSubscription $subscription): bool => $subscription->listensTo($name));
+
+        if ($subscriptions->isEmpty()) {
+            return;
+        }
+
+        $serialized = $this->serializer->serialize($event);
+
+        $webhookEvent = WebhookEvent::query()->create([
+            'name' => $name,
+            'resource_type' => $serialized['resource_type'],
+            'resource_id' => $serialized['resource_id'],
+            'payload' => $serialized['data'],
+        ]);
+
+        foreach ($subscriptions as $subscription) {
+            $delivery = null;
+
+            try {
+                $delivery = WebhookDelivery::query()->create([
+                    'webhook_event_id' => $webhookEvent->id,
+                    'webhook_subscription_id' => $subscription->id,
+                    'status' => WebhookDeliveryStatus::Pending,
+                ]);
+
+                DeliverWebhookJob::dispatch($delivery->id)
+                    ->onQueue((string) config('shopper.webhooks.queue', 'webhooks'));
+            } catch (Throwable $exception) {
+                $delivery?->update(['status' => WebhookDeliveryStatus::DispatchFailed]);
+
+                Log::error('Webhook delivery could not be queued.', [
+                    'subscription_id' => $subscription->id,
+                    'delivery_id' => $delivery?->id,
+                    'exception' => $exception->getMessage(),
+                ]);
+            }
+        }
+    }
+}

--- a/packages/core/src/Models/WebhookDelivery.php
+++ b/packages/core/src/Models/WebhookDelivery.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Core\Models;
+
+use Carbon\CarbonInterface;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Prunable;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Shopper\Core\Enum\WebhookDeliveryStatus;
+use Shopper\Core\Models\Traits\HasPublicId;
+
+/**
+ * @property-read int $id
+ * @property-read ?string $public_id
+ * @property-read int $webhook_event_id
+ * @property-read int $webhook_subscription_id
+ * @property-read int $attempt_number
+ * @property-read WebhookDeliveryStatus $status
+ * @property-read ?int $response_code
+ * @property-read ?string $response_body
+ * @property-read ?CarbonInterface $completed_at
+ * @property-read CarbonInterface $created_at
+ * @property-read CarbonInterface $updated_at
+ * @property-read WebhookEvent $event
+ * @property-read WebhookSubscription $subscription
+ */
+class WebhookDelivery extends Model
+{
+    use HasPublicId;
+    use Prunable;
+
+    protected $guarded = [];
+
+    public function getConnectionName(): ?string
+    {
+        return config('shopper.webhooks.database.connection') ?? parent::getConnectionName();
+    }
+
+    public function getTable(): string
+    {
+        return shopper_table('webhook_deliveries');
+    }
+
+    /**
+     * Retention policy consumed by the scheduled `model:prune` command:
+     * `succeeded` rows expire after `shopper.webhooks.prune.succeeded_after_days`
+     * (default 7), every other status after `failed_after_days` (default 90).
+     *
+     * @return Builder<static>
+     */
+    public function prunable(): Builder
+    {
+        $succeededAfter = (int) config('shopper.webhooks.prune.succeeded_after_days', 7);
+        $failedAfter = (int) config('shopper.webhooks.prune.failed_after_days', 90);
+
+        return static::query()
+            ->where(fn (Builder $query) => $query
+                ->where('status', WebhookDeliveryStatus::Succeeded)
+                ->where('created_at', '<', now()->subDays($succeededAfter)))
+            ->orWhere(fn (Builder $query) => $query
+                ->where('status', '<>', WebhookDeliveryStatus::Succeeded->value)
+                ->where('created_at', '<', now()->subDays($failedAfter)));
+    }
+
+    /**
+     * @return BelongsTo<WebhookEvent, $this>
+     */
+    public function event(): BelongsTo
+    {
+        return $this->belongsTo(WebhookEvent::class, 'webhook_event_id');
+    }
+
+    /**
+     * @return BelongsTo<WebhookSubscription, $this>
+     */
+    public function subscription(): BelongsTo
+    {
+        return $this->belongsTo(WebhookSubscription::class, 'webhook_subscription_id');
+    }
+
+    protected function casts(): array
+    {
+        return [
+            'completed_at' => 'datetime',
+            'status' => WebhookDeliveryStatus::class,
+        ];
+    }
+}

--- a/packages/core/src/Models/WebhookEvent.php
+++ b/packages/core/src/Models/WebhookEvent.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Core\Models;
+
+use Carbon\CarbonInterface;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Prunable;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Shopper\Core\Models\Traits\HasPublicId;
+
+/**
+ * @property-read int $id
+ * @property-read ?string $public_id
+ * @property-read string $name
+ * @property-read ?string $resource_type
+ * @property-read ?string $resource_id
+ * @property-read array<string, mixed> $payload
+ * @property-read CarbonInterface $created_at
+ * @property-read CarbonInterface $updated_at
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, WebhookDelivery> $deliveries
+ */
+class WebhookEvent extends Model
+{
+    use HasPublicId;
+    use Prunable;
+
+    protected $guarded = [];
+
+    public function getConnectionName(): ?string
+    {
+        return config('shopper.webhooks.database.connection') ?? parent::getConnectionName();
+    }
+
+    public function getTable(): string
+    {
+        return shopper_table('webhook_events');
+    }
+
+    /**
+     * Events carry the stored JSON payloads — the heaviest webhook data.
+     * A row is prunable once every delivery pointing at it has itself been
+     * pruned and the failure-retention window has passed.
+     *
+     * @return Builder<static>
+     */
+    public function prunable(): Builder
+    {
+        $failedAfter = (int) config('shopper.webhooks.prune.failed_after_days', 90);
+
+        return static::query()
+            ->whereDoesntHave('deliveries')
+            ->where('created_at', '<', now()->subDays($failedAfter));
+    }
+
+    /**
+     * @return HasMany<WebhookDelivery, $this>
+     */
+    public function deliveries(): HasMany
+    {
+        return $this->hasMany(WebhookDelivery::class);
+    }
+
+    protected function casts(): array
+    {
+        return [
+            'payload' => 'encrypted:array',
+        ];
+    }
+}

--- a/packages/core/src/Models/WebhookSubscription.php
+++ b/packages/core/src/Models/WebhookSubscription.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Core\Models;
+
+use Carbon\CarbonInterface;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Facades\Cache;
+use Shopper\Core\Database\Factories\WebhookSubscriptionFactory;
+use Shopper\Core\Enum\WebhookDeliveryStatus;
+
+/**
+ * @property-read int $id
+ * @property-read string $url
+ * @property-read array<int, string> $events
+ * @property-read string $secret
+ * @property-read bool $is_active
+ * @property-read ?string $description
+ * @property-read CarbonInterface $created_at
+ * @property-read CarbonInterface $updated_at
+ * @property-read Collection<int, WebhookDelivery> $deliveries
+ */
+class WebhookSubscription extends Model
+{
+    /** @use HasFactory<WebhookSubscriptionFactory> */
+    use HasFactory;
+
+    public const string ACTIVE_CACHE_KEY = 'shopper.webhooks.active_subscriptions';
+
+    protected $guarded = [];
+
+    /**
+     * The active subscriptions, cached so the dispatch listener adds zero
+     * queries to the domain-event hot path (checkout, payment). Invalidated
+     * by every Eloquent write on this model and by `disableWhenFailing()`,
+     * with a one-hour TTL as a safety net for raw query-builder writes.
+     *
+     * @return Collection<int, static>
+     */
+    public static function active(): Collection
+    {
+        return Cache::remember(
+            self::ACTIVE_CACHE_KEY,
+            3600,
+            fn (): Collection => static::query()->where('is_active', true)->get(),
+        );
+    }
+
+    public function getConnectionName(): ?string
+    {
+        return config('shopper.webhooks.database.connection') ?? parent::getConnectionName();
+    }
+
+    public function getTable(): string
+    {
+        return shopper_table('webhook_subscriptions');
+    }
+
+    public function listensTo(string $eventName): bool
+    {
+        return in_array($eventName, $this->events, true);
+    }
+
+    /**
+     * Deactivate the subscription when its last N terminal deliveries
+     * (N = `shopper.webhooks.disable_after_failures`) are all `failed`.
+     *
+     * The decision reads committed `webhook_deliveries` rows instead of
+     * maintaining a counter column: a read-modify-write counter loses
+     * increments under concurrent failing jobs. `rejected` (4xx) rows are
+     * excluded — a deterministic payload rejection is not an endpoint
+     * outage. The final update is guarded by `where is_active = true` so
+     * concurrent callers flip the flag exactly once.
+     */
+    public function disableWhenFailing(): void
+    {
+        $threshold = (int) config('shopper.webhooks.disable_after_failures', 15);
+
+        $recent = $this->deliveries()
+            ->whereIn('status', [WebhookDeliveryStatus::Succeeded, WebhookDeliveryStatus::Failed])
+            ->latest('id')
+            ->limit($threshold)
+            ->pluck('status');
+
+        if ($recent->count() < $threshold || $recent->contains(fn (WebhookDeliveryStatus $status): bool => $status === WebhookDeliveryStatus::Succeeded)) {
+            return;
+        }
+
+        static::query()
+            ->whereKey($this->id)
+            ->where('is_active', true)
+            ->update(['is_active' => false]);
+
+        Cache::forget(self::ACTIVE_CACHE_KEY);
+    }
+
+    /**
+     * @return HasMany<WebhookDelivery, $this>
+     */
+    public function deliveries(): HasMany
+    {
+        return $this->hasMany(WebhookDelivery::class);
+    }
+
+    protected static function booted(): void
+    {
+        static::saved(fn () => Cache::forget(self::ACTIVE_CACHE_KEY));
+        static::deleted(fn () => Cache::forget(self::ACTIVE_CACHE_KEY));
+    }
+
+    protected static function newFactory(): WebhookSubscriptionFactory
+    {
+        return WebhookSubscriptionFactory::new();
+    }
+
+    protected function casts(): array
+    {
+        return [
+            'events' => 'array',
+            'is_active' => 'boolean',
+            'secret' => 'encrypted',
+        ];
+    }
+}

--- a/packages/core/src/Webhooks/DefaultWebhookPayloadSerializer.php
+++ b/packages/core/src/Webhooks/DefaultWebhookPayloadSerializer.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Core\Webhooks;
+
+use Illuminate\Database\Eloquent\Model;
+use Shopper\Core\Contracts\WebhookPayloadSerializer;
+use Shopper\Core\Models\Contracts\Order;
+use Shopper\Core\Models\Contracts\Product;
+
+final class DefaultWebhookPayloadSerializer implements WebhookPayloadSerializer
+{
+    /**
+     * Attribute-safelist serializer: every emitted field is listed
+     * explicitly per resource type. Never spread `toArray()` here — model
+     * attributes added later would silently leak to third-party endpoints.
+     */
+    public function serialize(object $event): array
+    {
+        $resource = $this->resourceOf($event);
+
+        if (! $resource instanceof Model) {
+            return ['resource_type' => null, 'resource_id' => null, 'data' => []];
+        }
+
+        return [
+            'resource_type' => $resource->getMorphClass(),
+            'resource_id' => (string) ($resource->getAttribute('public_id') ?? $resource->getKey()),
+            'data' => $this->dataFor($resource),
+        ];
+    }
+
+    private function resourceOf(object $event): ?object
+    {
+        foreach (['order', 'product', 'customer', 'cart'] as $property) {
+            if (property_exists($event, $property)) {
+                return $event->{$property};
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function dataFor(Model $resource): array
+    {
+        return match (true) {
+            $resource instanceof Order => $this->orderData($resource),
+            $resource instanceof Product => $this->productData($resource),
+            default => $this->genericData($resource),
+        };
+    }
+
+    /**
+     * @param  Model&Order  $order
+     * @return array<string, mixed>
+     */
+    private function orderData(Order $order): array
+    {
+        return [
+            'id' => $order->getAttribute('public_id'),
+            'number' => $order->getAttribute('number'),
+            'status' => $order->getAttribute('status')?->value,
+            'payment_status' => $order->getAttribute('payment_status')?->value,
+            'shipping_status' => $order->getAttribute('shipping_status')?->value,
+            'price_amount' => $order->getAttribute('price_amount'),
+            'tax_amount' => $order->getAttribute('tax_amount'),
+            'shipping_amount' => $order->getAttribute('shipping_amount'),
+            'currency_code' => $order->getAttribute('currency_code'),
+            'email' => $order->getAttribute('email'),
+            'created_at' => $order->getAttribute('created_at')?->toIso8601String(),
+        ];
+    }
+
+    /**
+     * @param  Model&Product  $product
+     * @return array<string, mixed>
+     */
+    private function productData(Product $product): array
+    {
+        return [
+            'id' => $product->getAttribute('public_id'),
+            'name' => $product->getAttribute('name'),
+            'slug' => $product->getAttribute('slug'),
+            'sku' => $product->getAttribute('sku'),
+            'type' => $product->getAttribute('type')?->value,
+            'is_visible' => $product->getAttribute('is_visible'),
+            'published_at' => $product->getAttribute('published_at')?->toIso8601String(),
+            'updated_at' => $product->getAttribute('updated_at')?->toIso8601String(),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function genericData(Model $resource): array
+    {
+        return array_filter([
+            'id' => $resource->getAttribute('public_id') ?? $resource->getKey(),
+            'email' => $resource->getAttribute('email'),
+            'first_name' => $resource->getAttribute('first_name'),
+            'last_name' => $resource->getAttribute('last_name'),
+            'created_at' => $resource->getAttribute('created_at')?->toIso8601String(),
+        ], fn (mixed $value): bool => $value !== null);
+    }
+}

--- a/packages/core/src/Webhooks/WebhookSignature.php
+++ b/packages/core/src/Webhooks/WebhookSignature.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Core\Webhooks;
+
+final class WebhookSignature
+{
+    /**
+     * Compute the `X-Shopper-Signature` header value for a payload.
+     *
+     * Returns `t=<unix-timestamp>,v1=<hmac>` where the HMAC-SHA256 digest
+     * covers `"{timestamp}.{payload}"`. Binding the timestamp into the
+     * signed message prevents replay of a captured request outside the
+     * tolerance window enforced by `verify()`.
+     */
+    public static function sign(string $payload, string $secret, ?int $timestamp = null): string
+    {
+        $timestamp ??= now()->getTimestamp();
+
+        $signature = hash_hmac('sha256', "{$timestamp}.{$payload}", $secret);
+
+        return "t={$timestamp},v1={$signature}";
+    }
+
+    /**
+     * Validate a signature header against the raw request body.
+     *
+     * Fails on: malformed header, timestamp drift beyond the tolerance
+     * (`shopper.webhooks.signature_tolerance` seconds, default 300), or
+     * digest mismatch. Comparison uses `hash_equals()` to stay
+     * constant-time.
+     */
+    public static function verify(string $header, string $payload, string $secret, ?int $tolerance = null): bool
+    {
+        $tolerance ??= (int) config('shopper.webhooks.signature_tolerance', 300);
+
+        if (! preg_match('/^t=(\d+),v1=([a-f0-9]{64})$/', $header, $matches)) {
+            return false;
+        }
+
+        [, $timestamp, $signature] = $matches;
+
+        if (abs(now()->getTimestamp() - (int) $timestamp) > $tolerance) {
+            return false;
+        }
+
+        $expected = hash_hmac('sha256', "{$timestamp}.{$payload}", $secret);
+
+        return hash_equals($expected, $signature);
+    }
+}

--- a/packages/core/src/Webhooks/WebhookUrl.php
+++ b/packages/core/src/Webhooks/WebhookUrl.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Core\Webhooks;
+
+use Closure;
+use RuntimeException;
+
+final class WebhookUrl
+{
+    /** @var (Closure(string): list<string>)|null */
+    private static ?Closure $resolveHostUsing = null;
+
+    /**
+     * Replace the DNS resolver used by the guard. Pass null to restore the
+     * real resolver. Refused outside the test environment: this is the only
+     * lever that can neuter the SSRF guard, so it must never be reachable
+     * from production code or a compromised dependency.
+     *
+     * @param  (Closure(string): list<string>)|null  $resolver
+     */
+    public static function resolveHostUsing(?Closure $resolver): void
+    {
+        if (! app()->runningUnitTests()) {
+            throw new RuntimeException('The webhook DNS resolver can only be overridden in the test environment.');
+        }
+
+        self::$resolveHostUsing = $resolver;
+    }
+
+    /**
+     * SSRF guard for merchant-supplied delivery URLs.
+     *
+     * Rejects the URL unless: scheme is https, the host resolves, and every
+     * resolved address — both A and AAAA records, since curl may connect
+     * over either family — passes `FILTER_FLAG_NO_PRIV_RANGE` and
+     * `FILTER_FLAG_NO_RES_RANGE` (blocks RFC 1918, loopback, link-local —
+     * including cloud metadata endpoints such as 169.254.169.254).
+     *
+     * Must run at subscription time and again at delivery time: DNS may be
+     * re-pointed to a private address between the two (DNS rebinding). At
+     * delivery time, pair with `safeAddressFor()` + `pinnedResolveOptions()`
+     * so the connection uses the exact address that was validated.
+     */
+    public static function isSafe(string $url): bool
+    {
+        return self::safeAddressFor($url) !== null;
+    }
+
+    /**
+     * Validate the URL and return one vetted address to connect to, or null
+     * when the URL is unsafe. All resolved addresses must pass the guard —
+     * a host mixing one public and one private address is rejected outright.
+     */
+    public static function safeAddressFor(string $url): ?string
+    {
+        $parts = parse_url($url);
+
+        if (! is_array($parts) || ($parts['scheme'] ?? null) !== 'https' || ! isset($parts['host'])) {
+            return null;
+        }
+
+        $host = $parts['host'];
+
+        if (! self::hostIsAllowed($host)) {
+            return null;
+        }
+
+        $addresses = filter_var($host, FILTER_VALIDATE_IP) !== false
+            ? [$host]
+            : self::resolve($host);
+
+        if ($addresses === []) {
+            return null;
+        }
+
+        foreach ($addresses as $address) {
+            if (filter_var($address, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE) === false) {
+                return null;
+            }
+        }
+
+        return $addresses[0];
+    }
+
+    /**
+     * Curl options pinning the connection to the vetted address, so the
+     * HTTP client cannot re-resolve DNS to a different (possibly private)
+     * address between validation and connect. TLS SNI and the Host header
+     * keep using the original hostname.
+     *
+     * @return array<int, mixed>
+     */
+    public static function pinnedResolveOptions(string $url, string $address): array
+    {
+        $parts = parse_url($url);
+        $host = is_array($parts) ? ($parts['host'] ?? null) : null;
+
+        if ($host === null || filter_var($host, FILTER_VALIDATE_IP) !== false) {
+            return [];
+        }
+
+        $port = is_array($parts) ? ($parts['port'] ?? 443) : 443;
+
+        return [
+            CURLOPT_RESOLVE => ["{$host}:{$port}:{$address}"],
+        ];
+    }
+
+    /**
+     * A host passes when the allowlist is empty (open by default) or when it
+     * matches an allowlisted host exactly or as a subdomain. Locks deliveries
+     * to known integrations so a compromised admin cannot redirect the store's
+     * PII stream to an arbitrary endpoint.
+     */
+    private static function hostIsAllowed(string $host): bool
+    {
+        /** @var list<string> $allowed */
+        $allowed = (array) config('shopper.webhooks.allowed_hosts', []);
+
+        if ($allowed === []) {
+            return true;
+        }
+
+        $host = mb_strtolower($host);
+
+        foreach ($allowed as $entry) {
+            $entry = mb_strtolower(mb_trim($entry));
+
+            if ($host === $entry || str_ends_with($host, '.'.$entry)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function resolve(string $host): array
+    {
+        if (self::$resolveHostUsing !== null) {
+            return (self::$resolveHostUsing)($host);
+        }
+
+        $records = @dns_get_record($host, DNS_A | DNS_AAAA) ?: [];
+
+        return array_values(array_filter(array_map(
+            fn (array $record): ?string => $record['ip'] ?? $record['ipv6'] ?? null,
+            $records,
+        )));
+    }
+}

--- a/tests/Admin/Addon/AddonRegistrationTest.php
+++ b/tests/Admin/Addon/AddonRegistrationTest.php
@@ -47,20 +47,3 @@ it('throws when the same addon is registered twice', function (): void {
         new FakeFirstAddon,
     ]))->toThrow(LogicException::class);
 });
-
-it('registers the routes an addon declares', function (): void {
-    $provider = app()->getProvider(Shopper\ShopperServiceProvider::class);
-
-    $consume = (new ReflectionMethod($provider, 'registerAddonRoutes'))
-        ->getClosure($provider);
-
-    $consume([function (): void {
-        Illuminate\Support\Facades\Route::get('/addon-probe', fn (): string => 'ok')->name('shopper.addon-probe');
-    }]);
-
-    $registered = collect(app('router')->getRoutes()->getRoutes())
-        ->contains(fn ($route): bool => $route->getName() === 'shopper.addon-probe'
-            && str_starts_with($route->uri(), shopper()->prefix()));
-
-    expect($registered)->toBeTrue();
-});

--- a/tests/Admin/Addon/AddonRoutesTest.php
+++ b/tests/Admin/Addon/AddonRoutesTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Admin\Addon;
+
+use PHPUnit\Framework\Attributes\Test;
+use Shopper\Http\Middleware\Authenticate;
+use Tests\Admin\Addon\Stubs\RoutingAddonServiceProvider;
+use Tests\Admin\TestCase;
+
+final class AddonRoutesTest extends TestCase
+{
+    #[Test]
+    public function it_registers_addon_routes_inside_the_panel_group(): void
+    {
+        $route = app('router')->getRoutes()->getByName('shopper.settings.addon-probe');
+
+        $this->assertNotNull($route);
+        $this->assertSame(shopper()->prefix().'/setting/addon-probe', $route->uri());
+        $this->assertContains(Authenticate::class, $route->gatherMiddleware());
+    }
+
+    protected function getPackageProviders($app): array
+    {
+        return array_merge(parent::getPackageProviders($app), [
+            RoutingAddonServiceProvider::class,
+        ]);
+    }
+}

--- a/tests/Admin/Addon/Stubs/RoutingAddon.php
+++ b/tests/Admin/Addon/Stubs/RoutingAddon.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Admin\Addon\Stubs;
+
+use Illuminate\Support\Facades\Route;
+use Shopper\Addon\BaseAddon;
+use Shopper\ShopperPanel;
+
+final class RoutingAddon extends BaseAddon
+{
+    public function getId(): string
+    {
+        return 'routing-stub';
+    }
+
+    public function register(ShopperPanel $panel): void
+    {
+        $panel->addonRoutes(function (): void {
+            Route::prefix('setting')
+                ->as('settings.')
+                ->group(fn () => Route::get('/addon-probe', fn (): string => 'ok')->name('addon-probe'));
+        });
+    }
+}

--- a/tests/Admin/Addon/Stubs/RoutingAddonServiceProvider.php
+++ b/tests/Admin/Addon/Stubs/RoutingAddonServiceProvider.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Admin\Addon\Stubs;
+
+use Illuminate\Support\ServiceProvider;
+use Shopper\Facades\Shopper;
+
+final class RoutingAddonServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        Shopper::addons([new RoutingAddon]);
+    }
+}

--- a/tests/Admin/Livewire/Pages/Settings/WebhooksTest.php
+++ b/tests/Admin/Livewire/Pages/Settings/WebhooksTest.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Bus;
+use Livewire\Livewire;
+use Shopper\Core\Enum\WebhookDeliveryStatus;
+use Shopper\Core\Jobs\DeliverWebhookJob;
+use Shopper\Core\Models\Product;
+use Shopper\Core\Models\WebhookDelivery;
+use Shopper\Core\Models\WebhookEvent;
+use Shopper\Core\Models\WebhookSubscription;
+use Shopper\Core\Webhooks\WebhookUrl;
+use Shopper\Livewire\Pages\Settings\Webhooks;
+use Tests\Core\Stubs\User;
+
+uses(Tests\Admin\TestCase::class);
+
+beforeEach(function (): void {
+    $this->user = User::factory()->create();
+    $this->user->givePermissionTo('system.settings');
+    $this->actingAs($this->user);
+
+    WebhookUrl::resolveHostUsing(fn (): array => ['93.184.216.34']);
+});
+
+afterEach(function (): void {
+    WebhookUrl::resolveHostUsing(null);
+});
+
+describe(Webhooks::class, function (): void {
+    it('can render the webhooks settings page', function (): void {
+        WebhookSubscription::factory()->create();
+
+        Livewire::test(Webhooks::class)
+            ->assertOk()
+            ->assertViewIs('shopper::livewire.pages.settings.webhooks');
+    });
+
+    it('creates a subscription with a generated secret', function (): void {
+        Livewire::test(Webhooks::class)
+            ->callAction('createWebhook', [
+                'url' => 'https://erp.example.com/hooks',
+                'events' => ['order.paid'],
+            ])
+            ->assertHasNoActionErrors();
+
+        $subscription = WebhookSubscription::query()->sole();
+
+        expect($subscription->url)->toBe('https://erp.example.com/hooks')
+            ->and(mb_strlen($subscription->secret))->toBeGreaterThanOrEqual(32);
+    });
+
+    it('refuses to create a subscription past the configured cap', function (): void {
+        config()->set('shopper.webhooks.max_subscriptions', 2);
+        WebhookSubscription::factory()->count(2)->create();
+
+        Livewire::test(Webhooks::class)
+            ->callAction('createWebhook', [
+                'url' => 'https://erp.example.com/hooks',
+                'events' => ['order.paid'],
+            ]);
+
+        expect(WebhookSubscription::query()->count())->toBe(2);
+    });
+
+    it('regenerates the secret and invalidates the previous one', function (): void {
+        $subscription = WebhookSubscription::factory()->create(['secret' => 'old-secret']);
+
+        Livewire::test(Webhooks::class)
+            ->callTableAction('regenerateSecret', $subscription);
+
+        $newSecret = $subscription->refresh()->secret;
+
+        expect($newSecret)->not->toBe('old-secret')
+            ->and(mb_strlen($newSecret))->toBeGreaterThanOrEqual(32);
+    });
+
+    it('rejects a webhook url resolving to a private address', function (): void {
+        WebhookUrl::resolveHostUsing(fn (): array => ['169.254.169.254']);
+
+        Livewire::test(Webhooks::class)
+            ->callAction('createWebhook', [
+                'url' => 'https://metadata.example.com/steal',
+                'events' => ['order.paid'],
+            ])
+            ->assertHasActionErrors(['url']);
+
+        expect(WebhookSubscription::query()->count())->toBe(0);
+    });
+
+    it('redelivers the last delivery when the resource still exists', function (): void {
+        Bus::fake([DeliverWebhookJob::class]);
+
+        $product = Product::factory()->standard()->create();
+        $subscription = WebhookSubscription::factory()->create();
+
+        $event = WebhookEvent::query()->create([
+            'name' => 'product.updated',
+            'resource_type' => $product->getMorphClass(),
+            'resource_id' => $product->public_id,
+            'payload' => ['name' => $product->name],
+        ]);
+
+        WebhookDelivery::query()->create([
+            'webhook_event_id' => $event->id,
+            'webhook_subscription_id' => $subscription->id,
+            'status' => WebhookDeliveryStatus::Failed,
+        ]);
+
+        Livewire::test(Webhooks::class)
+            ->callTableAction('redeliver', $subscription);
+
+        expect(WebhookEvent::query()->count())->toBe(1);
+
+        $newDelivery = $subscription->deliveries()->latest('id')->first();
+
+        expect($subscription->deliveries()->count())->toBe(2)
+            ->and($newDelivery->webhook_event_id)->toBe($event->id);
+
+        Bus::assertDispatched(DeliverWebhookJob::class, function (DeliverWebhookJob $job) use ($newDelivery): bool {
+            $deliveryId = (fn (): int => $this->deliveryId)->call($job);
+
+            return $deliveryId === $newDelivery->id;
+        });
+    });
+
+    it('refuses to redeliver when the resource has been erased', function (): void {
+        Bus::fake([DeliverWebhookJob::class]);
+
+        $product = Product::factory()->standard()->create();
+        $subscription = WebhookSubscription::factory()->create();
+
+        $event = WebhookEvent::query()->create([
+            'name' => 'product.deleted',
+            'resource_type' => $product->getMorphClass(),
+            'resource_id' => $product->public_id,
+            'payload' => ['name' => $product->name],
+        ]);
+
+        WebhookDelivery::query()->create([
+            'webhook_event_id' => $event->id,
+            'webhook_subscription_id' => $subscription->id,
+            'status' => WebhookDeliveryStatus::Failed,
+        ]);
+
+        $product->forceDelete();
+
+        Livewire::test(Webhooks::class)
+            ->callTableAction('redeliver', $subscription);
+
+        expect($subscription->deliveries()->count())->toBe(1);
+        Bus::assertNothingDispatched();
+    });
+})->group('livewire', 'settings', 'webhooks');

--- a/tests/Cart/Feature/CartCompletedWebhookTest.php
+++ b/tests/Cart/Feature/CartCompletedWebhookTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Bus;
+use Shopper\Cart\Events\CartCompleted;
+use Shopper\Cart\Models\Cart;
+use Shopper\Core\Jobs\DeliverWebhookJob;
+use Shopper\Core\Models\Order;
+use Shopper\Core\Models\WebhookEvent;
+use Shopper\Core\Models\WebhookSubscription;
+
+uses(Tests\Cart\TestCase::class);
+
+it('dispatches `cart.completed` with the resulting order as the resource', function (): void {
+    Bus::fake([DeliverWebhookJob::class]);
+
+    WebhookSubscription::factory()->create(['events' => ['cart.completed']]);
+
+    $order = Order::factory()->create(['price_amount' => 12000]);
+    $cart = Cart::factory()->create();
+
+    event(new CartCompleted($cart, $order));
+
+    $webhookEvent = WebhookEvent::query()->where('name', 'cart.completed')->sole();
+
+    expect($webhookEvent->payload['number'])->toBe($order->number)
+        ->and($webhookEvent->resource_type)->toBe($order->getMorphClass());
+})->group('cart', 'webhooks');

--- a/tests/Core/Workflows/Webhooks/WebhookDeliveryTest.php
+++ b/tests/Core/Workflows/Webhooks/WebhookDeliveryTest.php
@@ -1,0 +1,355 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Http;
+use Shopper\Core\Enum\WebhookDeliveryStatus;
+use Shopper\Core\Jobs\DeliverWebhookJob;
+use Shopper\Core\Models\WebhookDelivery;
+use Shopper\Core\Models\WebhookEvent;
+use Shopper\Core\Models\WebhookSubscription;
+use Shopper\Core\Webhooks\WebhookSignature;
+use Shopper\Core\Webhooks\WebhookUrl;
+
+uses(Tests\Core\TestCase::class);
+
+beforeEach(function (): void {
+    WebhookUrl::resolveHostUsing(fn (): array => ['93.184.216.34']);
+});
+
+afterEach(function (): void {
+    WebhookUrl::resolveHostUsing(null);
+});
+
+function makeDelivery(array $subscriptionAttributes = []): WebhookDelivery
+{
+    $subscription = WebhookSubscription::factory()->create(array_merge([
+        'url' => 'https://receiver.test/hooks',
+        'secret' => 'shhh-secret',
+    ], $subscriptionAttributes));
+
+    $event = WebhookEvent::query()->create([
+        'name' => 'order.paid',
+        'resource_type' => 'order',
+        'resource_id' => '01TESTORDERID',
+        'payload' => ['number' => 'ORD-1', 'price_amount' => 5000],
+    ]);
+
+    return WebhookDelivery::query()->create([
+        'webhook_event_id' => $event->id,
+        'webhook_subscription_id' => $subscription->id,
+        'status' => WebhookDeliveryStatus::Pending,
+    ]);
+}
+
+describe('Webhook delivery job', function (): void {
+    it('posts the signed payload and marks the delivery succeeded', function (): void {
+        Http::fake(['receiver.test/*' => Http::response('', 200)]);
+
+        $delivery = makeDelivery();
+
+        (new DeliverWebhookJob($delivery->id))->handle();
+
+        Http::assertSent(function ($request) use ($delivery): bool {
+            $body = $request->body();
+
+            return $request->url() === 'https://receiver.test/hooks'
+                && $request->hasHeader('X-Shopper-Event', 'order.paid')
+                && $request->hasHeader('X-Shopper-Event-Id', (string) $delivery->event->public_id)
+                && WebhookSignature::verify($request->header('X-Shopper-Signature')[0], $body, 'shhh-secret')
+                && data_get(json_decode($body, true), 'data.number') === 'ORD-1'
+                && data_get(json_decode($body, true), 'id') === $delivery->event->public_id;
+        });
+
+        expect($delivery->refresh()->status)->toBe(WebhookDeliveryStatus::Succeeded)
+            ->and($delivery->response_code)->toBe(200);
+    });
+
+    it('marks a 4xx as rejected without retrying', function (): void {
+        Http::fake(['receiver.test/*' => Http::response('bad payload', 422)]);
+
+        $delivery = makeDelivery();
+
+        (new DeliverWebhookJob($delivery->id))->handle();
+
+        expect($delivery->refresh()->status)->toBe(WebhookDeliveryStatus::Rejected)
+            ->and($delivery->response_code)->toBe(422)
+            ->and($delivery->completed_at)->not->toBeNull();
+    });
+
+    it('refuses to deliver to a url resolving to a forbidden address', function (): void {
+        Http::fake();
+
+        $delivery = makeDelivery(['url' => 'https://127.0.0.1/steal']);
+
+        (new DeliverWebhookJob($delivery->id))->handle();
+
+        Http::assertNothingSent();
+        expect($delivery->refresh()->status)->toBe(WebhookDeliveryStatus::Rejected);
+    });
+
+    it('skips delivery for a subscription that was disabled meanwhile', function (): void {
+        Http::fake();
+
+        $delivery = makeDelivery(['is_active' => false]);
+
+        (new DeliverWebhookJob($delivery->id))->handle();
+
+        Http::assertNothingSent();
+        expect($delivery->refresh()->status)->toBe(WebhookDeliveryStatus::Pending);
+    });
+
+    it('disables a subscription whose recent history is nothing but failures', function (): void {
+        config()->set('shopper.webhooks.disable_after_failures', 3);
+
+        $subscription = WebhookSubscription::factory()->create();
+        $event = WebhookEvent::query()->create(['name' => 'order.paid', 'payload' => []]);
+
+        foreach (range(1, 3) as $i) {
+            WebhookDelivery::query()->create([
+                'webhook_event_id' => $event->id,
+                'webhook_subscription_id' => $subscription->id,
+                'status' => WebhookDeliveryStatus::Failed,
+            ]);
+        }
+
+        $subscription->disableWhenFailing();
+
+        expect($subscription->refresh()->is_active)->toBeFalse();
+    });
+
+    it('keeps a subscription active while a recent delivery succeeded', function (): void {
+        config()->set('shopper.webhooks.disable_after_failures', 3);
+
+        $subscription = WebhookSubscription::factory()->create();
+        $event = WebhookEvent::query()->create(['name' => 'order.paid', 'payload' => []]);
+
+        foreach ([WebhookDeliveryStatus::Failed, WebhookDeliveryStatus::Succeeded, WebhookDeliveryStatus::Failed] as $status) {
+            WebhookDelivery::query()->create([
+                'webhook_event_id' => $event->id,
+                'webhook_subscription_id' => $subscription->id,
+                'status' => $status,
+            ]);
+        }
+
+        $subscription->disableWhenFailing();
+
+        expect($subscription->refresh()->is_active)->toBeTrue();
+    });
+
+    it('does not count rejected deliveries toward the failure window', function (): void {
+        config()->set('shopper.webhooks.disable_after_failures', 3);
+
+        $subscription = WebhookSubscription::factory()->create();
+        $event = WebhookEvent::query()->create(['name' => 'order.paid', 'payload' => []]);
+
+        foreach ([
+            WebhookDeliveryStatus::Failed,
+            WebhookDeliveryStatus::Rejected,
+            WebhookDeliveryStatus::Rejected,
+            WebhookDeliveryStatus::Failed,
+            WebhookDeliveryStatus::Failed,
+        ] as $status) {
+            WebhookDelivery::query()->create([
+                'webhook_event_id' => $event->id,
+                'webhook_subscription_id' => $subscription->id,
+                'status' => $status,
+            ]);
+        }
+
+        $subscription->disableWhenFailing();
+
+        expect($subscription->refresh()->is_active)->toBeFalse();
+    });
+
+    it('does not let a success outside the recent window keep the subscription active', function (): void {
+        config()->set('shopper.webhooks.disable_after_failures', 3);
+
+        $subscription = WebhookSubscription::factory()->create();
+        $event = WebhookEvent::query()->create(['name' => 'order.paid', 'payload' => []]);
+
+        foreach ([
+            WebhookDeliveryStatus::Succeeded,
+            WebhookDeliveryStatus::Failed,
+            WebhookDeliveryStatus::Failed,
+            WebhookDeliveryStatus::Failed,
+        ] as $status) {
+            WebhookDelivery::query()->create([
+                'webhook_event_id' => $event->id,
+                'webhook_subscription_id' => $subscription->id,
+                'status' => $status,
+            ]);
+        }
+
+        $subscription->disableWhenFailing();
+
+        expect($subscription->refresh()->is_active)->toBeFalse();
+    });
+
+    it('does not disable a subscription with fewer deliveries than the threshold', function (): void {
+        config()->set('shopper.webhooks.disable_after_failures', 5);
+
+        $subscription = WebhookSubscription::factory()->create();
+        $event = WebhookEvent::query()->create(['name' => 'order.paid', 'payload' => []]);
+
+        foreach (range(1, 4) as $i) {
+            WebhookDelivery::query()->create([
+                'webhook_event_id' => $event->id,
+                'webhook_subscription_id' => $subscription->id,
+                'status' => WebhookDeliveryStatus::Failed,
+            ]);
+        }
+
+        $subscription->disableWhenFailing();
+
+        expect($subscription->refresh()->is_active)->toBeTrue();
+    });
+
+    it('stores the webhook secret encrypted at rest', function (): void {
+        $subscription = WebhookSubscription::factory()->create(['secret' => 'plain-secret-value']);
+
+        $raw = Illuminate\Support\Facades\DB::table(shopper_table('webhook_subscriptions'))
+            ->where('id', $subscription->id)
+            ->value('secret');
+
+        expect($raw)->not->toBe('plain-secret-value')
+            ->and($subscription->secret)->toBe('plain-secret-value');
+    });
+
+    it('requeues dispatch_failed and stale pending deliveries, leaving live retries alone', function (): void {
+        Illuminate\Support\Facades\Bus::fake([DeliverWebhookJob::class]);
+
+        $delivery = makeDelivery();
+        $event = $delivery->event;
+        $subscriptionId = $delivery->webhook_subscription_id;
+
+        $delivery->update(['status' => WebhookDeliveryStatus::DispatchFailed]);
+
+        $stalePending = WebhookDelivery::query()->create([
+            'webhook_event_id' => $event->id,
+            'webhook_subscription_id' => $subscriptionId,
+            'status' => WebhookDeliveryStatus::Pending,
+        ]);
+        $stalePending->updateQuietly(['created_at' => now()->subMinutes(30)]);
+
+        $freshPending = WebhookDelivery::query()->create([
+            'webhook_event_id' => $event->id,
+            'webhook_subscription_id' => $subscriptionId,
+            'status' => WebhookDeliveryStatus::Pending,
+        ]);
+
+        $liveRetry = WebhookDelivery::query()->create([
+            'webhook_event_id' => $event->id,
+            'webhook_subscription_id' => $subscriptionId,
+            'status' => WebhookDeliveryStatus::Failed,
+        ]);
+
+        $this->artisan('shopper:webhooks:redispatch')->assertSuccessful();
+
+        Illuminate\Support\Facades\Bus::assertDispatchedTimes(DeliverWebhookJob::class, 2);
+
+        expect($delivery->refresh()->status)->toBe(WebhookDeliveryStatus::Pending)
+            ->and($stalePending->refresh()->status)->toBe(WebhookDeliveryStatus::Pending)
+            ->and($freshPending->refresh()->status)->toBe(WebhookDeliveryStatus::Pending)
+            ->and($liveRetry->refresh()->status)->toBe(WebhookDeliveryStatus::Failed);
+    });
+
+    it('releases the job with the configured backoff delay on a 5xx response', function (): void {
+        config()->set('shopper.webhooks.backoff', [15, 45]);
+        Http::fake(['receiver.test/*' => Http::response('down', 503)]);
+
+        $delivery = makeDelivery();
+        $job = (new DeliverWebhookJob($delivery->id))->withFakeQueueInteractions();
+
+        $job->handle();
+
+        $job->assertReleased(delay: 15);
+        expect($delivery->refresh()->status)->toBe(WebhookDeliveryStatus::Failed)
+            ->and($delivery->attempt_number)->toBe(1)
+            ->and($delivery->completed_at)->toBeNull();
+    });
+
+    it('records a retryable failure when the connection times out', function (): void {
+        Http::fake(fn () => throw new Illuminate\Http\Client\ConnectionException('Connection timed out'));
+
+        $delivery = makeDelivery();
+        $job = (new DeliverWebhookJob($delivery->id))->withFakeQueueInteractions();
+
+        $job->handle();
+
+        $job->assertReleased();
+        expect($delivery->refresh()->status)->toBe(WebhookDeliveryStatus::Failed)
+            ->and($delivery->response_code)->toBeNull()
+            ->and($delivery->completed_at)->toBeNull();
+    });
+
+    it('marks the delivery terminal and disables the subscription once retries are exhausted', function (): void {
+        config()->set('shopper.webhooks.backoff', [10]);
+        config()->set('shopper.webhooks.disable_after_failures', 1);
+        Http::fake(['receiver.test/*' => Http::response('down', 500)]);
+
+        $delivery = makeDelivery();
+        $job = (new DeliverWebhookJob($delivery->id))->withFakeQueueInteractions();
+        $job->job->attempts = 2;
+
+        $job->handle();
+
+        $job->assertNotReleased();
+        expect($delivery->refresh()->status)->toBe(WebhookDeliveryStatus::Failed)
+            ->and($delivery->completed_at)->not->toBeNull()
+            ->and($delivery->subscription->refresh()->is_active)->toBeFalse();
+    });
+
+    it('reaches a terminal state through the failed handler when the job dies on an unexpected exception', function (): void {
+        config()->set('shopper.webhooks.disable_after_failures', 1);
+
+        $delivery = makeDelivery();
+
+        (new DeliverWebhookJob($delivery->id))->failed(new RuntimeException('worker died'));
+
+        expect($delivery->refresh()->status)->toBe(WebhookDeliveryStatus::Failed)
+            ->and($delivery->completed_at)->not->toBeNull()
+            ->and($delivery->response_body)->toBe('worker died')
+            ->and($delivery->subscription->refresh()->is_active)->toBeFalse();
+    });
+
+    it('prunes old succeeded deliveries but keeps recent failures', function (): void {
+        $delivery = makeDelivery();
+        $event = $delivery->event;
+
+        $old = WebhookDelivery::query()->create([
+            'webhook_event_id' => $event->id,
+            'webhook_subscription_id' => $delivery->webhook_subscription_id,
+            'status' => WebhookDeliveryStatus::Succeeded,
+        ]);
+        $old->updateQuietly(['created_at' => now()->subDays(10)]);
+
+        $failed = WebhookDelivery::query()->create([
+            'webhook_event_id' => $event->id,
+            'webhook_subscription_id' => $delivery->webhook_subscription_id,
+            'status' => WebhookDeliveryStatus::Failed,
+        ]);
+        $failed->updateQuietly(['created_at' => now()->subDays(10)]);
+
+        $this->artisan('model:prune', ['--model' => [WebhookDelivery::class]]);
+
+        expect(WebhookDelivery::query()->whereKey($old->id)->exists())->toBeFalse()
+            ->and(WebhookDelivery::query()->whereKey($failed->id)->exists())->toBeTrue();
+    });
+})->group('core', 'webhooks');
+
+describe('Webhook signature', function (): void {
+    it('signs and verifies within the tolerance window', function (): void {
+        $signature = WebhookSignature::sign('{"a":1}', 'secret');
+
+        expect(WebhookSignature::verify($signature, '{"a":1}', 'secret'))->toBeTrue()
+            ->and(WebhookSignature::verify($signature, '{"a":2}', 'secret'))->toBeFalse()
+            ->and(WebhookSignature::verify($signature, '{"a":1}', 'wrong'))->toBeFalse();
+    });
+
+    it('rejects a replayed signature outside the tolerance window', function (): void {
+        $signature = WebhookSignature::sign('{"a":1}', 'secret', now()->subMinutes(10)->getTimestamp());
+
+        expect(WebhookSignature::verify($signature, '{"a":1}', 'secret'))->toBeFalse();
+    });
+})->group('core', 'webhooks');

--- a/tests/Core/Workflows/Webhooks/WebhookDispatchTest.php
+++ b/tests/Core/Workflows/Webhooks/WebhookDispatchTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Bus;
+use Shopper\Core\Events\Orders\OrderPaid;
+use Shopper\Core\Events\Products\ProductDeleted;
+use Shopper\Core\Jobs\DeliverWebhookJob;
+use Shopper\Core\Models\Order;
+use Shopper\Core\Models\Product;
+use Shopper\Core\Models\WebhookDelivery;
+use Shopper\Core\Models\WebhookEvent;
+use Shopper\Core\Models\WebhookSubscription;
+
+uses(Tests\Core\TestCase::class);
+
+beforeEach(function (): void {
+    Bus::fake([DeliverWebhookJob::class]);
+});
+
+describe('Webhook dispatch', function (): void {
+    it('snapshots the event and queues one delivery per subscribed endpoint', function (): void {
+        WebhookSubscription::factory()->create(['events' => ['order.paid']]);
+        WebhookSubscription::factory()->create(['events' => ['order.paid', 'order.created']]);
+        WebhookSubscription::factory()->create(['events' => ['product.created']]);
+
+        $order = Order::factory()->create(['price_amount' => 5000]);
+
+        event(new OrderPaid($order));
+
+        $webhookEvent = WebhookEvent::query()->where('name', 'order.paid')->sole();
+
+        expect($webhookEvent->payload['number'])->toBe($order->number)
+            ->and($webhookEvent->payload['price_amount'])->toBe(5000)
+            ->and(WebhookDelivery::query()->where('webhook_event_id', $webhookEvent->id)->count())->toBe(2);
+    });
+
+    it('does nothing when no subscription listens to the event', function (): void {
+        WebhookSubscription::factory()->create(['events' => ['product.created']]);
+
+        event(new OrderPaid(Order::factory()->create()));
+
+        expect(WebhookEvent::query()->count())->toBe(0);
+        Bus::assertNothingDispatched();
+    });
+
+    it('ignores inactive subscriptions', function (): void {
+        WebhookSubscription::factory()->inactive()->create(['events' => ['order.paid']]);
+
+        event(new OrderPaid(Order::factory()->create()));
+
+        expect(WebhookDelivery::query()->count())->toBe(0);
+    });
+
+    it('snapshots a deleted product so the delete webhook can still be delivered', function (): void {
+        WebhookSubscription::factory()->create(['events' => ['product.deleted']]);
+
+        $product = Product::factory()->standard()->create(['name' => 'Gone Soon']);
+        $productId = $product->public_id;
+
+        event(new ProductDeleted($product));
+
+        $product->forceDelete();
+
+        $webhookEvent = WebhookEvent::query()->sole();
+
+        expect($webhookEvent->payload['name'])->toBe('Gone Soon')
+            ->and($webhookEvent->payload['id'])->toBe($productId)
+            ->and($webhookEvent->resource_id)->toBe($productId);
+    });
+
+    it('marks a delivery dispatch_failed when the queue rejects the push, without blocking the others', function (): void {
+        WebhookSubscription::factory()->create(['events' => ['order.paid']]);
+        WebhookSubscription::factory()->create(['events' => ['order.paid']]);
+
+        $order = Order::factory()->create();
+
+        $calls = 0;
+        Bus::shouldReceive('dispatch')->andReturnUsing(function () use (&$calls): void {
+            if (++$calls === 1) {
+                throw new RuntimeException('queue unavailable');
+            }
+        });
+
+        event(new OrderPaid($order));
+
+        $statuses = WebhookDelivery::query()
+            ->whereHas('event', fn ($query) => $query->where('name', 'order.paid'))
+            ->orderBy('id')
+            ->pluck('status');
+
+        expect($statuses->count())->toBe(2)
+            ->and($statuses[0])->toBe(Shopper\Core\Enum\WebhookDeliveryStatus::DispatchFailed)
+            ->and($statuses[1])->toBe(Shopper\Core\Enum\WebhookDeliveryStatus::Pending);
+    });
+
+    it('stores the event payload encrypted at rest', function (): void {
+        WebhookSubscription::factory()->create(['events' => ['order.paid']]);
+
+        $order = Order::factory()->create();
+
+        event(new OrderPaid($order));
+
+        $webhookEvent = WebhookEvent::query()->where('name', 'order.paid')->sole();
+
+        $raw = Illuminate\Support\Facades\DB::table(shopper_table('webhook_events'))
+            ->where('id', $webhookEvent->id)
+            ->value('payload');
+
+        expect($raw)->not->toContain($order->number)
+            ->and($webhookEvent->payload['number'])->toBe($order->number);
+    });
+
+    it('never ships auth material in a customer payload', function (): void {
+        WebhookSubscription::factory()->create(['events' => ['customer.registered']]);
+
+        $customer = Tests\Core\Stubs\User::factory()->create();
+
+        event(new Shopper\Core\Events\Customers\CustomerRegistered($customer));
+
+        $payload = WebhookEvent::query()->sole()->payload;
+
+        expect($payload)->not->toHaveKey('password')
+            ->not->toHaveKey('remember_token')
+            ->not->toHaveKey('store_two_factor_secret');
+    });
+})->group('core', 'webhooks');

--- a/tests/Core/Workflows/Webhooks/WebhookUrlTest.php
+++ b/tests/Core/Workflows/Webhooks/WebhookUrlTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+use Shopper\Core\Webhooks\WebhookUrl;
+
+uses(Tests\Core\TestCase::class);
+
+afterEach(function (): void {
+    WebhookUrl::resolveHostUsing(null);
+});
+
+describe(WebhookUrl::class, function (): void {
+    it('rejects non-https schemes', function (): void {
+        expect(WebhookUrl::isSafe('http://example.com/hook'))->toBeFalse();
+    });
+
+    it('rejects a url without a host', function (): void {
+        expect(WebhookUrl::isSafe('https:///hook'))->toBeFalse();
+    });
+
+    it('rejects a hostname resolving to no address', function (): void {
+        WebhookUrl::resolveHostUsing(fn (): array => []);
+
+        expect(WebhookUrl::isSafe('https://nowhere.example.com/hook'))->toBeFalse();
+    });
+
+    it('rejects a host when any resolved address is private, even alongside public ones', function (): void {
+        WebhookUrl::resolveHostUsing(fn (): array => ['93.184.216.34', '10.0.0.5']);
+
+        expect(WebhookUrl::isSafe('https://multi.example.com/hook'))->toBeFalse();
+    });
+
+    it('rejects a host whose ipv6 record is loopback while its ipv4 is public', function (): void {
+        WebhookUrl::resolveHostUsing(fn (): array => ['93.184.216.34', '::1']);
+
+        expect(WebhookUrl::isSafe('https://dualstack.example.com/hook'))->toBeFalse();
+    });
+
+    it('accepts a public ip literal without DNS resolution', function (): void {
+        expect(WebhookUrl::isSafe('https://93.184.216.34/hook'))->toBeTrue();
+    });
+
+    it('rejects private, loopback and metadata ip literals', function (string $url): void {
+        expect(WebhookUrl::isSafe($url))->toBeFalse();
+    })->with([
+        'https://127.0.0.1/hook',
+        'https://10.0.0.1/hook',
+        'https://192.168.1.1/hook',
+        'https://169.254.169.254/latest/meta-data',
+    ]);
+
+    it('pins the vetted address for hostname urls and never for ip literals', function (): void {
+        expect(WebhookUrl::pinnedResolveOptions('https://receiver.test/hooks', '93.184.216.34'))
+            ->toBe([CURLOPT_RESOLVE => ['receiver.test:443:93.184.216.34']])
+            ->and(WebhookUrl::pinnedResolveOptions('https://receiver.test:8443/hooks', '93.184.216.34'))
+            ->toBe([CURLOPT_RESOLVE => ['receiver.test:8443:93.184.216.34']])
+            ->and(WebhookUrl::pinnedResolveOptions('https://93.184.216.34/hooks', '93.184.216.34'))
+            ->toBe([]);
+    });
+
+    it('rejects a public host that is not on a non-empty allowlist', function (): void {
+        config()->set('shopper.webhooks.allowed_hosts', ['erp.acme.com']);
+        WebhookUrl::resolveHostUsing(fn (): array => ['93.184.216.34']);
+
+        expect(WebhookUrl::isSafe('https://evil.example.com/hook'))->toBeFalse();
+    });
+
+    it('accepts an allowlisted host and its subdomains', function (): void {
+        config()->set('shopper.webhooks.allowed_hosts', ['acme.com']);
+        WebhookUrl::resolveHostUsing(fn (): array => ['93.184.216.34']);
+
+        expect(WebhookUrl::isSafe('https://acme.com/hook'))->toBeTrue()
+            ->and(WebhookUrl::isSafe('https://hooks.acme.com/hook'))->toBeTrue()
+            ->and(WebhookUrl::isSafe('https://notacme.com/hook'))->toBeFalse();
+    });
+})->group('core', 'webhooks');


### PR DESCRIPTION
## Summary

Outbound webhooks let a merchant register HTTPS endpoints and get a signed POST whenever a domain event fires (`order.paid`, `customer.registered`, `product.deleted`, …). This is the integration primitive the addon ecosystem builds on: an ERP, WMS, marketing tool or Zapier flow subscribes once instead of polling the API.

The listener runs synchronously at event time and snapshots the payload (domain events use `SerializesModels`, so a queued listener would re-fetch and crash on every `*.deleted` event); a queued `DeliverWebhookJob` on a dedicated queue does the actual POST, so checkout never waits on a slow third party.

## What ships

- **Models** — `WebhookSubscription` (url, subscribed events, encrypted signing secret, active flag), `WebhookEvent` (one immutable snapshot per occurrence, payload stored once), `WebhookDelivery` (per-attempt journal). `WebhookEventType` / `WebhookDeliveryStatus` enums.
- **Delivery** — HMAC-SHA256 signature (`X-Shopper-Signature: t=…,v1=…`, timestamp-bound against replay), exponential-backoff retries, 4xx → terminal `rejected` (no retry), 5xx/timeout → retry, auto-disable after N consecutive failures derived from the delivery log (not a lossy counter). A `failed()` handler and a `shopper:webhooks:redispatch` reclaimer close the at-least-once contract when the queue broker or a worker dies.
- **Admin** — Settings → Webhooks: CRUD, per-subscription delivery log, manual redelivery, one-time secret reveal + regenerate. All actions gated by `system.settings`.
- **Extensibility** — payload shape is a rebindable `WebhookPayloadSerializer` contract (default is an explicit attribute safelist, no `toArray()` spread); event map lives in `shopper.webhooks.events` so any package or addon registers its own events.
- **Dedicated database** — `shopper.webhooks.database.connection` points the three tables at a separate connection (Laravel Pulse style) so webhook volume never competes with commerce data. Models and the migration honor it.

## Security

- **SSRF guard** (`WebhookUrl`): https-only, resolves both A and AAAA records, rejects RFC 1918 / loopback / link-local / cloud-metadata addresses, refuses hosts mixing public and private IPs. Runs at subscribe time and again at delivery time, and pins the validated address into curl (`CURLOPT_RESOLVE`) so DNS rebinding cannot swap it between check and connect. The DNS-resolver override is refused outside the test environment.
- **Anti-exfiltration / amplification** (opt-in, open by default): `allowed_hosts` locks deliveries to known integrations; `max_subscriptions` caps fan-out.
- **Data at rest**: signing secret and event payload are both encrypted casts, so a database dump exposes neither the keys nor customer PII.
- **Retention**: both event and delivery tables are `Prunable` and scheduled via `model:prune` (succeeded pruned early, failures kept for diagnostics).

Also removes a duplicate addon-route registration introduced in #616 that wired addon routes a second time under bare `web` middleware with no `Authenticate` guard — addon routes are now registered once, inside the authenticated panel group. Covered by a new end-to-end test.

## Tests

Fan-out (including `dispatch_failed` isolation and `cart.completed` cross-package), delivery (signed POST, 4xx/5xx/timeout paths, backoff release, exhaustion, `failed()` handler, reclaimer), auto-disable rules, encrypted-at-rest secret and payload, the SSRF guard (IPv6 bypass, mixed public/private, allowlist, subdomains, IP pinning), the subscription cap, and the authenticated addon-route registration.