### PR TITLE
Stop regenerating slugs on rename and add variant reordering

### DIFF
--- a/packages/admin/src/Actions/Store/Product/CreateNewVariant.php
+++ b/packages/admin/src/Actions/Store/Product/CreateNewVariant.php
@@ -24,6 +24,10 @@ final class CreateNewVariant
         DB::beginTransaction();
 
         try {
+            $values['position'] = (int) resolve(ProductVariant::class)::query()
+                ->where('product_id', $values['product_id'])
+                ->max('position') + 1;
+
             $variant = resolve(ProductVariant::class)::query()->create($values);
 
             if ($pricing = data_get($data, 'prices')) {

--- a/packages/admin/src/Actions/Store/Product/SaveProductVariantsAction.php
+++ b/packages/admin/src/Actions/Store/Product/SaveProductVariantsAction.php
@@ -43,6 +43,8 @@ final class SaveProductVariantsAction
                 fn (ProductVariant $variant) => $variant->delete()
             );
 
+            $position = (int) $product->variants()->max('position');
+
             foreach ($variants as $key => $variantState) {
                 /** @var ProductVariant $variant */
                 $variant = $variantState['variant_id']
@@ -51,6 +53,7 @@ final class SaveProductVariantsAction
                         'name' => $variantState['name'],
                         'product_id' => $product->id,
                         'sku' => $variantState['sku'],
+                        'position' => ++$position,
                     ]);
 
                 $variants[$key]['variant_id'] = $variant->id;

--- a/packages/admin/src/Livewire/Components/Products/Form/Edit.php
+++ b/packages/admin/src/Livewire/Components/Products/Form/Edit.php
@@ -71,13 +71,7 @@ class Edit extends Component implements HasActions, HasSchemas
                                 TextInput::make('name')
                                     ->label(__('shopper::forms.label.name'))
                                     ->required()
-                                    ->maxLength(255)
-                                    ->live(onBlur: true)
-                                    ->afterStateUpdated(function (?string $state, Set $set): void {
-                                        if ($state) {
-                                            $set('slug', Str::slug($state));
-                                        }
-                                    }),
+                                    ->maxLength(255),
                                 TextInput::make('slug')
                                     ->label(__('shopper::forms.label.slug'))
                                     ->disabled()

--- a/packages/admin/src/Livewire/Components/Products/Form/Variants.php
+++ b/packages/admin/src/Livewire/Components/Products/Form/Variants.php
@@ -53,8 +53,10 @@ class Variants extends Component implements HasActions, HasSchemas, HasTable
             ->query(
                 resolve(ProductVariant::class)::query()
                     ->where('product_id', $this->product->id)
-                    ->latest()
             )
