### PR TITLE
Variant reordering, product page titles and breadcrumbs

### DIFF
--- a/packages/admin/resources/lang/en/pages/products.php
+++ b/packages/admin/resources/lang/en/pages/products.php
@@ -68,7 +68,6 @@ return [
         'add' => 'Add variant',
         'generate' => 'Generate variants',
         'generate_description' => 'Your products are generated according to the attributes you have selected',
-        'variant_title' => 'Variants ~ :name',
         'empty' => 'No variant found',
         'search_label' => 'Search variant',
         'search_placeholder' => 'Search product variant',

--- a/packages/admin/resources/lang/es/pages/products.php
+++ b/packages/admin/resources/lang/es/pages/products.php
@@ -68,7 +68,6 @@ return [
         'add' => 'Añadir variante',
         'generate' => 'Generar variantes',
         'generate_description' => 'Tus productos se generan de acuerdo a los atributos que has seleccionado',
-        'variant_title' => 'Variantes ~ :name',
         'empty' => 'No se encontró variante',
         'search_label' => 'Buscar variante',
         'search_placeholder' => 'Buscar variante de producto',

--- a/packages/admin/resources/lang/fr/pages/products.php
+++ b/packages/admin/resources/lang/fr/pages/products.php
@@ -68,7 +68,6 @@ return [
         'add' => 'Ajouter une variante',
         'generate' => 'Générer les variantes',
         'generate_description' => 'Vos produits sont générés en fonction des attributs que vous avez sélectionnés',
-        'variant_title' => 'Variantes ~ :name',
         'empty' => 'Aucune variante trouvée',
         'search_label' => 'Recherche de variantes',
         'search_placeholder' => 'Rechercher une variante du produit',

--- a/packages/admin/resources/lang/tr/pages/products.php
+++ b/packages/admin/resources/lang/tr/pages/products.php
@@ -68,7 +68,6 @@ return [
         'add' => 'Varyant ekle',
         'generate' => 'Varyant oluştur',
         'generate_description' => 'Ürünleriniz seçtiğiniz özelliklere göre oluşturulur',
-        'variant_title' => 'Varyantlar ~ :name',
         'empty' => 'Varyant bulunamadı',
         'search_label' => 'Varyant ara',
         'search_placeholder' => 'Ürün varyantı ara',

--- a/packages/admin/resources/views/components/layouts/product.blade.php
+++ b/packages/admin/resources/views/components/layouts/product.blade.php
@@ -6,12 +6,19 @@
     $product = request()->route('product');
     $groups = resolve(\Shopper\Navigation\Product\ProductSectionManager::class)->groupedForProduct($product);
 
+    resolve(\Shopper\Sidebar\Breadcrumbs\Breadcrumbs::class)->prepend(
+        new \Shopper\Sidebar\Breadcrumbs\Breadcrumb(
+            text: $product->name,
+            url: route('shopper.products.edit', $product),
+        )
+    );
+
     $editPath = trim(parse_url(route('shopper.products.edit', ['product' => $product]), PHP_URL_PATH) ?? '', '/');
     $currentRest = ltrim(\Illuminate\Support\Str::after(trim(request()->path(), '/'), $editPath), '/');
     $currentSegment = $currentRest === '' ? '' : \Illuminate\Support\Str::before($currentRest, '/');
 @endphp
 
-<x-shopper::layouts.app :title="$title">
+<x-shopper::layouts.app :$title>
     <div class="sticky top-0 z-10 bg-sh-surface border-b border-sh-border py-8">
         <x-shopper::container>
             <x-shopper::heading>

--- a/packages/admin/resources/views/filament/form/slug-input.blade.php
+++ b/packages/admin/resources/views/filament/form/slug-input.blade.php
@@ -2,7 +2,7 @@
     $statePath = $getStatePath();
     $fromStatePath = $getFromStatePath();
     $isDisabled = $isDisabled();
-    $shouldSync = $fromStatePath && blank($getRecord());
+    $shouldSync = $fromStatePath && ! $getRecord()?->exists;
     $prefixLabel = $getPrefixLabel();
 @endphp
 

--- a/packages/admin/src/Actions/Store/Product/CreateNewVariant.php
+++ b/packages/admin/src/Actions/Store/Product/CreateNewVariant.php
@@ -24,6 +24,10 @@ final class CreateNewVariant
         DB::beginTransaction();
 
         try {
+            $values['position'] = (int) resolve(ProductVariant::class)::query()
+                ->where('product_id', $values['product_id'])
+                ->max('position') + 1;
+
             $variant = resolve(ProductVariant::class)::query()->create($values);
 
             if ($pricing = data_get($data, 'prices')) {

--- a/packages/admin/src/Actions/Store/Product/SaveProductVariantsAction.php
+++ b/packages/admin/src/Actions/Store/Product/SaveProductVariantsAction.php
@@ -43,6 +43,8 @@ final class SaveProductVariantsAction
                 fn (ProductVariant $variant) => $variant->delete()
             );
 
+            $position = (int) $product->variants()->max('position');
+
             foreach ($variants as $key => $variantState) {
                 /** @var ProductVariant $variant */
                 $variant = $variantState['variant_id']
@@ -51,6 +53,7 @@ final class SaveProductVariantsAction
                         'name' => $variantState['name'],
                         'product_id' => $product->id,
                         'sku' => $variantState['sku'],
+                        'position' => ++$position,
                     ]);
 
                 $variants[$key]['variant_id'] = $variant->id;

--- a/packages/admin/src/Livewire/Pages/Account.php
+++ b/packages/admin/src/Livewire/Pages/Account.php
@@ -5,11 +5,21 @@ declare(strict_types=1);
 namespace Shopper\Livewire\Pages;
 
 use Illuminate\Contracts\View\View;
+use Shopper\Sidebar\Breadcrumbs\Breadcrumb;
+use Shopper\Sidebar\Traits\WithBreadcrumbs;
 use Shopper\Traits\HandlesAuthorizationExceptions;
 
 class Account extends AbstractPageComponent
 {
     use HandlesAuthorizationExceptions;
+    use WithBreadcrumbs;
+
+    public function getBreadcrumbs(): array
+    {
+        return [
+            new Breadcrumb(text: __('shopper::pages/auth.account.title')),
+        ];
+    }
 
     public function render(): View
     {

--- a/packages/admin/src/Livewire/Pages/Product/Attributes.php
+++ b/packages/admin/src/Livewire/Pages/Product/Attributes.php
@@ -135,6 +135,7 @@ class Attributes extends Component implements HasActions, HasSchemas, HasTable
 
     public function render(): View
     {
-        return view('shopper::livewire.components.products.forms.attributes');
+        return view('shopper::livewire.components.products.forms.attributes')
+            ->title($this->product->name.' ~ '.__('shopper::pages/attributes.menu'));
     }
 }

--- a/packages/admin/src/Livewire/Pages/Product/Files.php
+++ b/packages/admin/src/Livewire/Pages/Product/Files.php
@@ -72,6 +72,7 @@ class Files extends Component implements HasSchemas
 
     public function render(): View
     {
-        return view('shopper::livewire.components.products.forms.files');
+        return view('shopper::livewire.components.products.forms.files')
+            ->title($this->product->name.' ~ '.__('shopper::words.files'));
     }
 }

--- a/packages/admin/src/Livewire/Pages/Product/Inventory.php
+++ b/packages/admin/src/Livewire/Pages/Product/Inventory.php
@@ -210,6 +210,7 @@ class Inventory extends Component implements HasActions, HasSchemas, HasTable
     #[On('inventory.updated')]
     public function render(): View
     {
-        return view('shopper::livewire.components.products.forms.inventory');
+        return view('shopper::livewire.components.products.forms.inventory')
+            ->title($this->product->name.' ~ '.__('shopper::pages/products.stock_inventory_heading'));
     }
 }

--- a/packages/admin/src/Livewire/Pages/Product/Media.php
+++ b/packages/admin/src/Livewire/Pages/Product/Media.php
@@ -81,6 +81,7 @@ class Media extends Component implements HasSchemas
 
     public function render(): View
     {
-        return view('shopper::livewire.components.products.forms.media');
+        return view('shopper::livewire.components.products.forms.media')
+            ->title($this->product->name.' ~ '.__('shopper::words.media'));
     }
 }

--- a/packages/admin/src/Livewire/Pages/Product/Overview.php
+++ b/packages/admin/src/Livewire/Pages/Product/Overview.php
@@ -226,6 +226,7 @@ class Overview extends Component implements HasActions, HasSchemas
 
     public function render(): View
     {
-        return view('shopper::livewire.components.products.forms.edit');
+        return view('shopper::livewire.components.products.forms.edit')
+            ->title($this->product->name.' ~ '.__('shopper::words.overview'));
     }
 }

--- a/packages/admin/src/Livewire/Pages/Product/Pricing.php
+++ b/packages/admin/src/Livewire/Pages/Product/Pricing.php
@@ -21,6 +21,6 @@ class Pricing extends Component
     public function render(): View
     {
         return view('shopper::livewire.pages.products.pricing')
-            ->title(__('shopper::words.pricing'));
+            ->title($this->product->name.' ~ '.__('shopper::words.pricing'));
     }
 }

