### PR TITLE
feat(core): sales channel drivers

### DIFF
--- a/packages/admin/config/components/setting.php
+++ b/packages/admin/config/components/setting.php
@@ -21,6 +21,7 @@ return [
         'location-create' => Pages\Settings\Locations\Create::class,
         'location-edit' => Pages\Settings\Locations\Edit::class,
         'legal' => Pages\Settings\LegalPage::class,
+        'channels' => Pages\Settings\Channels::class,
         'payment-methods' => Pages\Settings\PaymentMethods::class,
         'carriers' => Pages\Settings\Carriers::class,
         'team-index' => Pages\Settings\Team\Index::class,

--- a/packages/admin/config/settings.php
+++ b/packages/admin/config/settings.php
@@ -24,6 +24,7 @@ return [
         Items\AppearanceSetting::class => true,
         Items\StaffSetting::class => true,
         Items\LocationSetting::class => true,
+        Items\ChannelSetting::class => true,
         Items\PaymentSetting::class => true,
         Items\CarrierSetting::class => true,
         Items\LegalSetting::class => true,

--- a/packages/admin/resources/lang/en/pages/settings/channels.php
+++ b/packages/admin/resources/lang/en/pages/settings/channels.php
@@ -6,5 +6,6 @@ return [
 
     'title' => 'Sales channels',
     'single' => 'Sales channel',
+    'no_channel' => 'No sales channel found',
 
 ];

--- a/packages/admin/resources/lang/en/pages/settings/webhooks.php
+++ b/packages/admin/resources/lang/en/pages/settings/webhooks.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 return [
     'title' => 'Webhooks',
     'add_webhook' => 'Add webhook',
+    'empty' => 'No webhook subscriptions',
     'no_webhook' => 'No webhook subscription yet. Add one to notify an external system when events happen in your store.',
     'events' => 'Events',
     'deliveries' => 'Deliveries',

--- a/packages/admin/resources/lang/es/pages/settings/channels.php
+++ b/packages/admin/resources/lang/es/pages/settings/channels.php
@@ -6,5 +6,6 @@ return [
 
     'title' => 'Canales de venta',
     'single' => 'Canal de venta',
+    'no_channel' => 'No se encontró ningún canal de venta',
 
 ];

--- a/packages/admin/resources/lang/es/pages/settings/webhooks.php
+++ b/packages/admin/resources/lang/es/pages/settings/webhooks.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 return [
     'title' => 'Webhooks',
     'add_webhook' => 'Añadir webhook',
+    'empty' => 'Sin suscripciones de webhook',
     'no_webhook' => 'Aún no hay suscripciones de webhook. Añade una para notificar a un sistema externo cuando ocurran eventos en tu tienda.',
     'events' => 'Eventos',
     'deliveries' => 'Entregas',

--- a/packages/admin/resources/lang/fr/pages/settings/channels.php
+++ b/packages/admin/resources/lang/fr/pages/settings/channels.php
@@ -6,5 +6,6 @@ return [
 
     'title' => 'Canaux de ventes',
     'single' => 'Canal de vente',
+    'no_channel' => 'Aucun canal de vente trouvé',
 
 ];

--- a/packages/admin/resources/lang/fr/pages/settings/webhooks.php
+++ b/packages/admin/resources/lang/fr/pages/settings/webhooks.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 return [
     'title' => 'Webhooks',
     'add_webhook' => 'Ajouter un webhook',
+    'empty' => 'Aucun abonnement webhook',
     'no_webhook' => 'Aucun abonnement webhook pour le moment. Ajoutez-en un pour notifier un système externe lorsque des événements se produisent dans votre boutique.',
     'events' => 'Événements',
     'deliveries' => 'Livraisons',

--- a/packages/admin/resources/lang/tr/pages/settings/channels.php
+++ b/packages/admin/resources/lang/tr/pages/settings/channels.php
@@ -6,5 +6,6 @@ return [
 
     'title' => 'Satış kanalları',
     'single' => 'Satış kanalı',
+    'no_channel' => 'Satış kanalı bulunamadı',
 
 ];

--- a/packages/admin/resources/views/livewire/pages/settings/channels.blade.php
+++ b/packages/admin/resources/views/livewire/pages/settings/channels.blade.php
@@ -1,0 +1,9 @@
+<div>
+    <x-shopper::container class="space-y-8">
+        <x-shopper::heading :title="__('shopper::pages/settings/channels.title')" />
+
+        {{ $this->table }}
+    </x-shopper::container>
+
+    <x-filament-actions::modals />
+</div>

--- a/packages/admin/resources/views/livewire/tables/empty-states/webhooks.blade.php
+++ b/packages/admin/resources/views/livewire/tables/empty-states/webhooks.blade.php
@@ -1,0 +1,26 @@
+<x-shopper::empty-state
+    :title="__('shopper::pages/settings/webhooks.empty')"
+    :content="__('shopper::pages/settings/webhooks.no_webhook')"
+>
+    <svg class="h-44 w-auto sm:h-52" viewBox="0 0 360 300" fill="none" aria-hidden="true">
+        <ellipse class="fill-primary-500 opacity-[0.08] dark:opacity-[0.16]" cx="180" cy="160" rx="150" ry="120" />
+        <ellipse class="fill-primary-600 opacity-10" cx="172" cy="244" rx="94" ry="14" />
+
+        <rect class="fill-primary-500" x="96" y="128" width="104" height="88" rx="10" />
+        <rect class="fill-primary-600" x="96" y="128" width="104" height="26" rx="10" />
+        <g class="fill-sh-surface opacity-70">
+            <circle cx="112" cy="141" r="4" />
+            <circle cx="126" cy="141" r="4" />
+        </g>
+        <g class="stroke-sh-surface opacity-60" stroke-width="4" stroke-linecap="round">
+            <path d="M112 174h56M112 192h40" />
+        </g>
+
+        <path class="stroke-primary-600" d="M212 172c34 0 34-42 62-46" stroke-width="6" stroke-linecap="round" stroke-dasharray="2 12" />
+        <circle class="fill-amber-400" cx="282" cy="122" r="10" />
+        <path class="stroke-primary-300" d="M296 100a34 34 0 0 1 10 22M268 100a34 34 0 0 0-10 22" stroke-width="6" stroke-linecap="round" />
+
+        <path class="fill-primary-300" d="M78 92l5 11 11 5-11 5-5 11-5-11-11-5 11-5z" />
+        <path class="fill-amber-400" d="M236 226l3.4 7.4 7.4 3.4-7.4 3.4-3.4 7.4-3.4-7.4-7.4-3.4 7.4-3.4z" />
+    </svg>
+</x-shopper::empty-state>

--- a/packages/admin/routes/admin/setting.php
+++ b/packages/admin/routes/admin/setting.php
@@ -15,6 +15,7 @@ Route::prefix('locations')->group(function (): void {
 
 Route::livewire('/legal', config('shopper.components.setting.pages.legal'))->name('legal');
 Route::livewire('/analytics', config('shopper.components.setting.pages.analytics'))->name('analytics');
+Route::livewire('/channels', config('shopper.components.setting.pages.channels'))->name('channels');
 Route::livewire('/payment-methods', config('shopper.components.setting.pages.payment-methods'))->name('payment-methods');
 Route::livewire('/carriers', config('shopper.components.setting.pages.carriers'))->name('carriers');
 Route::livewire('/zones', config('shopper.components.setting.pages.zones'))->name('zones');

--- a/packages/admin/src/Livewire/Pages/Settings/Channels.php
+++ b/packages/admin/src/Livewire/Pages/Settings/Channels.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Livewire\Pages\Settings;
+
+use Filament\Actions\Concerns\InteractsWithActions;
+use Filament\Actions\Contracts\HasActions;
+use Filament\Schemas\Concerns\InteractsWithSchemas;
+use Filament\Schemas\Contracts\HasSchemas;
+use Filament\Tables\Columns\IconColumn;
+use Filament\Tables\Columns\ImageColumn;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Columns\ToggleColumn;
+use Filament\Tables\Concerns\InteractsWithTable;
+use Filament\Tables\Contracts\HasTable;
+use Filament\Tables\Table;
+use Illuminate\Contracts\View\View;
+use Livewire\Attributes\Layout;
+use Livewire\Component;
+use Shopper\Core\Channel\Facades\Channels as ChannelDrivers;
+use Shopper\Core\Models\Channel;
+use Shopper\Core\Models\Contracts\Channel as ChannelContract;
+use Shopper\Livewire\Concerns\WithSettingsBreadcrumbs;
+use Shopper\Sidebar\Breadcrumbs\Breadcrumb;
+use Shopper\Traits\HandlesAuthorizationExceptions;
+
+#[Layout('shopper::components.layouts.setting')]
+class Channels extends Component implements HasActions, HasSchemas, HasTable
+{
+    use HandlesAuthorizationExceptions;
+    use InteractsWithActions;
+    use InteractsWithSchemas;
+    use InteractsWithTable;
+    use WithSettingsBreadcrumbs;
+
+    public function settingsPageBreadcrumbs(): array
+    {
+        return [
+            new Breadcrumb(text: __('shopper::pages/settings/channels.title')),
+        ];
+    }
+
+    public function mount(): void
+    {
+        $this->authorize('system.settings');
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->query(
+                resolve(ChannelContract::class)::query()
+                    ->orderByDesc('is_default')
+                    ->orderBy('name')
+            )
+            ->columns([
+                ImageColumn::make('logo')
+                    ->label(__('shopper::forms.label.logo'))
+                    ->circular()
+                    ->getStateUsing(fn (Channel $record): ?string => $this->channelLogo($record))
+                    ->defaultImageUrl(shopper_fallback_url()),
+                TextColumn::make('name')
+                    ->label(__('shopper::forms.label.name'))
+                    ->description(fn (Channel $record): ?string => $record->url)
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('driver')
+                    ->label(__('shopper::forms.label.driver'))
+                    ->badge()
+                    ->default('web')
+                    ->formatStateUsing(fn (string $state): string => $this->driverLabel($state))
+                    ->color(fn (string $state): string => match (true) {
+                        $state === 'web' => 'gray',
+                        ChannelDrivers::isConfigured($state) => 'success',
+                        default => 'warning',
+                    }),
+                IconColumn::make('is_default')
+                    ->label(__('shopper::words.default'))
+                    ->boolean(),
+                ToggleColumn::make('is_enabled')
+                    ->label(__('shopper::forms.label.status'))
+                    ->disabled(fn (Channel $record): bool => $record->is_default)
+                    ->beforeStateUpdated(fn (): mixed => $this->authorize('system.settings')),
+                TextColumn::make('updated_at')
+                    ->label(__('shopper::forms.label.updated_at'))
+                    ->date(),
+            ])
+            ->emptyStateIcon('untitledui-shop')
+            ->emptyStateDescription(__('shopper::pages/settings/channels.no_channel'));
+    }
+
+    public function render(): View
+    {
+        return view('shopper::livewire.pages.settings.channels')
+            ->title(__('shopper::pages/settings/channels.title'));
+    }
+
+    protected function channelLogo(Channel $record): ?string
+    {
+        return in_array($record->driver ?? 'web', ChannelDrivers::availableDrivers(), true)
+            ? ChannelDrivers::driver($record->driver)->logo()
+            : null;
+    }
+
+    protected function driverLabel(string $driver): string
+    {
+        return in_array($driver, ChannelDrivers::availableDrivers(), true)
+            ? ChannelDrivers::driver($driver)->name()
+            : $driver;
+    }
+}

--- a/packages/admin/src/Livewire/Pages/Settings/Webhooks.php
+++ b/packages/admin/src/Livewire/Pages/Settings/Webhooks.php
@@ -169,8 +169,7 @@ class Webhooks extends Component implements HasActions, HasSchemas, HasTable
                     ->authorize('system.settings')
                     ->iconButton(),
             ])
-            ->emptyStateIcon(Untitledui::Share07)
-            ->emptyStateDescription(__('shopper::pages/settings/webhooks.no_webhook'));
+            ->emptyState(view('shopper::livewire.tables.empty-states.webhooks'));
     }
 
     public function render(): View

--- a/packages/admin/src/Navigation/Setting/Items/ChannelSetting.php
+++ b/packages/admin/src/Navigation/Setting/Items/ChannelSetting.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Navigation\Setting\Items;
+
+use Shopper\Enum\SettingGroup;
+use Shopper\Navigation\Setting\Setting;
+
+final class ChannelSetting extends Setting
+{
+    public function name(): string
+    {
+        return __('shopper::pages/settings/menu.sales');
+    }
+
+    public function description(): string
+    {
+        return __('shopper::pages/settings/menu.sales_description');
+    }
+
+    public function icon(): string
+    {
+        return 'untitledui-shop';
+    }
+
+    public function url(): string
+    {
+        return route('shopper.settings.channels');
+    }
+
+    public function order(): int
+    {
+        return 3;
+    }
+
+    public function group(): string
+    {
+        return SettingGroup::Selling->value;
+    }
+}

--- a/packages/core/database/migrations/2026_07_07_000001_add_driver_column_to_channels_table.php
+++ b/packages/core/database/migrations/2026_07_07_000001_add_driver_column_to_channels_table.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Shopper\Core\Helpers\Migration;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table($this->getTableName('channels'), static function (Blueprint $table): void {
+            $table->string('driver')->nullable()->after('url');
+        });
+    }
+};

--- a/packages/core/src/Channel/ChannelManager.php
+++ b/packages/core/src/Channel/ChannelManager.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Core\Channel;
+
+use Closure;
+use Illuminate\Support\Collection;
+use InvalidArgumentException;
+use Shopper\Core\Channel\Contracts\ChannelDriver;
+use Shopper\Core\Channel\Drivers\WebDriver;
+use Throwable;
+
+final class ChannelManager
+{
+    /** @var array<string, ChannelDriver> */
+    private array $drivers = [];
+
+    /** @var array<string, Closure> */
+    private array $customCreators = [];
+
+    public function driver(?string $name = null): ChannelDriver
+    {
+        $name ??= 'web';
+
+        return $this->drivers[$name] ??= $this->resolve($name);
+    }
+
+    public function extend(string $name, Closure $callback): self
+    {
+        $this->customCreators[$name] = $callback;
+
+        return $this;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function availableDrivers(): array
+    {
+        $builtIn = ['web'];
+        $custom = array_keys($this->customCreators);
+
+        return array_unique([...$builtIn, ...$custom]);
+    }
+
+    /**
+     * @return Collection<string, ChannelDriver>
+     */
+    public function configuredDrivers(): Collection
+    {
+        return collect($this->availableDrivers())
+            ->filter(fn (string $name): bool => $this->isConfigured($name))
+            ->mapWithKeys(fn (string $name): array => [$name => $this->driver($name)]);
+    }
+
+    public function isConfigured(string $name): bool
+    {
+        try {
+            return $this->driver($name)->isConfigured();
+        } catch (Throwable) {
+            return false;
+        }
+    }
+
+    private function resolve(string $name): ChannelDriver
+    {
+        if (isset($this->customCreators[$name])) {
+            return call_user_func($this->customCreators[$name], $name);
+        }
+
+        return match ($name) {
+            'web' => new WebDriver,
+            default => throw new InvalidArgumentException("Channel driver [{$name}] is not supported."),
+        };
+    }
+}

--- a/packages/core/src/Channel/Contracts/ChannelDriver.php
+++ b/packages/core/src/Channel/Contracts/ChannelDriver.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Core\Channel\Contracts;
+
+interface ChannelDriver
+{
+    public function code(): string;
+
+    public function name(): string;
+
+    public function logo(): ?string;
+
+    public function isConfigured(): bool;
+}

--- a/packages/core/src/Channel/Drivers/WebDriver.php
+++ b/packages/core/src/Channel/Drivers/WebDriver.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Core\Channel\Drivers;
+
+use Shopper\Core\Channel\Contracts\ChannelDriver;
+
+final class WebDriver implements ChannelDriver
+{
+    public function code(): string
+    {
+        return 'web';
+    }
+
+    public function name(): string
+    {
+        return 'Web';
+    }
+
+    public function logo(): string
+    {
+        return shopper_svg_data_uri(<<<'SVG'
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+                <circle cx="32" cy="32" r="32" fill="#EFF6FF"/>
+                <rect x="16" y="24" width="28" height="20" rx="2" fill="#3B82F6"/>
+                <rect x="20" y="33" width="8" height="7" rx="1" fill="#93C5FD"/>
+                <rect x="32" y="33" width="7" height="11" fill="#2563EB"/>
+                <rect x="14" y="14" width="32" height="7" rx="1.5" fill="#3B82F6"/>
+                <path d="M13 20h34v3a4.25 4.25 0 0 1-8.5 0 4.25 4.25 0 0 1-8.5 0 4.25 4.25 0 0 1-8.5 0 4.25 4.25 0 0 1-8.5 0z" fill="#2563EB"/>
+                <circle cx="45" cy="44" r="8.5" fill="#FBBF24"/>
+                <ellipse cx="45" cy="44" rx="3.5" ry="8.5" fill="none" stroke="#fff" stroke-width="1.5"/>
+                <path d="M36.5 44h17" stroke="#fff" stroke-width="1.5"/>
+            </svg>
+            SVG);
+    }
+
+    public function isConfigured(): bool
+    {
+        return true;
+    }
+}

--- a/packages/core/src/Channel/Facades/Channels.php
+++ b/packages/core/src/Channel/Facades/Channels.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Core\Channel\Facades;
+
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Facade;
+use Shopper\Core\Channel\ChannelManager;
+use Shopper\Core\Channel\Contracts\ChannelDriver;
+
+/**
+ * @method static ChannelDriver driver(?string $name = null)
+ * @method static ChannelManager extend(string $name, \Closure $callback)
+ * @method static array<int, string> availableDrivers()
+ * @method static Collection<string, ChannelDriver> configuredDrivers()
+ * @method static bool isConfigured(string $name)
+ *
+ * @see ChannelManager
+ */
+final class Channels extends Facade
+{
+    protected static function getFacadeAccessor(): string
+    {
+        return ChannelManager::class;
+    }
+}

--- a/packages/core/src/CoreServiceProvider.php
+++ b/packages/core/src/CoreServiceProvider.php
@@ -7,6 +7,7 @@ namespace Shopper\Core;
 use Carbon\Carbon;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Database\Eloquent\Relations\Relation;
+use Shopper\Core\Channel\ChannelManager;
 use Shopper\Core\Console\ReclaimPendingOrdersCommand;
 use Shopper\Core\Console\ReconcileStockLevelsCommand;
 use Shopper\Core\Console\RedispatchWebhooksCommand;
@@ -98,6 +99,7 @@ final class CoreServiceProvider extends PackageServiceProvider
         $this->registerStockAllocator();
         $this->registerTaxCalculator();
         $this->registerPriceResolver();
+        $this->registerChannelManager();
 
         $this->app->singleton(WebhookPayloadSerializer::class, DefaultWebhookPayloadSerializer::class);
     }
@@ -184,6 +186,11 @@ final class CoreServiceProvider extends PackageServiceProvider
     protected function registerPriceResolver(): void
     {
         $this->app->singleton(PriceResolver::class, CatalogPriceResolver::class);
+    }
+
+    protected function registerChannelManager(): void
+    {
+        $this->app->singleton(ChannelManager::class, fn (): ChannelManager => new ChannelManager);
     }
 
     protected function bootModelRelationName(): void

--- a/packages/core/src/Models/Channel.php
+++ b/packages/core/src/Models/Channel.php
@@ -25,6 +25,7 @@ use Shopper\Core\Traits\HasModelContract;
  * @property-read ?string $description
  * @property-read ?string $timezone
  * @property-read ?string $url
+ * @property-read ?string $driver
  * @property-read bool $is_default
  * @property-read bool $is_enabled
  * @property-read array<string, mixed>|null $metadata

--- a/packages/core/src/Observers/ChannelObserver.php
+++ b/packages/core/src/Observers/ChannelObserver.php
@@ -11,11 +11,20 @@ class ChannelObserver
     public function creating(Channel $channel): void
     {
         $this->ensureOnlyOneIsDefault($channel);
+        $this->ensureDefaultStaysEnabled($channel);
     }
 
     public function updating(Channel $channel): void
     {
         $this->ensureOnlyOneIsDefault($channel);
+        $this->ensureDefaultStaysEnabled($channel);
+    }
+
+    private function ensureDefaultStaysEnabled(Channel $channel): void
+    {
+        if ($channel->is_default) {
+            $channel->is_enabled = true;
+        }
     }
 
     private function ensureOnlyOneIsDefault(Channel $channel): void

--- a/packages/core/src/helpers.php
+++ b/packages/core/src/helpers.php
@@ -133,3 +133,10 @@ if (! function_exists('is_no_division_currency')) {
         return in_array($currency, zero_decimal_currencies());
     }
 }
+
+if (! function_exists('shopper_svg_data_uri')) {
+    function shopper_svg_data_uri(string $svg): string
+    {
+        return 'data:image/svg+xml;base64,'.base64_encode($svg);
+    }
+}

--- a/tests/Admin/Livewire/Pages/Settings/ChannelsTest.php
+++ b/tests/Admin/Livewire/Pages/Settings/ChannelsTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+use Filament\Tables\Columns\ToggleColumn;
+use Livewire\Livewire;
+use Shopper\Core\Channel\Contracts\ChannelDriver;
+use Shopper\Core\Channel\Facades\Channels;
+use Shopper\Core\Models\Channel;
+use Shopper\Livewire\Pages\Settings\Channels as ChannelsPage;
+use Tests\Core\Stubs\User;
+
+uses(Tests\Admin\TestCase::class);
+
+beforeEach(function (): void {
+    $this->user = User::factory()->create();
+    $this->user->givePermissionTo('system.settings');
+    $this->actingAs($this->user);
+});
+
+describe(ChannelsPage::class, function (): void {
+    it('can render the channels settings component', function (): void {
+        Livewire::test(ChannelsPage::class)
+            ->assertOk()
+            ->assertViewIs('shopper::livewire.pages.settings.channels');
+    });
+
+    it('lists channels in the table', function (): void {
+        Channel::factory()->count(3)->create();
+
+        Livewire::test(ChannelsPage::class)
+            ->loadTable()
+            ->assertCanSeeTableRecords(Channel::query()->limit(3)->get());
+    });
+
+    it('renders the web driver badge for a driverless channel', function (): void {
+        $default = Channel::query()->where('is_default', true)->first();
+
+        Livewire::test(ChannelsPage::class)
+            ->loadTable()
+            ->assertTableColumnStateSet('driver', 'web', $default);
+    });
+
+    it('shows the driver name for a channel bound to a registered driver', function (): void {
+        Channels::extend('custom', fn (): ChannelDriver => new class implements ChannelDriver
+        {
+            public function code(): string
+            {
+                return 'custom';
+            }
+
+            public function name(): string
+            {
+                return 'Custom Channel';
+            }
+
+            public function logo(): ?string
+            {
+                return null;
+            }
+
+            public function isConfigured(): bool
+            {
+                return true;
+            }
+        });
+
+        Channel::factory()->create(['driver' => 'custom', 'name' => 'Custom Store']);
+
+        Livewire::test(ChannelsPage::class)
+            ->loadTable()
+            ->assertSee('Custom Channel');
+    });
+
+    it('forbids mount for users without `system.settings`', function (): void {
+        $this->actingAs(User::factory()->create());
+
+        Livewire::test(ChannelsPage::class)->assertForbidden();
+    });
+
+    it('renders a channel bound to an unregistered driver without crashing', function (): void {
+        Channel::factory()->create(['driver' => 'shopify', 'name' => 'Ghost Store']);
+
+        Livewire::test(ChannelsPage::class)
+            ->loadTable()
+            ->assertOk()
+            ->assertSee('shopify');
+    });
+
+    it('disables the enabled toggle for the default channel but not for others', function (): void {
+        $default = Channel::query()->where('is_default', true)->first();
+        $other = Channel::factory()->create(['is_default' => false]);
+
+        Livewire::test(ChannelsPage::class)
+            ->loadTable()
+            ->assertTableColumnExists('is_enabled', fn (ToggleColumn $column): bool => $column->isDisabled(), $default)
+            ->assertTableColumnExists('is_enabled', fn (ToggleColumn $column): bool => ! $column->isDisabled(), $other);
+    });
+});

--- a/tests/Core/Channel/ChannelManagerTest.php
+++ b/tests/Core/Channel/ChannelManagerTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+use Shopper\Core\Channel\ChannelManager;
+use Shopper\Core\Channel\Contracts\ChannelDriver;
+use Shopper\Core\Channel\Facades\Channels;
+
+uses(Tests\Core\TestCase::class);
+
+function fakeChannelDriver(string $code, bool $configured = true): ChannelDriver
+{
+    return new class($code, $configured) implements ChannelDriver
+    {
+        public function __construct(private string $code, private bool $configured) {}
+
+        public function code(): string
+        {
+            return $this->code;
+        }
+
+        public function name(): string
+        {
+            return ucfirst($this->code);
+        }
+
+        public function logo(): ?string
+        {
+            return null;
+        }
+
+        public function isConfigured(): bool
+        {
+            return $this->configured;
+        }
+    };
+}
+
+describe(ChannelManager::class, function (): void {
+    it('resolves a registered driver', function (): void {
+        $manager = resolve(ChannelManager::class)
+            ->extend('custom', fn (): ChannelDriver => fakeChannelDriver('custom'));
+
+        expect($manager->driver('custom'))
+            ->toBeInstanceOf(ChannelDriver::class)
+            ->and($manager->driver('custom')->name())->toBe('Custom');
+    });
+
+    it('throws for an unknown driver', function (): void {
+        resolve(ChannelManager::class)->driver('missing');
+    })->throws(InvalidArgumentException::class);
+
+    it('lists available driver codes', function (): void {
+        $manager = resolve(ChannelManager::class)
+            ->extend('custom', fn (): ChannelDriver => fakeChannelDriver('custom'))
+            ->extend('other', fn (): ChannelDriver => fakeChannelDriver('other'));
+
+        expect($manager->availableDrivers())->toBe(['web', 'custom', 'other']);
+    });
+
+    it('resolves the built-in web driver by default', function (): void {
+        expect(resolve(ChannelManager::class)->driver()->code())->toBe('web');
+    });
+
+    it('keeps only configured drivers in the configured set', function (): void {
+        $manager = resolve(ChannelManager::class)
+            ->extend('custom', fn (): ChannelDriver => fakeChannelDriver('custom', configured: true))
+            ->extend('other', fn (): ChannelDriver => fakeChannelDriver('other', configured: false));
+
+        expect($manager->configuredDrivers()->keys()->all())->toBe(['web', 'custom'])
+            ->and($manager->isConfigured('custom'))->toBeTrue()
+            ->and($manager->isConfigured('other'))->toBeFalse();
+    });
+
+    it('reports an unknown driver as not configured', function (): void {
+        expect(resolve(ChannelManager::class)->isConfigured('missing'))->toBeFalse();
+    });
+
+    it('exposes the manager through the Channels facade', function (): void {
+        Channels::extend('custom', fn (): ChannelDriver => fakeChannelDriver('custom'));
+
+        expect(Channels::driver('custom')->code())->toBe('custom')
+            ->and(Channels::availableDrivers())->toBe(['web', 'custom']);
+    });
+
+    it('reports a driver whose configuration probe throws as not configured', function (): void {
+        $manager = resolve(ChannelManager::class)
+            ->extend('faulty', fn (): ChannelDriver => new class implements ChannelDriver
+            {
+                public function code(): string
+                {
+                    return 'faulty';
+                }
+
+                public function name(): string
+                {
+                    return 'Faulty';
+                }
+
+                public function logo(): ?string
+                {
+                    return null;
+                }
+
+                public function isConfigured(): bool
+                {
+                    throw new RuntimeException('boom');
+                }
+            });
+
+        expect($manager->isConfigured('faulty'))->toBeFalse();
+    });
+});

--- a/tests/Core/Observers/ChannelObserverTest.php
+++ b/tests/Core/Observers/ChannelObserverTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+use Shopper\Core\Models\Channel;
+
+uses(Tests\Core\TestCase::class);
+
+describe('ChannelObserver', function (): void {
+    it('keeps a default channel enabled on create', function (): void {
+        $channel = Channel::factory()->create([
+            'is_default' => true,
+            'is_enabled' => false,
+        ]);
+
+        expect($channel->is_enabled)->toBeTrue();
+    });
+
+    it('re-enables a default channel when it is disabled', function (): void {
+        $channel = Channel::factory()->create([
+            'is_default' => true,
+            'is_enabled' => true,
+        ]);
+
+        $channel->update(['is_enabled' => false]);
+
+        expect($channel->refresh()->is_enabled)->toBeTrue();
+    });
+
+    it('allows a non-default channel to be disabled', function (): void {
+        $channel = Channel::factory()->create([
+            'is_default' => false,
+            'is_enabled' => true,
+        ]);
+
+        $channel->update(['is_enabled' => false]);
+
+        expect($channel->refresh()->is_enabled)->toBeFalse();
+    });
+
+    it('unsets the previous default and force-enables the promoted channel', function (): void {
+        $previous = Channel::query()->where('is_default', true)->first();
+
+        $channel = Channel::factory()->create(['is_default' => false, 'is_enabled' => false]);
+        $channel->update(['is_default' => true]);
+
+        expect($previous->refresh()->is_default)->toBeFalse()
+            ->and($channel->refresh())
+            ->is_default->toBeTrue()
+            ->is_enabled->toBeTrue();
+    });
+});


### PR DESCRIPTION
## What

Adds the sales channel driver seam to the core, so connector addons (POS, social platforms, marketplaces) can plug into a `Channel` the same way payment providers plug into `PaymentManager` and carriers into `ShippingManager`.

### Core

* New nullable `driver` column on the `channels` table, mirroring `payment_methods.driver`. A channel without a driver is a native web channel.
* New `ChannelDriver` contract (`code`, `name`, `logo`, `isConfigured`) with a `ChannelManager` registry and a `Channels` facade. Addons register their connector with `Channels::extend('code', fn () => new MyDriver)`.
* Built-in `WebDriver` resolved by default, following the `ShippingManager` manual driver pattern. Its duotone logo ships inline through the new `shopper_svg_data_uri()` helper, so drivers can paste brand SVGs directly in their class without publishing assets. Filament `ImageColumn` renders data URIs natively.
* `ChannelManager::isConfigured()` catches any `Throwable` from third party drivers, so a faulty addon degrades to a "not configured" badge instead of breaking the settings page.
* `ChannelObserver` now keeps the default channel enabled: a store can never disable its default sales channel, from the UI or programmatically.

### Admin

* New "Sales channels" settings page under the Selling group: channel logo, name and URL, driver badge (native, configured, not configured), default indicator and enable toggle. The toggle is locked for the default channel.
* Channels bound to an uninstalled driver render gracefully with the raw driver code and a warning badge, keeping historical attribution intact.
* New duotone empty state for the webhooks table, replacing the default Filament icon.

## Why

Merchants sell on more surfaces than their storefront: point of sale, social shops, marketplaces. Each connector needs a first-class identity in the admin and an attribution axis on orders. `orders.channel_id` already exists; this PR adds the missing piece so a channel can declare which connector drives it, and gives merchants a single page to see every place they sell.

The POS addon is the first consumer: its install command now provisions the `pos` channel with its own driver, icon and app URL.