+            ->defaultSort('position')
+            ->reorderable('position')
+            ->authorizeReorder(shopper()->auth()->user()->can('edit_product_variants'))
             ->columns([
                 SpatieMediaLibraryImageColumn::make('thumbnail')
                     ->collection(config('shopper.media.storage.thumbnail_collection'))

--- a/packages/admin/src/Livewire/Pages/Collection/Edit.php
+++ b/packages/admin/src/Livewire/Pages/Collection/Edit.php
@@ -17,14 +17,12 @@ use Filament\Notifications\Notification;
 use Filament\Schemas\Components\Grid;
 use Filament\Schemas\Components\Group;
 use Filament\Schemas\Components\Livewire;
-use Filament\Schemas\Components\Utilities\Set;
 use Filament\Schemas\Concerns\InteractsWithSchemas;
 use Filament\Schemas\Contracts\HasSchemas;
 use Filament\Schemas\Schema;
 use Illuminate\Contracts\View\View;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\HtmlString;
-use Illuminate\Support\Str;
 use Shopper\Components\Form\SeoField;
 use Shopper\Core\Models\Contracts\Collection;
 use Shopper\Livewire\Components\Collection\CollectionProducts;
@@ -65,13 +63,7 @@ class Edit extends AbstractPageComponent implements HasActions, HasSchemas
                                 TextInput::make('name')
                                     ->label(__('shopper::forms.label.name'))
                                     ->placeholder('Summers Collections, Christmas promotions...')
-                                    ->required()
-                                    ->live(onBlur: true)
-                                    ->afterStateUpdated(function (string $operation, ?string $state, Set $set): void {
-                                        if ($state) {
-                                            $set('slug', Str::slug($state));
-                                        }
-                                    }),
+                                    ->required(),
                                 TextInput::make('slug')
                                     ->label(__('shopper::forms.label.slug'))
                                     ->disabled()

--- a/packages/admin/src/Livewire/Pages/Settings/Carriers.php
+++ b/packages/admin/src/Livewire/Pages/Settings/Carriers.php
@@ -14,6 +14,7 @@ use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Notifications\Notification;
+use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Components\Utilities\Set;
 use Filament\Schemas\Concerns\InteractsWithSchemas;
 use Filament\Schemas\Contracts\HasSchemas;
@@ -25,6 +26,7 @@ use Filament\Tables\Concerns\InteractsWithTable;
 use Filament\Tables\Contracts\HasTable;
 use Filament\Tables\Table;
 use Illuminate\Contracts\View\View;
+use Illuminate\Database\Eloquent\Model;
 use Livewire\Attributes\Layout;
 use Livewire\Component;
 use Mckenziearts\Icons\Untitledui\Enums\Untitledui;
@@ -130,7 +132,13 @@ class Carriers extends Component implements HasActions, HasSchemas, HasTable
                 ->placeholder('UPS, FedEx, DHL...')
                 ->required()
                 ->live(onBlur: true)
-                ->afterStateUpdated(fn (Set $set, ?string $state): mixed => $set('slug', $state)),
+                ->afterStateUpdated(function (?Model $record, Set $set, ?string $state, Get $get): void {
+                    if ($record?->exists && filled($get('slug'))) {
+                        return;
+                    }
+
+                    $set('slug', $state);
+                }),
             Hidden::make('slug'),
             Select::make('driver')
                 ->label(__('shopper::forms.label.driver'))

--- a/packages/admin/src/Livewire/Pages/Settings/PaymentMethods.php
+++ b/packages/admin/src/Livewire/Pages/Settings/PaymentMethods.php
@@ -14,6 +14,7 @@ use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Notifications\Notification;
+use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Components\Utilities\Set;
 use Filament\Schemas\Concerns\InteractsWithSchemas;
 use Filament\Schemas\Contracts\HasSchemas;
@@ -25,6 +26,7 @@ use Filament\Tables\Concerns\InteractsWithTable;
 use Filament\Tables\Contracts\HasTable;
 use Filament\Tables\Table;
 use Illuminate\Contracts\View\View;
+use Illuminate\Database\Eloquent\Model;
 use Livewire\Attributes\Layout;
 use Livewire\Component;
 use Mckenziearts\Icons\Untitledui\Enums\Untitledui;
@@ -130,7 +132,13 @@ class PaymentMethods extends Component implements HasActions, HasSchemas, HasTab
                 ->placeholder('NotchPay')
                 ->required()
                 ->live(onBlur: true)
-                ->afterStateUpdated(fn (Set $set, ?string $state): mixed => $set('slug', $state)),
+                ->afterStateUpdated(function (?Model $record, Set $set, ?string $state, Get $get): void {
+                    if ($record?->exists && filled($get('slug'))) {
+                        return;
+                    }
+
+                    $set('slug', $state);
+                }),
             Hidden::make('slug'),
             Select::make('driver')
                 ->label(__('shopper::forms.label.driver'))

--- a/packages/admin/src/Livewire/Pages/Tag/Index.php
+++ b/packages/admin/src/Livewire/Pages/Tag/Index.php
@@ -10,6 +10,7 @@ use Filament\Actions\Contracts\HasActions;
 use Filament\Actions\DeleteBulkAction;
 use Filament\Forms\Components\TextInput;
 use Filament\Notifications\Notification;
+use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Components\Utilities\Set;
 use Filament\Schemas\Concerns\InteractsWithSchemas;
 use Filament\Schemas\Contracts\HasSchemas;
@@ -21,6 +22,7 @@ use Filament\Tables\Contracts\HasTable;
 use Filament\Tables\Table;
 use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
 use Mckenziearts\Icons\Untitledui\Enums\Untitledui;
 use Shopper\Core\Models\ProductTag;
@@ -118,7 +120,13 @@ class Index extends AbstractPageComponent implements HasActions, HasSchemas, Has
                 ->label(__('shopper::forms.label.name'))
                 ->required()
                 ->live(onBlur: true)
-                ->afterStateUpdated(fn (?string $state, Set $set): mixed => $set('slug', Str::slug($state ?? ''))),
+                ->afterStateUpdated(function (?Model $record, ?string $state, Set $set, Get $get): void {
+                    if ($record?->exists && filled($get('slug'))) {
+                        return;
+                    }
+
+                    $set('slug', Str::slug($state ?? ''));
+                }),
             TextInput::make('slug')
                 ->label(__('shopper::forms.label.slug'))
                 ->disabled()

--- a/packages/admin/src/Livewire/SlideOvers/AttributeForm.php
+++ b/packages/admin/src/Livewire/SlideOvers/AttributeForm.php
@@ -12,10 +12,12 @@ use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
 use Filament\Notifications\Notification;
+use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Components\Utilities\Set;
 use Filament\Schemas\Concerns\InteractsWithSchemas;
 use Filament\Schemas\Contracts\HasSchemas;
 use Filament\Schemas\Schema;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
 use Laravelcm\LivewireSlideOvers\SlideOverComponent;
 use Shopper\Components\Form\IconPicker;
@@ -71,7 +73,11 @@ class AttributeForm extends SlideOverComponent implements HasActions, HasSchemas
                     ->required()
                     ->live(onBlur: true)
                     ->maxLength(75)
-                    ->afterStateUpdated(function (string $operation, ?string $state, Set $set): void {
+                    ->afterStateUpdated(function (?Model $record, ?string $state, Set $set, Get $get): void {
+                        if ($record?->exists && filled($get('slug'))) {
+                            return;
+                        }
+
                         if ($state) {
                             $set('slug', Str::slug($state));
                         }

--- a/packages/admin/src/Livewire/SlideOvers/BrandForm.php
+++ b/packages/admin/src/Livewire/SlideOvers/BrandForm.php
@@ -13,10 +13,12 @@ use Filament\Forms\Components\SpatieMediaLibraryFileUpload;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
 use Filament\Notifications\Notification;
+use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Components\Utilities\Set;
 use Filament\Schemas\Concerns\InteractsWithSchemas;
 use Filament\Schemas\Contracts\HasSchemas;
 use Filament\Schemas\Schema;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
 use Laravelcm\LivewireSlideOvers\SlideOverComponent;
 use Shopper\Components\Form\SeoField;
@@ -75,8 +77,12 @@ class BrandForm extends SlideOverComponent implements HasActions, HasSchemas, Sl
                             ->placeholder('Apple, Nike, Samsung...')
                             ->required()
                             ->live(onBlur: true)
-                            ->afterStateUpdated(function (string $operation, $state, Set $set): void {
-                                $set('slug', Str::slug($state));
+                            ->afterStateUpdated(function (?Model $record, ?string $state, Set $set, Get $get): void {
+                                if ($record?->exists && filled($get('slug'))) {
+                                    return;
+                                }
+
+                                $set('slug', Str::slug($state ?? ''));
                             }),
                         Hidden::make('slug'),
                         TextInput::make('website')

--- a/packages/admin/src/Livewire/SlideOvers/CategoryForm.php
+++ b/packages/admin/src/Livewire/SlideOvers/CategoryForm.php
@@ -14,11 +14,13 @@ use Filament\Forms\Components\SpatieMediaLibraryFileUpload;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
 use Filament\Notifications\Notification;
+use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Components\Utilities\Set;
 use Filament\Schemas\Concerns\InteractsWithSchemas;
 use Filament\Schemas\Contracts\HasSchemas;
 use Filament\Schemas\Schema;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
 use Laravelcm\LivewireSlideOvers\SlideOverComponent;
 use Shopper\Components\Form\SeoField;
@@ -77,7 +79,11 @@ class CategoryForm extends SlideOverComponent implements HasActions, HasSchemas,
                             ->placeholder('Women, Baby Shoes, MacBook...')
                             ->required()
                             ->live(onBlur: true)
-                            ->afterStateUpdated(function (string $operation, ?string $state, Set $set): void {
+                            ->afterStateUpdated(function (?Model $record, ?string $state, Set $set, Get $get): void {
+                                if ($record?->exists && filled($get('slug'))) {
+                                    return;
+                                }
+
                                 if ($state) {
                                     $set('slug', Str::slug($state));
                                 }

--- a/packages/admin/src/Livewire/SlideOvers/SupplierForm.php
+++ b/packages/admin/src/Livewire/SlideOvers/SupplierForm.php
@@ -13,10 +13,12 @@ use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
 use Filament\Notifications\Notification;
+use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Components\Utilities\Set;
 use Filament\Schemas\Concerns\InteractsWithSchemas;
 use Filament\Schemas\Contracts\HasSchemas;
 use Filament\Schemas\Schema;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
 use Laravelcm\LivewireSlideOvers\SlideOverComponent;
 use Shopper\Components\Section;
@@ -73,8 +75,12 @@ class SupplierForm extends SlideOverComponent implements HasActions, HasSchemas,
                             ->label(__('shopper::forms.label.name'))
                             ->required()
                             ->live(onBlur: true)
-                            ->afterStateUpdated(function (string $operation, $state, Set $set): void {
-                                $set('slug', Str::slug($state));
+                            ->afterStateUpdated(function (?Model $record, ?string $state, Set $set, Get $get): void {
+                                if ($record?->exists && filled($get('slug'))) {
+                                    return;
+                                }
+
+                                $set('slug', Str::slug($state ?? ''));
                             }),
                         Hidden::make('slug'),
                         TextInput::make('email')

--- a/packages/admin/src/Livewire/SlideOvers/ZoneForm.php
+++ b/packages/admin/src/Livewire/SlideOvers/ZoneForm.php
@@ -15,10 +15,12 @@ use Filament\Infolists\Components\TextEntry;
 use Filament\Notifications\Notification;
 use Filament\Schemas\Components\Grid;
 use Filament\Schemas\Components\Group;
+use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Components\Utilities\Set;
 use Filament\Schemas\Concerns\InteractsWithSchemas;
 use Filament\Schemas\Contracts\HasSchemas;
 use Filament\Schemas\Schema;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\HtmlString;
@@ -108,7 +110,11 @@ class ZoneForm extends SlideOverComponent implements HasActions, HasSchemas, Sli
                             ->placeholder('Africa')
                             ->required()
                             ->live(onBlur: true)
-                            ->afterStateUpdated(function (?string $state, Set $set): void {
+                            ->afterStateUpdated(function (?Model $record, ?string $state, Set $set, Get $get): void {
+                                if ($record?->exists && filled($get('slug'))) {
+                                    return;
+                                }
+
                                 if ($state) {
                                     $set('slug', Str::slug($state));
                                 }

--- a/packages/core/src/Models/Product.php
+++ b/packages/core/src/Models/Product.php
@@ -197,7 +197,7 @@ class Product extends Model implements HasReviews, Priceable, ProductContract, S
      */
     public function variants(): HasMany
     {
-        return $this->hasMany(config('shopper.models.variant'), 'product_id');
+        return $this->hasMany(config('shopper.models.variant'), 'product_id')->orderBy('position');
     }
 
     /**

--- a/tests/Admin/Actions/Store/Product/CreateNewVariantTest.php
+++ b/tests/Admin/Actions/Store/Product/CreateNewVariantTest.php
@@ -41,4 +41,26 @@ describe(CreateNewVariant::class, function (): void {
             ->and($variant->stock)->toBe(10)
             ->and($variant->prices()->count())->toBe(1);
     });
+
+    it('assigns incremental positions per product', function (): void {
+        /** @var ProductContract $product */
+        $product = Product::factory()->create(['type' => ProductType::Variant]);
+
+        /** @var ProductVariantContract $first */
+        $first = app()->call(CreateNewVariant::class, ['data' => [
+            'product_id' => $product->id,
+            'name' => 'First Variant',
+            'sku' => 'VAR-POS-1',
+        ]]);
+
+        /** @var ProductVariantContract $second */
+        $second = app()->call(CreateNewVariant::class, ['data' => [
+            'product_id' => $product->id,
+            'name' => 'Second Variant',
+            'sku' => 'VAR-POS-2',
+        ]]);
+
+        expect($first->position)->toBe(1)
+            ->and($second->position)->toBe(2);
+    });
 })->group('actions', 'product');

--- a/tests/Admin/Livewire/Components/Products/Form/EditTest.php
+++ b/tests/Admin/Livewire/Components/Products/Form/EditTest.php
@@ -23,8 +23,9 @@ beforeEach(function (): void {
 });
 
 describe(Edit::class, function (): void {
-    it('can update product information', function (): void {
+    it('can update product information without changing the slug', function (): void {
         $product = Product::factory()->standard()->create();
+        $originalSlug = $product->slug;
 
         Livewire::test(Edit::class, ['product' => $product])
             ->fillForm([
@@ -37,7 +38,8 @@ describe(Edit::class, function (): void {
 
         Event::assertDispatched(ProductUpdated::class);
 
-        expect($product->slug)->toBe('demo-product');
+        expect($product->name)->toBe('Demo product')
+            ->and($product->slug)->toBe($originalSlug);
     });
 
     it('ensure that external_id field is invisible on non external product', function (): void {

--- a/tests/Admin/Livewire/Components/Products/Form/VariantsTest.php
+++ b/tests/Admin/Livewire/Components/Products/Form/VariantsTest.php
@@ -69,4 +69,28 @@ describe(Variants::class, function (): void {
 
         expect(ProductVariant::query()->find($variant->id))->toBeNull();
     });
+
+    it('blocks reordering variants for users without `edit_product_variants`', function (): void {
+        $a = ProductVariant::factory()->create(['product_id' => $this->product->id, 'position' => 1]);
+        $b = ProductVariant::factory()->create(['product_id' => $this->product->id, 'position' => 2]);
+
+        Livewire::test(Variants::class, ['product' => $this->product])
+            ->call('reorderTable', [$b->getKey(), $a->getKey()]);
+
+        expect($a->refresh()->position)->toBe(1)
+            ->and($b->refresh()->position)->toBe(2);
+    });
+
+    it('allows reordering variants for users with `edit_product_variants`', function (): void {
+        $this->user->givePermissionTo('edit_product_variants');
+
+        $a = ProductVariant::factory()->create(['product_id' => $this->product->id, 'position' => 1]);
+        $b = ProductVariant::factory()->create(['product_id' => $this->product->id, 'position' => 2]);
+
+        Livewire::test(Variants::class, ['product' => $this->product])
+            ->call('reorderTable', [$b->getKey(), $a->getKey()]);
+
+        expect($a->refresh()->position)->toBe(2)
+            ->and($b->refresh()->position)->toBe(1);
+    });
 })->group('livewire', 'components', 'products', 'security');

--- a/tests/Admin/Livewire/SlideOvers/CategoryFormTest.php
+++ b/tests/Admin/Livewire/SlideOvers/CategoryFormTest.php
@@ -61,6 +61,22 @@ describe(CategoryForm::class, function (): void {
             ->toBe('my-first-category-1');
     });
 
+    it('generates the slug from the name while typing on create', function (): void {
+        $component = Livewire::test(CategoryForm::class)
+            ->set('data.name', 'Summer Shoes');
+
+        expect($component->get('data.slug'))->toBe('summer-shoes');
+    });
+
+    it('keeps the slug when renaming an existing category', function (): void {
+        $category = Category::factory()->create(['name' => 'Shoes', 'slug' => 'shoes']);
+
+        $component = Livewire::test(CategoryForm::class, ['category' => $category])
+            ->set('data.name', 'Footwear');
+
+        expect($component->get('data.slug'))->toBe('shoes');
+    });
+
     it('can create category with parent', function (): void {
         $parent = Category::factory()->create(['name' => 'Parent', 'is_enabled' => true]);
 

--- a/tests/Admin/Livewire/SlideOvers/GenerateVariantsTest.php
+++ b/tests/Admin/Livewire/SlideOvers/GenerateVariantsTest.php
@@ -104,4 +104,34 @@ describe(GenerateVariants::class, function (): void {
         $component->call('generate')
             ->assertNotified();
     });
+
+    it('assigns incremental positions to generated variants', function (): void {
+        $component = Livewire::test(GenerateVariants::class, ['product' => $this->product]);
+
+        $component->set('variants', [
+            [
+                'key' => 'test-key-1',
+                'variant_id' => null,
+                'name' => 'Variant 1',
+                'sku' => 'SKU-POS-1',
+                'price' => 1000,
+                'stock' => 10,
+                'values' => [],
+            ],
+            [
+                'key' => 'test-key-2',
+                'variant_id' => null,
+                'name' => 'Variant 2',
+                'sku' => 'SKU-POS-2',
+                'price' => 1000,
+                'stock' => 10,
+                'values' => [],
+            ],
+        ]);
+
+        $component->call('generate');
+
+        expect($this->product->variants()->pluck('position', 'sku')->all())
+            ->toBe(['SKU-POS-1' => 1, 'SKU-POS-2' => 2]);
+    });
 })->group('livewire', 'slideovers', 'products');


### PR DESCRIPTION
## What

Fixes a bug reported on Discord: renaming a Category (and most other sluggable records) silently regenerated the slug, breaking public storefront URLs. Since the slug field is hidden in most admin forms, merchants had no way to see it happen or correct it.

### Slug regeneration

The name field's `afterStateUpdated` hook always rewrote the slug, on create and on edit alike.

- The 8 shared create/edit forms (Category, Brand, Supplier, Zone, Attribute, Tag, PaymentMethod, Carrier) now skip the slug sync when the record is persisted and already has a filled slug. Records with an empty slug still get one generated
- The edit-only product and collection forms no longer sync the slug at all, it is generated once by `AddProduct` / `AddCollectionForm` on create
- 3.x already behaves this way through the `SlugInput` component (#625)

### Variant reordering

Backport of the variants part of #625: the `position` column existed but nothing wrote it and there was no reorder UI.

- Drag-and-drop reordering on the variants table, gated by `edit_product_variants`
- `CreateNewVariant` and `SaveProductVariantsAction` assign incremental positions per product
- `Product::variants()` is ordered by `position`, so `$product->variants->first()` is the merchant-defined default in storefronts and starter kits