--- a/packages/admin/src/Livewire/Pages/Product/Related.php
+++ b/packages/admin/src/Livewire/Pages/Product/Related.php
@@ -98,6 +98,6 @@ class Related extends Component implements HasActions, HasSchemas
     {
         return view('shopper::livewire.components.products.forms.related', [
             'relatedProducts' => $this->product->relatedProducts,
-        ]);
+        ])->title($this->product->name.' ~ '.__('shopper::pages/products.related_products'));
     }
 }

--- a/packages/admin/src/Livewire/Pages/Product/Seo.php
+++ b/packages/admin/src/Livewire/Pages/Product/Seo.php
@@ -67,6 +67,7 @@ class Seo extends Component implements HasSchemas
 
     public function render(): View
     {
-        return view('shopper::livewire.components.products.forms.seo');
+        return view('shopper::livewire.components.products.forms.seo')
+            ->title($this->product->name.' ~ '.__('shopper::words.seo.slug'));
     }
 }

--- a/packages/admin/src/Livewire/Pages/Product/Shipping.php
+++ b/packages/admin/src/Livewire/Pages/Product/Shipping.php
@@ -73,6 +73,7 @@ class Shipping extends Component implements HasSchemas
 
     public function render(): View
     {
-        return view('shopper::livewire.components.products.forms.shipping');
+        return view('shopper::livewire.components.products.forms.shipping')
+            ->title($this->product->name.' ~ '.__('shopper::words.shipping'));
     }
 }

