### PR TITLE
fix(admin): align dashboard metrics with canonical sales definitions

### DIFF
--- a/packages/admin/resources/views/components/card.blade.php
+++ b/packages/admin/resources/views/components/card.blade.php
@@ -9,7 +9,7 @@
 <div
     {{ $attributes->twMerge(['class' => 'sh-card flex flex-col justify-bewteen bg-sh-card ring-sh-border overflow-hidden rounded-xl p-0.5 ring-1']) }}
 >
-    @if ($title)
+    @if (mb_trim((string) $title) !== '')
         <header class="sh-card-header px-2 py-3">
             @if ($title instanceof \Illuminate\View\ComponentSlot)
                 {{ $title }}

--- a/packages/admin/src/Livewire/Components/Dashboard/RevenueChart.php
+++ b/packages/admin/src/Livewire/Components/Dashboard/RevenueChart.php
@@ -11,9 +11,11 @@ use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Js;
 use Leandrocfe\FilamentApexCharts\Widgets\ApexChartWidget;
+use Shopper\Core\Enum\OrderRefundStatus;
 use Shopper\Core\Enum\PaymentStatus;
 use Shopper\Core\Models\Contracts\Order;
 use Shopper\Core\Models\Currency;
+use Shopper\Core\Models\OrderRefund;
 
 final class RevenueChart extends ApexChartWidget
 {
@@ -98,26 +100,46 @@ final class RevenueChart extends ApexChartWidget
 
         $months = collect(CarbonPeriod::create($startDate, '1 month', $endDate));
 
-        /** @var array{select: string, groupBy: string} $expr */
-        $expr = $this->revenueExpressions();
-
         /** @var array<string, float> $revenueByMonth */
         $revenueByMonth = Cache::flexible(
             "dashboard:revenue:{$currency}",
             [300, 1800],
-            fn () => resolve(Order::class)::query()
-                ->selectRaw($expr['select'])
-                ->where('payment_status', PaymentStatus::Paid)
-                ->where('currency_code', $currency)
-                ->where('created_at', '>=', $startDate)
-                ->where('created_at', '<=', $endDate)
-                ->groupByRaw($expr['groupBy'])
-                ->get()
-                ->keyBy(fn ($row): string => $row->getAttribute('year').'-'.$row->getAttribute('month'))
-                ->map(fn ($row): float => is_no_division_currency($currency)
-                    ? (float) $row->getAttribute('total')
-                    : (float) $row->getAttribute('total') / 100)
-                ->all(),
+            function () use ($currency, $startDate, $endDate): array {
+                $collectedExpr = $this->monthlyTotalExpressions('price_amount');
+                $refundedExpr = $this->monthlyTotalExpressions('amount');
+
+                $collected = resolve(Order::class)::query()
+                    ->selectRaw($collectedExpr['select'])
+                    ->whereIn('payment_status', PaymentStatus::revenueBearing())
+                    ->where('currency_code', $currency)
+                    ->where('created_at', '>=', $startDate)
+                    ->where('created_at', '<=', $endDate)
+                    ->groupByRaw($collectedExpr['groupBy'])
+                    ->get()
+                    ->keyBy(fn ($row): string => $row->getAttribute('year').'-'.$row->getAttribute('month'))
+                    ->map(fn ($row): int => (int) $row->getAttribute('total'));
+
+                $refunded = OrderRefund::query()
+                    ->selectRaw($refundedExpr['select'])
+                    ->whereIn('status', OrderRefundStatus::settled())
+                    ->where('currency', $currency)
+                    ->where('created_at', '>=', $startDate)
+                    ->where('created_at', '<=', $endDate)
+                    ->groupByRaw($refundedExpr['groupBy'])
+                    ->get()
+                    ->keyBy(fn ($row): string => $row->getAttribute('year').'-'.$row->getAttribute('month'))
+                    ->map(fn ($row): int => (int) $row->getAttribute('total'));
+
+                return $collected->keys()
+                    ->merge($refunded->keys())
+                    ->unique()
+                    ->mapWithKeys(function (string $month) use ($collected, $refunded, $currency): array {
+                        $total = ($collected[$month] ?? 0) - ($refunded[$month] ?? 0);
+
+                        return [$month => is_no_division_currency($currency) ? (float) $total : $total / 100];
+                    })
+                    ->all();
+            },
         );
 
         $data = $months->map(fn (Carbon $month): float => $revenueByMonth[$month->year.'-'.$month->month] ?? 0.0);
@@ -160,19 +182,19 @@ final class RevenueChart extends ApexChartWidget
     /**
      * @return array{select: string, groupBy: string}
      */
-    private function revenueExpressions(): array
+    private function monthlyTotalExpressions(string $column): array
     {
         return match (DB::connection()->getDriverName()) {
             'pgsql' => [
-                'select' => 'EXTRACT(YEAR FROM created_at)::int as year, EXTRACT(MONTH FROM created_at)::int as month, SUM(price_amount) as total',
+                'select' => "EXTRACT(YEAR FROM created_at)::int as year, EXTRACT(MONTH FROM created_at)::int as month, SUM({$column}) as total",
                 'groupBy' => 'EXTRACT(YEAR FROM created_at), EXTRACT(MONTH FROM created_at)',
             ],
             'sqlite' => [
-                'select' => "CAST(strftime('%Y', created_at) AS INTEGER) as year, CAST(strftime('%m', created_at) AS INTEGER) as month, SUM(price_amount) as total",
+                'select' => "CAST(strftime('%Y', created_at) AS INTEGER) as year, CAST(strftime('%m', created_at) AS INTEGER) as month, SUM({$column}) as total",
                 'groupBy' => "strftime('%Y', created_at), strftime('%m', created_at)",
             ],
             default => [
-                'select' => 'YEAR(created_at) as year, MONTH(created_at) as month, SUM(price_amount) as total',
+                'select' => "YEAR(created_at) as year, MONTH(created_at) as month, SUM({$column}) as total",
                 'groupBy' => 'YEAR(created_at), MONTH(created_at)',
             ],
         };

--- a/packages/admin/src/Livewire/Components/Dashboard/StatCards.php
+++ b/packages/admin/src/Livewire/Components/Dashboard/StatCards.php
@@ -9,9 +9,12 @@ use Illuminate\Contracts\View\View;
 use Illuminate\Support\Facades\Cache;
 use Livewire\Attributes\Computed;
 use Livewire\Component;
+use Shopper\Core\Enum\OrderRefundStatus;
+use Shopper\Core\Enum\OrderStatus;
 use Shopper\Core\Enum\PaymentStatus;
 use Shopper\Core\Models\Contracts\Order;
 use Shopper\Core\Models\Contracts\Product as ProductContract;
+use Shopper\Core\Models\OrderRefund;
 
 /**
  * @property-read array<int, array{label: string, value: string|int, change: float, trend: string, icon: string, route: string}> $cards
@@ -21,9 +24,10 @@ final class StatCards extends Component
     #[Computed]
     public function cards(): array
     {
-        return Cache::flexible('dashboard:stat-cards:'.app()->getLocale(), [300, 1800], function () {
+        $currency = shopper_currency();
+
+        return Cache::flexible('dashboard:stat-cards:'.app()->getLocale().':'.$currency, [300, 1800], function () use ($currency) {
             $now = Carbon::now();
-            $currency = shopper_currency();
 
             return [
                 $this->buildRevenueCard($now, $currency),
@@ -49,17 +53,8 @@ final class StatCards extends Component
      */
     private function buildRevenueCard(Carbon $now, string $currency): array
     {
-        $currentMonth = (int) resolve(Order::class)::query()
-            ->where('payment_status', PaymentStatus::Paid)
-            ->where('currency_code', $currency)
-            ->whereBetween('created_at', $this->monthRange($now))
-            ->sum('price_amount');
-
-        $lastMonth = (int) resolve(Order::class)::query()
-            ->where('payment_status', PaymentStatus::Paid)
-            ->where('currency_code', $currency)
-            ->whereBetween('created_at', $this->monthRange($now->copy()->subMonth()))
-            ->sum('price_amount');
+        $currentMonth = $this->netRevenue($currency, $this->monthToDateRange($now));
+        $lastMonth = $this->netRevenue($currency, $this->previousMonthToDateRange($now));
 
         return [
             'label' => __('shopper::pages/dashboard.stats.revenue'),
@@ -76,11 +71,11 @@ final class StatCards extends Component
     private function buildProductsCard(Carbon $now): array
     {
         $current = resolve(ProductContract::class)::query()
-            ->whereBetween('created_at', $this->monthRange($now))
+            ->whereBetween('created_at', $this->monthToDateRange($now))
             ->count();
 
         $previous = resolve(ProductContract::class)::query()
-            ->whereBetween('created_at', $this->monthRange($now->copy()->subMonth()))
+            ->whereBetween('created_at', $this->previousMonthToDateRange($now))
             ->count();
 
         return [
@@ -98,19 +93,19 @@ final class StatCards extends Component
     private function buildOrdersCard(Carbon $now): array
     {
         $current = resolve(Order::class)::query()
-            ->where('payment_status', PaymentStatus::Paid)
-            ->whereBetween('created_at', $this->monthRange($now))
+            ->whereNotIn('status', [OrderStatus::Cancelled, OrderStatus::Archived])
+            ->whereBetween('created_at', $this->monthToDateRange($now))
             ->count();
 
         $previous = resolve(Order::class)::query()
-            ->where('payment_status', PaymentStatus::Paid)
-            ->whereBetween('created_at', $this->monthRange($now->copy()->subMonth()))
+            ->whereNotIn('status', [OrderStatus::Cancelled, OrderStatus::Archived])
+            ->whereBetween('created_at', $this->previousMonthToDateRange($now))
             ->count();
 
         return [
             'label' => __('shopper::pages/dashboard.stats.orders'),
             'value' => resolve(Order::class)::query()
-                ->where('payment_status', PaymentStatus::Paid)
+                ->whereNotIn('status', [OrderStatus::Cancelled, OrderStatus::Archived])
                 ->count(),
             ...$this->calculateChange($current, $previous),
             'icon' => 'phosphor-shopping-bag-open-duotone',
@@ -127,12 +122,12 @@ final class StatCards extends Component
 
         $current = $userModel::query()
             ->scopes('customers')
-            ->whereBetween('created_at', $this->monthRange($now))
+            ->whereBetween('created_at', $this->monthToDateRange($now))
             ->count();
 
         $previous = $userModel::query()
             ->scopes('customers')
-            ->whereBetween('created_at', $this->monthRange($now->copy()->subMonth()))
+            ->whereBetween('created_at', $this->previousMonthToDateRange($now))
             ->count();
 
         return [
@@ -145,11 +140,31 @@ final class StatCards extends Component
     }
 
     /**
+     * @param  array{0: Carbon, 1: Carbon}  $period
+     */
+    private function netRevenue(string $currency, array $period): int
+    {
+        $collected = (int) resolve(Order::class)::query()
+            ->whereIn('payment_status', PaymentStatus::revenueBearing())
+            ->where('currency_code', $currency)
+            ->whereBetween('created_at', $period)
+            ->sum('price_amount');
+
+        $refunded = (int) OrderRefund::query()
+            ->whereIn('status', OrderRefundStatus::settled())
+            ->where('currency', $currency)
+            ->whereBetween('created_at', $period)
+            ->sum('amount');
+
+        return $collected - $refunded;
+    }
+
+    /**
      * @return array{change: float, trend: string}
      */
     private function calculateChange(int $current, int $previous): array
     {
-        if ($previous === 0) {
+        if ($previous <= 0) {
             return [
                 'change' => $current > 0 ? 100.0 : 0.0,
                 'trend' => $current > 0 ? 'up' : 'neutral',
@@ -167,8 +182,18 @@ final class StatCards extends Component
     /**
      * @return array{0: Carbon, 1: Carbon}
      */
-    private function monthRange(Carbon $month): array
+    private function monthToDateRange(Carbon $now): array
     {
-        return [$month->copy()->startOfMonth(), $month->copy()->endOfMonth()];
+        return [$now->copy()->startOfMonth(), $now->copy()];
+    }
+
+    /**
+     * @return array{0: Carbon, 1: Carbon}
+     */
+    private function previousMonthToDateRange(Carbon $now): array
+    {
+        $end = $now->copy()->subMonthNoOverflow();
+
+        return [$end->copy()->startOfMonth(), $end];
     }
 }

--- a/packages/admin/src/Livewire/Components/Dashboard/TopSellingProducts.php
+++ b/packages/admin/src/Livewire/Components/Dashboard/TopSellingProducts.php
@@ -53,7 +53,7 @@ final class TopSellingProducts extends Component
                 $join->on('pv.id', '=', 'oi.product_id')
                     ->where('oi.product_type', '=', $variantClass);
             })
-            ->where('o.payment_status', PaymentStatus::Paid->value)
+            ->whereIn('o.payment_status', array_map(fn (PaymentStatus $status): string => $status->value, PaymentStatus::revenueBearing()))
             ->where('o.created_at', '>=', now()->subDays(90))
             ->selectRaw('COALESCE(pv.product_id, oi.product_id) as parent_product_id, SUM(oi.quantity) as total_sales')
             ->groupBy('parent_product_id')

--- a/packages/api/src/Http/Resources/OrderRefundResource.php
+++ b/packages/api/src/Http/Resources/OrderRefundResource.php
@@ -21,9 +21,9 @@ final class OrderRefundResource extends JsonApiResource
     {
         return [
             'status' => $this->status->value,
-            'amount' => $this->refund_amount,
+            'amount' => $this->amount,
             'currency' => $this->currency,
-            'reason' => $this->refund_reason,
+            'reason' => $this->reason,
             'created_at' => $this->created_at->toIso8601String(),
         ];
     }

--- a/packages/core/src/Enum/OrderRefundStatus.php
+++ b/packages/core/src/Enum/OrderRefundStatus.php
@@ -36,6 +36,14 @@ enum OrderRefundStatus: string implements HasLabel
 
     case Cancelled = 'cancelled';
 
+    /**
+     * @return array<int, self>
+     */
+    public static function settled(): array
+    {
+        return [self::Partial_Refund, self::Refunded];
+    }
+
     public function getLabel(): string
     {
         return match ($this) {

--- a/packages/core/src/Enum/PaymentStatus.php
+++ b/packages/core/src/Enum/PaymentStatus.php
@@ -36,6 +36,14 @@ enum PaymentStatus: string implements HasColor, HasIcon, HasLabel
     case Voided = 'voided';
 
     /**
+     * @return array<int, self>
+     */
+    public static function revenueBearing(): array
+    {
+        return [self::Paid, self::PartiallyRefunded, self::Refunded];
+    }
+
+    /**
      * @return array<string, array<int, self>>
      */
     public static function transitions(): array

--- a/packages/core/src/Models/OrderRefund.php
+++ b/packages/core/src/Models/OrderRefund.php
@@ -16,8 +16,8 @@ use Shopper\Core\Models\Traits\HasPublicId;
 /**
  * @property-read int $id
  * @property-read ?string $public_id
- * @property-read ?string $refund_reason
- * @property-read ?int $refund_amount
+ * @property-read ?string $reason
+ * @property-read int $amount
  * @property-read OrderRefundStatus $status
  * @property-read ?string $notes
  * @property-read string $currency

--- a/tests/Admin/Livewire/Components/Dashboard/RevenueChartTest.php
+++ b/tests/Admin/Livewire/Components/Dashboard/RevenueChartTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+use Carbon\Carbon;
+use Livewire\Livewire;
+use Shopper\Core\Enum\OrderRefundStatus;
+use Shopper\Core\Enum\OrderStatus;
+use Shopper\Core\Enum\PaymentStatus;
+use Shopper\Core\Enum\ShippingStatus;
+use Shopper\Core\Models\Order;
+use Shopper\Core\Models\OrderRefund;
+use Shopper\Livewire\Components\Dashboard\RevenueChart;
+use Tests\Core\Stubs\User;
+
+uses(Tests\Admin\TestCase::class);
+
+beforeEach(function (): void {
+    Carbon::setTestNow('2026-07-15 12:00:00');
+
+    $this->actingAs(User::factory()->create(), config('shopper.auth.guard'));
+});
+
+afterEach(fn () => Carbon::setTestNow());
+
+describe(RevenueChart::class, function (): void {
+    it('nets settled refunds against the month the refund was issued', function (): void {
+        $currency = shopper_currency();
+
+        $order = Order::factory()->create([
+            'status' => OrderStatus::Completed,
+            'payment_status' => PaymentStatus::PartiallyRefunded,
+            'shipping_status' => ShippingStatus::Delivered,
+            'currency_code' => $currency,
+            'price_amount' => 10000,
+            'created_at' => Carbon::parse('2026-05-10'),
+        ]);
+
+        OrderRefund::factory()->create([
+            'order_id' => $order->id,
+            'amount' => 3000,
+            'currency' => $currency,
+            'status' => OrderRefundStatus::Refunded,
+            'created_at' => Carbon::parse('2026-07-05'),
+        ]);
+
+        $options = Livewire::test(RevenueChart::class)->get('options');
+
+        $data = $options['series'][0]['data'];
+
+        expect($data)->toHaveCount(12)
+            ->and($data[9])->toBe(100.0)
+            ->and($data[11])->toBe(-30.0);
+    });
+})->group('dashboard', 'revenue-chart');

--- a/tests/Admin/Livewire/Components/Dashboard/StatCardsTest.php
+++ b/tests/Admin/Livewire/Components/Dashboard/StatCardsTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+use Carbon\Carbon;
+use Livewire\Livewire;
+use Shopper\Core\Enum\OrderRefundStatus;
+use Shopper\Core\Enum\OrderStatus;
+use Shopper\Core\Enum\PaymentStatus;
+use Shopper\Core\Enum\ShippingStatus;
+use Shopper\Core\Models\Order;
+use Shopper\Core\Models\OrderRefund;
+use Shopper\Livewire\Components\Dashboard\StatCards;
+use Tests\Core\Stubs\User;
+
+uses(Tests\Admin\TestCase::class);
+
+beforeEach(function (): void {
+    Carbon::setTestNow('2026-07-15 12:00:00');
+
+    $this->actingAs(User::factory()->create(), config('shopper.auth.guard'));
+});
+
+afterEach(fn () => Carbon::setTestNow());
+
+function createDashboardOrder(array $attributes = []): Order
+{
+    return Order::factory()->create([
+        'status' => OrderStatus::Completed,
+        'payment_status' => PaymentStatus::Paid,
+        'shipping_status' => ShippingStatus::Delivered,
+        'currency_code' => shopper_currency(),
+        'created_at' => Carbon::now(),
+        'updated_at' => Carbon::now(),
+        ...$attributes,
+    ]);
+}
+
+describe(StatCards::class, function (): void {
+    it('keeps refunded orders in revenue and deducts settled refund amounts', function (): void {
+        $currency = shopper_currency();
+
+        createDashboardOrder(['price_amount' => 10000]);
+
+        $partiallyRefunded = createDashboardOrder([
+            'price_amount' => 5000,
+            'payment_status' => PaymentStatus::PartiallyRefunded,
+        ]);
+
+        OrderRefund::factory()->create([
+            'order_id' => $partiallyRefunded->id,
+            'amount' => 2000,
+            'currency' => $currency,
+            'status' => OrderRefundStatus::Partial_Refund,
+        ]);
+
+        $awaitingRefund = createDashboardOrder(['price_amount' => 3000]);
+
+        OrderRefund::factory()->create([
+            'order_id' => $awaitingRefund->id,
+            'amount' => 999,
+            'currency' => $currency,
+            'status' => OrderRefundStatus::Awaiting,
+        ]);
+
+        createDashboardOrder([
+            'price_amount' => 7000,
+            'payment_status' => PaymentStatus::Voided,
+        ]);
+
+        $cards = Livewire::test(StatCards::class)->instance()->cards;
+
+        expect($cards[0]['value'])->toBe(shopper_money_format(10000 + 5000 - 2000 + 3000, $currency));
+    });
+
+    it('compares month to date against the same elapsed window of the previous month', function (): void {
+        createDashboardOrder([
+            'price_amount' => 10000,
+            'created_at' => Carbon::parse('2026-07-10'),
+        ]);
+
+        createDashboardOrder([
+            'price_amount' => 5000,
+            'created_at' => Carbon::parse('2026-06-10'),
+        ]);
+
+        createDashboardOrder([
+            'price_amount' => 99999,
+            'created_at' => Carbon::parse('2026-06-20'),
+        ]);
+
+        $cards = Livewire::test(StatCards::class)->instance()->cards;
+
+        expect($cards[0]['change'])->toBe(100.0)
+            ->and($cards[0]['trend'])->toBe('up');
+    });
+
+    it('counts orders of any payment status except cancelled and archived ones', function (): void {
+        createDashboardOrder(['price_amount' => 1000, 'status' => OrderStatus::New, 'payment_status' => PaymentStatus::Pending]);
+        createDashboardOrder(['price_amount' => 1000, 'status' => OrderStatus::Processing]);
+        createDashboardOrder(['price_amount' => 1000, 'status' => OrderStatus::Cancelled]);
+        createDashboardOrder(['price_amount' => 1000, 'status' => OrderStatus::Archived]);
+
+        $cards = Livewire::test(StatCards::class)->instance()->cards;
+
+        expect($cards[2]['value'])->toBe(2);
+    });
+})->group('dashboard', 'stat-cards');

--- a/tests/Admin/TestCase.php
+++ b/tests/Admin/TestCase.php
@@ -17,9 +17,11 @@ use Filament\Schemas\SchemasServiceProvider;
 use Filament\Support\Livewire\Partials\DataStoreOverride;
 use Filament\Support\SupportServiceProvider;
 use Filament\Tables\TablesServiceProvider;
+use Filament\Widgets\WidgetsServiceProvider;
 use JaOcero\RadioDeck\RadioDeckServiceProvider;
 use Laravel\Passkeys\PasskeysServiceProvider;
 use Laravelcm\LivewireSlideOvers\LivewireSlideOverServiceProvider;
+use Leandrocfe\FilamentApexCharts\FilamentApexChartsServiceProvider;
 use Livewire\LivewireServiceProvider;
 use Livewire\Mechanisms\DataStore;
 use Mckenziearts\BladeUntitledUIIcons\BladeUntitledUIIconsServiceProvider;
@@ -87,9 +89,11 @@ abstract class TestCase extends \Tests\TestCase
             SupportServiceProvider::class,
             NotificationsServiceProvider::class,
             TablesServiceProvider::class,
+            WidgetsServiceProvider::class,
             MediaLibraryServiceProvider::class,
             TailwindMergeServiceProvider::class,
             RadioDeckServiceProvider::class,
+            FilamentApexChartsServiceProvider::class,
             FilamentSelectTreeServiceProvider::class,
             LivewireSlideOverServiceProvider::class,
         ];


### PR DESCRIPTION
## Problem

The dashboard widgets encode several definitional bugs that make the numbers impossible to reconcile with what merchants actually collected:

- Revenue gates strictly on `payment_status = paid`. A partially refunded or refunded order vanishes entirely from revenue instead of having only the refunded portion deducted.
- Settled refunds are never subtracted anywhere, so net revenue is overstated.
- Month-over-month deltas compare the in-progress month against the full previous month, which shows misleading negative trends early in the month.
- The stat cards cache key is scoped by locale but not by currency, so changing the default currency can serve figures in the previous currency for up to 30 minutes.

While auditing the models involved, two more issues surfaced: the `OrderRefund` docblock referenced `refund_reason` and `refund_amount` while the real columns are `reason` and `amount`, and `OrderRefundResource` read those phantom properties, so the API always serialized `amount` and `reason` as `null`.

## Changes

- Add `PaymentStatus::revenueBearing()` (`paid`, `partially_refunded`, `refunded`) and `OrderRefundStatus::settled()` (`partial_refund`, `refunded`) as reusable domain seams
- `StatCards`: revenue is now revenue-bearing orders minus settled refunds, compared month-to-date against the same elapsed window of the previous month (`subMonthNoOverflow`); the orders card counts every order except cancelled and archived ones; the cache key is scoped by currency
- `RevenueChart`: same payment gate, with settled refunds netted against the month the refund was issued
- `TopSellingProducts`: same revenue-bearing gate
- `OrderRefund`: docblock now matches the real table columns
- `OrderRefundResource`: serializes `amount` and `reason` from the real columns
- Tests cover refund netting, the month-to-date comparison window, order counting and refund bucketing by refund month; `RevenueChart` is now bootable in tests through the apex charts and widgets providers