### PR TITLE
fix(admin): show customers without roles and assign customer role on order

### DIFF
--- a/packages/admin/src/Listeners/EnsureCustomerRole.php
+++ b/packages/admin/src/Listeners/EnsureCustomerRole.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Listeners;
+
+use Shopper\Core\Events\Orders\OrderCreated;
+
+final class EnsureCustomerRole
+{
+    public function handle(OrderCreated $event): void
+    {
+        $event->order->customer?->assignRole(config('shopper.admin.roles.user'));
+    }
+}

--- a/packages/admin/src/ShopperServiceProvider.php
+++ b/packages/admin/src/ShopperServiceProvider.php
@@ -31,6 +31,7 @@ use Shopper\Concerns\TwoFactorAuthenticationProvider;
 use Shopper\Contracts\LoginResponse as LoginResponseContract;
 use Shopper\Contracts\TwoFactorAuthenticationProvider as TwoFactorAuthenticationProviderContract;
 use Shopper\Core\Enum\DiscountEligibility;
+use Shopper\Core\Events\Orders\OrderCreated;
 use Shopper\Core\Traits\HasRegisterConfigAndMigrationFiles;
 use Shopper\Discounts\DiscountEligibilityFieldRegistry;
 use Shopper\Facades\Shopper;
@@ -38,6 +39,7 @@ use Shopper\Http\Middleware\Authenticate;
 use Shopper\Http\Middleware\DispatchShopper;
 use Shopper\Http\Middleware\SetLocale;
 use Shopper\Http\Responses\LoginResponse;
+use Shopper\Listeners\EnsureCustomerRole;
 use Shopper\Livewire\Components;
 use Shopper\Livewire\Pages;
 use Shopper\Navigation\Product\ProductSectionManager;
@@ -126,6 +128,8 @@ final class ShopperServiceProvider extends PackageServiceProvider
 
         $this->app->register(SidebarServiceProvider::class);
         $this->app->register(ComponentsServiceProvider::class);