--- a/packages/admin/src/Livewire/Pages/Product/Variant.php
+++ b/packages/admin/src/Livewire/Pages/Product/Variant.php
@@ -15,7 +15,6 @@ use Filament\Schemas\Contracts\HasSchemas;
 use Filament\Support\Enums\Size;
 use Filament\Support\Enums\Width;
 use Illuminate\Contracts\View\View;
-use Illuminate\Support\Facades\Route;
 use Illuminate\Validation\Rules\Unique;
 use Livewire\Attributes\Layout;
 use Shopper\Core\Models\Contracts\Product;
@@ -39,22 +38,9 @@ class Variant extends AbstractPageComponent implements HasActions, HasSchemas
 
     public function getBreadcrumbs(): array
     {
-        $crumbs = [];
-
-        if ($this->product !== null) {
-            $crumbs[] = new Breadcrumb(
-                text: $this->product->name,
-                url: Route::has('shopper.products.edit')
-                    ? route('shopper.products.edit', $this->product)
-                    : null,
-            );
-        }
-
-        if ($this->variant !== null) {
-            $crumbs[] = new Breadcrumb(text: $this->variant->name);
-        }
-
-        return $crumbs;
+        return $this->variant !== null
+            ? [new Breadcrumb(text: $this->variant->name)]
+            : [];
     }
 
     public function mount(): void
@@ -137,6 +123,6 @@ class Variant extends AbstractPageComponent implements HasActions, HasSchemas
     public function render(): View
     {
         return view('shopper::livewire.pages.products.variant')
-            ->title(__('shopper::pages/products.variants.variant_title', ['name' => $this->variant->name]));
+            ->title($this->product->name.' ~ '.$this->variant->name);
     }
 }

