### PR TITLE
fix(admin): guard fulfillment shipping address inside the card title slot

### DIFF
--- a/packages/admin/resources/views/livewire/components/orders/fulfillment.blade.php
+++ b/packages/admin/resources/views/livewire/components/orders/fulfillment.blade.php
@@ -1,7 +1,7 @@
 <div>
     <x-shopper::card>
-        @if ($shippingAddress)
-            <x-slot:title>
+        <x-slot:title>
+            @if ($shippingAddress)
                 <div>
                     <p class="flex items-center gap-2 text-sm text-sh-fg-secondary">
                         <span>{{ __('shopper::pages/orders.expedition_to') }}</span>
@@ -24,8 +24,8 @@
                         @endif
                     </p>
                 </div>
-            </x-slot:title>
-        @endif
+            @endif
+        </x-slot:title>
 
             <div class="grid grid-cols-4 gap-3">
                 @foreach ($steps as $index => $step)


### PR DESCRIPTION
## Problem

Opening an order without a shipping address throws:

```
ErrorException: Attempt to read property "full_name" on null
packages/admin/resources/views/livewire/components/orders/fulfillment.blade.php:9
```

The view wrapped the card `<x-slot:title>` in `@if ($shippingAddress)`. Blaze's component compiler collects `<x-slot:*>` nodes as direct children of the component tag and hoists them out of any surrounding Blade directive, which it only sees as loose text. In the compiled output the guard ends up empty and the slot content, including `$shippingAddress->full_name`, executes unconditionally:

```php
<?php if($shippingAddress): ?>
<?php endif; ?>
...
$__slots[...]['title'] = new ComponentSlot(...); // always registered
```

This happens on the runtime compilation path, so marking the slot as unsafe for folding would not help: folding was already refused since the slot name matches a declared prop.

## Changes

Move the condition inside the slot instead of wrapping the slot in the condition. The slot is always declared, but its content only renders when a shipping address exists. When it is empty, the card header is skipped thanks to the `mb_trim((string) $title)` check introduced in #622, so nothing renders where the header used to be.

Verified on the compiled output: the `if ($shippingAddress)` guard now lives inside the slot buffer and `full_name` is only evaluated behind it. This was the only occurrence of a conditional wrapped around a slot in the admin views.