+
+        $this->app['events']->listen(OrderCreated::class, EnsureCustomerRole::class);
 
         if (config('shopper.admin.notifications.database.enabled')) {
             $this->app->register(EventServiceProvider::class);

--- a/packages/admin/src/Traits/InteractsWithShopper.php
+++ b/packages/admin/src/Traits/InteractsWithShopper.php
@@ -90,8 +90,15 @@ trait InteractsWithShopper
      */
     public function scopeCustomers(Builder $query): Builder
     {
-        return $query->whereHas('roles', function (Builder $query): void {
-            $query->where('name', config('shopper.admin.roles.user'));
+        return $query->where(function (Builder $query): void {
+            $query->whereDoesntHave('roles', function (Builder $query): void {
+                $query->whereIn('name', [
+                    config('shopper.admin.roles.admin'),
+                    config('shopper.admin.roles.manager'),
+                ]);
+            })->orWhereHas('roles', function (Builder $query): void {
+                $query->where('name', config('shopper.admin.roles.user'));
+            });
         });
     }
 

--- a/tests/Admin/Listeners/EnsureCustomerRoleTest.php
+++ b/tests/Admin/Listeners/EnsureCustomerRoleTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+use Shopper\Core\Models\Order;
+use Tests\Core\Stubs\User;
+
+uses(Tests\Admin\TestCase::class);
+
+it('assigns the customer role when a user places an order', function (): void {
+    $admin = User::factory()->create();
+    $admin->assignRole(config('shopper.admin.roles.admin'));
+
+    Order::factory()->create(['customer_id' => $admin->id]);
+
+    $admin->refresh();
+
+    expect($admin->hasRole(config('shopper.admin.roles.user')))->toBeTrue()
+        ->and($admin->hasRole(config('shopper.admin.roles.admin')))->toBeTrue()
+        ->and(User::customers()->whereKey($admin->id)->exists())->toBeTrue();
+});
+
+it('does not duplicate the customer role on repeat orders', function (): void {
+    $customer = User::factory()->create();
+    $customer->assignRole(config('shopper.admin.roles.user'));
+
+    Order::factory()->count(2)->create(['customer_id' => $customer->id]);
+
+    expect($customer->refresh()->roles)->toHaveCount(1);
+});
+
+it('ignores guest orders', function (): void {
+    $order = Order::factory()->create(['customer_id' => null]);
+
+    expect($order->exists)->toBeTrue();
+});

--- a/tests/Admin/Livewire/Pages/Customers/IndexTest.php
+++ b/tests/Admin/Livewire/Pages/Customers/IndexTest.php
@@ -13,6 +13,7 @@ uses(Tests\Admin\TestCase::class);
 
 beforeEach(function (): void {
     $this->user = User::factory()->create();
+    $this->user->assignRole(config('shopper.admin.roles.admin'));
     $this->user->givePermissionTo('customers.browse');
     $this->actingAs($this->user);
 });
@@ -51,7 +52,7 @@ describe(Index::class, function (): void {
         ]);
     });
 
-    it('counts only users that hold the customer role', function (): void {
+    it('counts users that are not administrators', function (): void {
         $customer = User::factory()->create();
         $customer->assignRole(config('shopper.admin.roles.user'));
 

--- a/tests/Admin/Livewire/Pages/Customers/ShowTest.php
+++ b/tests/Admin/Livewire/Pages/Customers/ShowTest.php
@@ -18,6 +18,7 @@ uses(Tests\Admin\TestCase::class);
 
 beforeEach(function (): void {
     $this->user = User::factory()->create();
+    $this->user->assignRole(config('shopper.admin.roles.admin'));
     $this->user->givePermissionTo('customers.read');
     $this->actingAs($this->user);
 });
@@ -49,8 +50,9 @@ describe(Show::class, function (): void {
             ->assertForbidden();
     });
 
-    it('aborts when target user is not a customer', function (): void {
+    it('aborts when target user is an administrator', function (): void {
         $admin = User::factory()->create();
+        $admin->assignRole(config('shopper.admin.roles.admin'));
 
         Livewire::test(Show::class, ['user' => $admin->id]);
     })->throws(ModelNotFoundException::class);
@@ -217,8 +219,9 @@ describe(Show::class, function (): void {
             ->assertRedirect(route('shopper.customers.show', ['user' => $other->id]));
     });
 
-    it('aborts goToCustomer when target id is not a customer', function (): void {
+    it('aborts goToCustomer when target id is an administrator', function (): void {
         $admin = User::factory()->create();
+        $admin->assignRole(config('shopper.admin.roles.admin'));
         $current = makeCustomer();
 
         Livewire::test(Show::class, ['user' => $current->id])

--- a/tests/Core/Models/UserTest.php
+++ b/tests/Core/Models/UserTest.php
@@ -88,12 +88,27 @@ describe(User::class, function (): void {
 
     it('scopes customers correctly', function (): void {
         $customerRole = Role::query()->firstOrCreate(['name' => config('shopper.admin.roles.user')]);
+        $adminRole = Role::query()->firstOrCreate(['name' => config('shopper.admin.roles.admin')]);
+        $managerRole = Role::query()->firstOrCreate(['name' => config('shopper.admin.roles.manager')]);
+
         $customers = User::factory()->count(3)->create();
         $customers->each(fn ($user) => $user->assignRole($customerRole));
 
         User::factory()->count(2)->create();
 
-        expect(User::customers()->count())->toBe(3);
+        $admin = User::factory()->create();
+        $admin->assignRole($adminRole);
+
+        $manager = User::factory()->create();
+        $manager->assignRole($managerRole);
+
+        $buyingAdmin = User::factory()->create();
+        $buyingAdmin->assignRole($adminRole);
+        $buyingAdmin->assignRole($customerRole);
+
+        expect(User::customers()->count())->toBe(6)
+            ->and(User::customers()->whereKey($admin->id)->exists())->toBeFalse()
+            ->and(User::customers()->whereKey($buyingAdmin->id)->exists())->toBeTrue();
     });
 
     it('scopes administrators correctly', function (): void {


### PR DESCRIPTION
## Problem

Reported on Discord: an admin placed a test order, and clicking "View customer" from the order detail page returned a 404. The customers scope required the `user` role, so any buyer without that exact role (admins, users created without roles) was invisible in the customers section while still being linked from their orders.

## Changes

- The `customers()` scope now includes every user that does not hold the admin or manager role, plus any user holding the customer role. A user without any role who placed an order is now visible, and an admin who also holds the customer role stays visible.
- New `EnsureCustomerRole` listener on `OrderCreated` assigns the customer role to the buyer on every new order. Guest orders (no customer) are ignored, and the assignment is idempotent so repeat orders never duplicate roles.
- The listener is registered outside the database notifications flag, since `EventServiceProvider` was only loaded when `shopper.admin.notifications.database.enabled` was true.
- Tests updated to the new scope semantics: actors in customers page tests are now real administrators, and 404 cases target actual admins instead of role-less users.