--- a/packages/admin/src/Livewire/Pages/Product/Variants.php
+++ b/packages/admin/src/Livewire/Pages/Product/Variants.php
@@ -55,8 +55,10 @@ class Variants extends Component implements HasActions, HasSchemas, HasTable
             ->query(
                 resolve(ProductVariant::class)::query()
                     ->where('product_id', $this->product->id)
-                    ->latest()
             )
+            ->defaultSort('position')
+            ->reorderable('position')
+            ->authorizeReorder(shopper()->auth()->user()->can('products.variants.edit'))
             ->columns([
                 SpatieMediaLibraryImageColumn::make('thumbnail')
                     ->collection(config('shopper.media.storage.thumbnail_collection'))
@@ -152,6 +154,7 @@ class Variants extends Component implements HasActions, HasSchemas, HasTable
 
     public function render(): View
     {
-        return view('shopper::livewire.components.products.forms.variants');
+        return view('shopper::livewire.components.products.forms.variants')
+            ->title($this->product->name.' ~ '.__('shopper::words.variants'));
     }
 }

--- a/packages/core/src/Models/Product.php
+++ b/packages/core/src/Models/Product.php
@@ -179,7 +179,7 @@ class Product extends Model implements HasReviews, Priceable, ProductContract, S
      */
     public function variants(): HasMany
     {
-        return $this->hasMany(config('shopper.models.variant'), 'product_id');
+        return $this->hasMany(config('shopper.models.variant'), 'product_id')->orderBy('position');
     }
 
     /**

--- a/packages/sidebar/src/Breadcrumbs/Breadcrumbs.php
+++ b/packages/sidebar/src/Breadcrumbs/Breadcrumbs.php
@@ -24,6 +24,11 @@ class Breadcrumbs
         $this->pushed[] = $crumb;
     }
 
+    public function prepend(Breadcrumb $crumb): void
+    {
+        array_unshift($this->pushed, $crumb);
+    }
+
     /**
      * @return list<Breadcrumb>
      */

--- a/tests/Admin/Actions/Store/Product/CreateNewVariantTest.php
+++ b/tests/Admin/Actions/Store/Product/CreateNewVariantTest.php
@@ -41,4 +41,26 @@ describe(CreateNewVariant::class, function (): void {
             ->and($variant->stock)->toBe(10)
             ->and($variant->prices()->count())->toBe(1);
     });
+
+    it('assigns incremental positions per product', function (): void {
+        /** @var ProductContract $product */
+        $product = Product::factory()->create(['type' => ProductType::Variant]);
+
+        /** @var ProductVariantContract $first */
+        $first = app()->call(CreateNewVariant::class, ['data' => [
+            'product_id' => $product->id,
+            'name' => 'First Variant',
+            'sku' => 'VAR-POS-1',
+        ]]);
+
+        /** @var ProductVariantContract $second */
+        $second = app()->call(CreateNewVariant::class, ['data' => [
+            'product_id' => $product->id,
+            'name' => 'Second Variant',
+            'sku' => 'VAR-POS-2',
+        ]]);
+
+        expect($first->position)->toBe(1)
+            ->and($second->position)->toBe(2);
+    });
 })->group('actions', 'product');

--- a/tests/Admin/Livewire/Components/Products/Form/VariantsTest.php
+++ b/tests/Admin/Livewire/Components/Products/Form/VariantsTest.php
@@ -68,4 +68,28 @@ describe(Variants::class, function (): void {
 
         expect(ProductVariant::query()->find($variant->id))->toBeNull();
     });
+
+    it('blocks reordering variants for users without `products.variants.edit`', function (): void {
+        $a = ProductVariant::factory()->create(['product_id' => $this->product->id, 'position' => 1]);
+        $b = ProductVariant::factory()->create(['product_id' => $this->product->id, 'position' => 2]);
+
+        Livewire::test(Variants::class, ['product' => $this->product])
+            ->call('reorderTable', [$b->getKey(), $a->getKey()]);
+
+        expect($a->refresh()->position)->toBe(1)
+            ->and($b->refresh()->position)->toBe(2);
+    });
+
+    it('allows reordering variants for users with `products.variants.edit`', function (): void {
+        $this->user->givePermissionTo('products.variants.edit');
+
+        $a = ProductVariant::factory()->create(['product_id' => $this->product->id, 'position' => 1]);
+        $b = ProductVariant::factory()->create(['product_id' => $this->product->id, 'position' => 2]);
+
+        Livewire::test(Variants::class, ['product' => $this->product])
+            ->call('reorderTable', [$b->getKey(), $a->getKey()]);
+
+        expect($a->refresh()->position)->toBe(2)
+            ->and($b->refresh()->position)->toBe(1);
+    });
 })->group('livewire', 'components', 'products', 'security');

