### PR TITLE
fix(core): product import follow-ups after #629

### DIFF
--- a/packages/admin/resources/views/livewire/pages/products/index.blade.php
+++ b/packages/admin/resources/views/livewire/pages/products/index.blade.php
@@ -15,8 +15,6 @@
         </x-slot>
     </x-shopper::heading>
 
-    <livewire:shopper-products.import-progress />
-
     {{ shopper()->getRenderHook(\Shopper\View\ProductRenderHook::INDEX_TABLE_BEFORE) }}
 
     <div class="mt-10">

--- a/packages/core/src/Import/ProductRowImporter.php
+++ b/packages/core/src/Import/ProductRowImporter.php
@@ -163,6 +163,7 @@ final class ProductRowImporter
         $product->update([
             'sku' => $variant->sku,
             'barcode' => $variant->barcode,
+            'allow_backorder' => $variant->allowBackorder,
             ...$this->weightData($variant),
         ]);
 
@@ -189,6 +190,7 @@ final class ProductRowImporter
             'barcode' => $row->barcode,
             'ean' => $row->ean,
             'upc' => $row->upc,
+            'allow_backorder' => $row->allowBackorder,
             ...$this->weightData($row),
         ];
 

--- a/packages/core/src/Import/VariantRow.php
+++ b/packages/core/src/Import/VariantRow.php
@@ -22,6 +22,7 @@ final readonly class VariantRow
         public ?float $weightValue = null,
         public ?string $weightUnit = null,
         public bool $requiresShipping = true,
+        public bool $allowBackorder = false,
         public ?string $imageUrl = null,
     ) {}
 


### PR DESCRIPTION
Follow-ups to #629 after real world testing of the WooCommerce migration addon against the import pipeline.

* The import progress banner is removed from the products index. Live tracking is handled by the migrator addon slide over, and the banner design will be revisited separately.
* `VariantRow` carries a new `allowBackorder` flag, applied to imported products and variants. Sources like WooCommerce expose in stock records without managed quantities, and those now remain purchasable after the import instead of landing at zero stock without backorder.