--- a/tests/Admin/Livewire/SlideOvers/GenerateVariantsTest.php
+++ b/tests/Admin/Livewire/SlideOvers/GenerateVariantsTest.php
@@ -99,4 +99,34 @@ describe(GenerateVariants::class, function (): void {
         $component->call('generate')
             ->assertNotified();
     });
+
+    it('assigns incremental positions to generated variants', function (): void {
+        $component = Livewire::test(GenerateVariants::class, ['product' => $this->product]);
+
+        $component->set('variants', [
+            [
+                'key' => 'test-key-1',
+                'variant_id' => null,
+                'name' => 'Variant 1',
+                'sku' => 'SKU-POS-1',
+                'price' => 1000,
+                'stock' => 10,
+                'values' => [],
+            ],
+            [
+                'key' => 'test-key-2',
+                'variant_id' => null,
+                'name' => 'Variant 2',
+                'sku' => 'SKU-POS-2',
+                'price' => 1000,
+                'stock' => 10,
+                'values' => [],
+            ],
+        ]);
+
+        $component->call('generate');
+
+        expect($this->product->variants()->pluck('position', 'sku')->all())
+            ->toBe(['SKU-POS-1' => 1, 'SKU-POS-2' => 2]);
+    });
 })->group('livewire', 'slideovers', 'products');

--- a/tests/Sidebar/Breadcrumbs/BreadcrumbsTest.php
+++ b/tests/Sidebar/Breadcrumbs/BreadcrumbsTest.php
@@ -86,6 +86,16 @@ it('preserves push order across multiple breadcrumbs', function (): void {
     expect($this->breadcrumbs->all())->toBe([$products, $brands, $nike]);
 })->group('Breadcrumbs');
 
+it('prepends a breadcrumb before previously pushed ones', function (): void {
+    $variant = new Breadcrumb(text: '45');
+    $product = new Breadcrumb(text: 'Nike Air Max 90', url: '/admin/products/1/edit');
+
+    $this->breadcrumbs->push($variant);
+    $this->breadcrumbs->prepend($product);
+
+    expect($this->breadcrumbs->all())->toBe([$product, $variant]);
+})->group('Breadcrumbs');
+
 it('empties the stack on reset', function (): void {
     $this->breadcrumbs->push(new Breadcrumb(text: 'Products'));
     $this->breadcrumbs->push(new Breadcrumb(text: 'Brands'));


### PR DESCRIPTION
## What

Fixes several admin UX gaps reported by a community tester on Discord.

### Variant reordering

The `position` column existed on product variants but nothing ever wrote it, every variant stayed at 1 and there was no way to reorder them.

- Drag-and-drop reordering on the variants table, same pattern as brands (`reorderable('position')` gated by `products.variants.edit`)
- `CreateNewVariant` and `SaveProductVariantsAction` now assign incremental positions per product, new variants append at the end
- `Product::variants()` is ordered by `position`, so `$product->variants->first()` is the merchant-defined default everywhere (admin, API, storefronts)

### Product page titles

Nine product shell pages had no page title, and the ones that did showed only the section name. All product pages now use `{product name} ~ {section}` with the same translation keys as the section navigation. The dead `variant_title` key was removed from the four locales.

### Breadcrumbs

The #535 navigation shell rework dropped the product breadcrumb: only the variant page kept it. Pushing it from each page component would not work for `#[Lazy]` pages since their mount is skipped on the initial request, so the product crumb is now prepended from the product layout itself, which renders on every initial request and covers current and future sections. Added `Breadcrumbs::prepend()` to the sidebar package to keep the product crumb before crumbs pushed during mount. The account page now pushes a My profile crumb.

### SlugInput

`blank($getRecord())` treated the empty model instance bound by create/edit slide-overs (Brand, Category) as an existing record, so the slug never synced while typing on create. Replaced with `! $getRecord()?->exists`.