### PR TITLE
feat(core): add Scout search indexing foundation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
     "laravel/framework": "^12.0|^13.0",
     "laravel/passkeys": "^0.2",
     "laravel/sanctum": "^4.0",
+    "laravel/scout": "^10.13",
     "laravelcm/livewire-slide-overs": "^2.1",
     "league/csv": "^9.20",
     "leandrocfe/filament-apex-charts": "^5.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1130f58bb41aff7c9d189bd2b36591f6",
+    "content-hash": "c2332d252d0ebf01bc026f4c3a2b287b",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -3667,6 +3667,86 @@
                 "source": "https://github.com/laravel/sanctum"
             },
             "time": "2026-04-30T11:46:25+00:00"
+        },
+        {
+            "name": "laravel/scout",
+            "version": "v10.25.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/scout.git",
+                "reference": "f28630dca44a63d80c15e596bedc5af42c8985d5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/scout/zipball/f28630dca44a63d80c15e596bedc5af42c8985d5",
+                "reference": "f28630dca44a63d80c15e596bedc5af42c8985d5",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/bus": "^9.0|^10.0|^11.0|^12.0|^13.0",
+                "illuminate/contracts": "^9.0|^10.0|^11.0|^12.0|^13.0",
+                "illuminate/database": "^9.0|^10.0|^11.0|^12.0|^13.0",
+                "illuminate/http": "^9.0|^10.0|^11.0|^12.0|^13.0",
+                "illuminate/pagination": "^9.0|^10.0|^11.0|^12.0|^13.0",
+                "illuminate/queue": "^9.0|^10.0|^11.0|^12.0|^13.0",
+                "illuminate/support": "^9.0|^10.0|^11.0|^12.0|^13.0",
+                "php": "^8.0",
+                "symfony/console": "^6.0|^7.0|^8.0"
+            },
+            "conflict": {
+                "algolia/algoliasearch-client-php": "<3.2.0|>=5.0.0"
+            },
+            "require-dev": {
+                "algolia/algoliasearch-client-php": "^3.2|^4.0",
+                "meilisearch/meilisearch-php": "^1.0",
+                "mockery/mockery": "^1.0",
+                "orchestra/testbench": "^7.31|^8.36|^9.15|^10.8|^11.0",
+                "php-http/guzzle7-adapter": "^1.0",
+                "phpstan/phpstan": "^1.10",
+                "typesense/typesense-php": "^4.9.3"
+            },
+            "suggest": {
+                "algolia/algoliasearch-client-php": "Required to use the Algolia engine (^3.2).",
+                "meilisearch/meilisearch-php": "Required to use the Meilisearch engine (^1.0).",
+                "typesense/typesense-php": "Required to use the Typesense engine (^4.9)."
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Laravel\\Scout\\ScoutServiceProvider"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-master": "10.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Scout\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "Laravel Scout provides a driver based solution to searching your Eloquent models.",
+            "keywords": [
+                "algolia",
+                "laravel",
+                "search"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/scout/issues",
+                "source": "https://github.com/laravel/scout"
+            },
+            "time": "2026-03-10T16:16:46+00:00"
         },
         {
             "name": "laravel/serializable-closure",

--- a/packages/admin/src/Traits/InteractsWithShopper.php
+++ b/packages/admin/src/Traits/InteractsWithShopper.php
@@ -13,6 +13,7 @@ use Shopper\Core\Models\Address;
 use Shopper\Core\Models\Order;
 use Shopper\Core\Models\Traits\HasDiscounts;
 use Shopper\Core\Models\Traits\HasPublicId;
+use Shopper\Core\Models\Traits\Searchable;
 use Spatie\Permission\Traits\HasRoles;
 
 /**
@@ -26,6 +27,7 @@ trait InteractsWithShopper
     use HasProfilePhoto;
     use HasPublicId;
     use HasRoles;
+    use Searchable;
 
     public static function bootInteractsWithShopper(): void
     {

--- a/packages/api/config/api.php
+++ b/packages/api/config/api.php
@@ -35,7 +35,7 @@ return [
             'filters' => [
                 'name' => 'partial',
                 'sku' => 'exact',
-                'q' => ['scope', 'search'],
+                'q' => ['scope', 'matching'],
                 'category' => 'scope',
                 'collection' => ['scope', 'collection'],
                 'brand' => ['scope', 'byBrand'],

--- a/packages/core/composer.json
+++ b/packages/core/composer.json
@@ -10,6 +10,7 @@
     "illuminate/contracts": "^12.0|^13.0",
     "illuminate/database": "^12.0|^13.0",
     "illuminate/support": "^12.0|^13.0",
+    "laravel/scout": "^10.13",
     "league/csv": "^9.20",
     "spatie/laravel-package-tools": "^1.9",
     "staudenmeir/laravel-adjacency-list": "^1.0"

--- a/packages/core/config/search.php
+++ b/packages/core/config/search.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+use Shopper\Core\Models\Brand;
+use Shopper\Core\Models\Category;
+use Shopper\Core\Models\Collection;
+use Shopper\Core\Models\Order;
+use Shopper\Core\Models\Product;
+use Shopper\Core\Search\BrandIndexer;
+use Shopper\Core\Search\CategoryIndexer;
+use Shopper\Core\Search\CollectionIndexer;
+use Shopper\Core\Search\OrderIndexer;
+use Shopper\Core\Search\ProductIndexer;
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Search Engine Mapping
+    |--------------------------------------------------------------------------
+    |
+    | Here you may define which Laravel Scout driver each searchable model
+    | should use. Models that are not listed here will fall back to the
+    | driver defined by the SCOUT_DRIVER environment variable.
+    |
+    */
+
+    'engine_map' => [
+        // Product::class => 'typesense',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Model Indexers
+    |--------------------------------------------------------------------------
+    |
+    | Every searchable model delegates its index name, indexed payload and
+    | field definitions to an indexer class. You may swap any indexer for
+    | your own implementation to customize the data sent to the engine.
+    |
+    */
+
+    'indexers' => [
+        Brand::class => BrandIndexer::class,
+        Category::class => CategoryIndexer::class,
+        Collection::class => CollectionIndexer::class,
+        Order::class => OrderIndexer::class,
+        Product::class => ProductIndexer::class,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Facets
+    |--------------------------------------------------------------------------
+    |
+    | Here you may define the fields available for faceting when searching
+    | through the shopper/search addon. Each facet may define a label and
+    | any additional metadata returned alongside its values.
+    |
+    */
+
+    'facets' => [
+        Product::class => [
+            'brand' => ['label' => 'Brand'],
+            'categories' => ['label' => 'Categories'],
+        ],
+    ],
+
+];

--- a/packages/core/src/CoreServiceProvider.php
+++ b/packages/core/src/CoreServiceProvider.php
@@ -78,6 +78,7 @@ final class CoreServiceProvider extends PackageServiceProvider
     protected array $configFiles = [
         'core',
         'orders',
+        'search',
         'webhooks',
     ];
 
@@ -106,6 +107,7 @@ final class CoreServiceProvider extends PackageServiceProvider
         $this->registerObservers();
         $this->scheduleCommands();
         $this->registerWebhookListener();
+        $this->registerCustomerIndexer();
     }
 
     public function packageRegistered(): void
@@ -126,6 +128,15 @@ final class CoreServiceProvider extends PackageServiceProvider
                 $this->app['events']->listen(array_keys($events), DispatchWebhooksListener::class);
             }
         });
+    }
+
+    protected function registerCustomerIndexer(): void
+    {
+        $userModel = (string) config('auth.providers.users.model');
+
+        if ($userModel !== '' && blank(config('shopper.search.indexers.'.$userModel))) {
+            config(['shopper.search.indexers.'.$userModel => Search\CustomerIndexer::class]);
+        }
     }
 
     protected function scheduleCommands(): void

--- a/packages/core/src/Models/Brand.php
+++ b/packages/core/src/Models/Brand.php
@@ -16,6 +16,7 @@ use Shopper\Core\Models\Contracts\Brand as BrandContract;
 use Shopper\Core\Models\Traits\HasMediaCollections;
 use Shopper\Core\Models\Traits\HasPublicId;
 use Shopper\Core\Models\Traits\HasSlug;
+use Shopper\Core\Models\Traits\Searchable;
 use Shopper\Core\Traits\HasModelContract;
 
 /**
@@ -43,6 +44,7 @@ class Brand extends Model implements BrandContract, ShopperHasMedia
     use HasModelContract;
     use HasPublicId;
     use HasSlug;
+    use Searchable;
 
     protected $guarded = [];
 

--- a/packages/core/src/Models/Category.php
+++ b/packages/core/src/Models/Category.php
@@ -17,6 +17,7 @@ use Shopper\Core\Models\Contracts\Category as CategoryContract;
 use Shopper\Core\Models\Traits\HasMediaCollections;
 use Shopper\Core\Models\Traits\HasPublicId;
 use Shopper\Core\Models\Traits\HasSlug;
+use Shopper\Core\Models\Traits\Searchable;
 use Shopper\Core\Traits\HasModelContract;
 use Staudenmeir\LaravelAdjacencyList\Eloquent\HasRecursiveRelationships;
 use Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\HasManyOfDescendants;
@@ -48,6 +49,7 @@ class Category extends Model implements CategoryContract, ShopperHasMedia
     use HasPublicId;
     use HasRecursiveRelationships;
     use HasSlug;
+    use Searchable;
 
     protected $guarded = [];
 

--- a/packages/core/src/Models/Collection.php
+++ b/packages/core/src/Models/Collection.php
@@ -19,6 +19,7 @@ use Shopper\Core\Models\Contracts\Collection as CollectionContract;
 use Shopper\Core\Models\Traits\HasMediaCollections;
 use Shopper\Core\Models\Traits\HasPublicId;
 use Shopper\Core\Models\Traits\HasSlug;
+use Shopper\Core\Models\Traits\Searchable;
 use Shopper\Core\Queries\CollectionProductsQuery;
 use Shopper\Core\Traits\HasModelContract;
 
@@ -50,6 +51,7 @@ class Collection extends Model implements CollectionContract, ShopperHasMedia
     use HasModelContract;
     use HasPublicId;
     use HasSlug;
+    use Searchable;
 
     protected $guarded = [];
 

--- a/packages/core/src/Models/Order.php
+++ b/packages/core/src/Models/Order.php
@@ -20,6 +20,7 @@ use Shopper\Core\Enum\PaymentStatus;
 use Shopper\Core\Enum\ShippingStatus;
 use Shopper\Core\Models\Contracts\Order as OrderContract;
 use Shopper\Core\Models\Traits\HasPublicId;
+use Shopper\Core\Models\Traits\Searchable;
 use Shopper\Core\Traits\HasModelContract;
 use Shopper\Core\Traits\HasOrderStatusTransitions;
 use Shopper\Core\Traits\HasPaymentStatusTransitions;
@@ -75,6 +76,7 @@ class Order extends Model implements OrderContract
     use HasOrderStatusTransitions;
     use HasPaymentStatusTransitions;
     use HasPublicId;
+    use Searchable;
     use SoftDeletes;
 
     protected $guarded = [];

--- a/packages/core/src/Models/Order.php
+++ b/packages/core/src/Models/Order.php
@@ -61,7 +61,7 @@ use Shopper\Core\Traits\HasPaymentStatusTransitions;
  * @property-read ?Zone $zone
  * @property-read ?Channel $channel
  * @property-read ?static $parent
- * @property-read Model $customer
+ * @property-read ?Model $customer
  * @property-read Collection<int, OrderItem> $items
  * @property-read Collection<int, OrderPromotion> $promotions
  * @property-read Collection<int, OrderShipping> $shippings

--- a/packages/core/src/Models/Product.php
+++ b/packages/core/src/Models/Product.php
@@ -74,7 +74,7 @@ use Shopper\Core\Traits\HasModelContract;
  * @property-read ?CarbonInterface $deleted_at
  * @property-read int $stock
  * @property-read ?Supplier $supplier
- * @property-read Brand $brand
+ * @property-read ?Brand $brand
  * @property-read \Illuminate\Database\Eloquent\Collection<int, Channel> $channels
  * @property-read \Illuminate\Database\Eloquent\Collection<int, Category> $categories
  * @property-read \Illuminate\Database\Eloquent\Collection<int, Attribute> $options

--- a/packages/core/src/Models/Product.php
+++ b/packages/core/src/Models/Product.php
@@ -34,6 +34,7 @@ use Shopper\Core\Models\Traits\HasPublicId;
 use Shopper\Core\Models\Traits\HasSlug;
 use Shopper\Core\Models\Traits\HasStock;
 use Shopper\Core\Models\Traits\InteractsWithReviews;
+use Shopper\Core\Models\Traits\Searchable;
 use Shopper\Core\Traits\HasModelContract;
 
 /**
@@ -100,6 +101,7 @@ class Product extends Model implements HasReviews, Priceable, ProductContract, S
     use HasSlug;
     use HasStock;
     use InteractsWithReviews;
+    use Searchable;
     use SoftDeletes;
 
     protected $guarded = [];
@@ -342,7 +344,7 @@ class Product extends Model implements HasReviews, Priceable, ProductContract, S
      * @param  Builder<Product>  $query
      */
     #[Scope]
-    protected function search(Builder $query, string $term): void
+    protected function matching(Builder $query, string $term): void
     {
         $term = '%'.mb_strtolower($term).'%';
 

--- a/packages/core/src/Models/Traits/Searchable.php
+++ b/packages/core/src/Models/Traits/Searchable.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Core\Models\Traits;
+
+use Illuminate\Database\Eloquent\Builder;
+use Laravel\Scout\EngineManager;
+use Laravel\Scout\Engines\Engine;
+use Laravel\Scout\Searchable as ScoutSearchable;
+use Shopper\Core\Search\ScoutIndexer;
+
+trait Searchable
+{
+    use ScoutSearchable;
+
+    public function searchableAs(): string
+    {
+        return $this->indexer()->searchableAs($this);
+    }
+
+    public function shouldBeSearchable(): bool
+    {
+        return $this->indexer()->shouldBeSearchable($this);
+    }
+
+    public function getScoutKey(): mixed
+    {
+        return $this->indexer()->getScoutKey($this);
+    }
+
+    public function getScoutKeyName(): string
+    {
+        return $this->indexer()->getScoutKeyName($this);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toSearchableArray(): array
+    {
+        return $this->indexer()->toSearchableArray($this);
+    }
+
+    public function searchableUsing(): Engine
+    {
+        $engines = (array) config('shopper.search.engine_map', []);
+
+        $engine = $engines[static::class] ?? $engines[self::class] ?? null;
+
+        return app(EngineManager::class)->engine($engine);
+    }
+
+    public function indexer(): ScoutIndexer
+    {
+        $indexers = (array) config('shopper.search.indexers', []);
+
+        return app($indexers[static::class] ?? $indexers[self::class] ?? ScoutIndexer::class);
+    }
+
+    /**
+     * @param  Builder<covariant static>  $query
+     * @return Builder<covariant static>
+     */
+    protected function makeAllSearchableUsing(Builder $query): Builder
+    {
+        return $this->indexer()->makeAllSearchableUsing($query);
+    }
+}

--- a/packages/core/src/Search/BrandIndexer.php
+++ b/packages/core/src/Search/BrandIndexer.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Core\Search;
+
+use Illuminate\Database\Eloquent\Model;
+use Shopper\Core\Models\Brand;
+
+class BrandIndexer extends ScoutIndexer
+{
+    public function shouldBeSearchable(Model $model): bool
+    {
+        /** @var Brand $model */
+        return $model->is_enabled;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getSearchableFields(): array
+    {
+        return ['name', 'description'];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toSearchableArray(Model $model): array
+    {
+        /** @var Brand $model */
+        return [
+            'id' => (string) $model->getKey(),
+            'name' => $model->name,
+            'slug' => $model->slug,
+            'description' => strip_tags((string) $model->description) ?: null,
+            'created_at' => $model->created_at->getTimestamp(),
+        ];
+    }
+}

--- a/packages/core/src/Search/CategoryIndexer.php
+++ b/packages/core/src/Search/CategoryIndexer.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Core\Search;
+
+use Illuminate\Database\Eloquent\Model;
+use Shopper\Core\Models\Category;
+
+class CategoryIndexer extends ScoutIndexer
+{
+    public function shouldBeSearchable(Model $model): bool
+    {
+        /** @var Category $model */
+        return $model->is_enabled;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getSearchableFields(): array
+    {
+        return ['name', 'description'];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toSearchableArray(Model $model): array
+    {
+        /** @var Category $model */
+        return [
+            'id' => (string) $model->getKey(),
+            'name' => $model->name,
+            'slug' => $model->slug,
+            'description' => strip_tags((string) $model->description) ?: null,
+            'created_at' => $model->created_at->getTimestamp(),
+        ];
+    }
+}

--- a/packages/core/src/Search/CollectionIndexer.php
+++ b/packages/core/src/Search/CollectionIndexer.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Core\Search;
+
+use Illuminate\Database\Eloquent\Model;
+use Shopper\Core\Models\Collection;
+
+class CollectionIndexer extends ScoutIndexer
+{
+    public function shouldBeSearchable(Model $model): bool
+    {
+        /** @var Collection $model */
+        return $model->published_at !== null && $model->published_at->isPast();
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getSearchableFields(): array
+    {
+        return ['name', 'description'];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toSearchableArray(Model $model): array
+    {
+        /** @var Collection $model */
+        return [
+            'id' => (string) $model->getKey(),
+            'name' => $model->name,
+            'slug' => $model->slug,
+            'description' => strip_tags((string) $model->description) ?: null,
+            'published_at' => $model->published_at?->getTimestamp(),
+            'created_at' => $model->created_at->getTimestamp(),
+        ];
+    }
+}

--- a/packages/core/src/Search/CollectionIndexer.php
+++ b/packages/core/src/Search/CollectionIndexer.php
@@ -12,7 +12,7 @@ class CollectionIndexer extends ScoutIndexer
     public function shouldBeSearchable(Model $model): bool
     {
         /** @var Collection $model */
-        return $model->published_at !== null && $model->published_at->isPast();
+        return $model->published_at->isPast();
     }
 
     /**
@@ -34,7 +34,7 @@ class CollectionIndexer extends ScoutIndexer
             'name' => $model->name,
             'slug' => $model->slug,
             'description' => strip_tags((string) $model->description) ?: null,
-            'published_at' => $model->published_at?->getTimestamp(),
+            'published_at' => $model->published_at->getTimestamp(),
             'created_at' => $model->created_at->getTimestamp(),
         ];
     }

--- a/packages/core/src/Search/CustomerIndexer.php
+++ b/packages/core/src/Search/CustomerIndexer.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Core\Search;
+
+use Illuminate\Database\Eloquent\Model;
+
+class CustomerIndexer extends ScoutIndexer
+{
+    /**
+     * @return list<string>
+     */
+    public function getSearchableFields(): array
+    {
+        return ['name', 'email'];
+    }
+
+    /** @return array<string, mixed> */
+    public function toSearchableArray(Model $model): array
+    {
+        return [
+            'id' => (string) $model->getKey(),
+            'name' => mb_trim(implode(' ', array_filter([$model->first_name, $model->last_name]))) ?: null,
+            'email' => $model->email,
+            'created_at' => $model->created_at->getTimestamp(),
+        ];
+    }
+}

--- a/packages/core/src/Search/CustomerIndexer.php
+++ b/packages/core/src/Search/CustomerIndexer.php
@@ -21,9 +21,9 @@ class CustomerIndexer extends ScoutIndexer
     {
         return [
             'id' => (string) $model->getKey(),
-            'name' => mb_trim(implode(' ', array_filter([$model->first_name, $model->last_name]))) ?: null,
-            'email' => $model->email,
-            'created_at' => $model->created_at->getTimestamp(),
+            'name' => mb_trim(implode(' ', array_filter([$model->getAttribute('first_name'), $model->getAttribute('last_name')]))) ?: null,
+            'email' => $model->getAttribute('email'),
+            'created_at' => $model->getAttribute('created_at')?->getTimestamp(),
         ];
     }
 }

--- a/packages/core/src/Search/OrderIndexer.php
+++ b/packages/core/src/Search/OrderIndexer.php
@@ -54,7 +54,7 @@ class OrderIndexer extends ScoutIndexer
             'number' => $model->number,
             'email' => $model->email,
             'status' => $model->status->value,
-            'customer' => $model->customer?->full_name,
+            'customer' => $model->customer?->getAttribute('full_name'),
             'total' => $model->price_amount,
             'currency_code' => $model->currency_code,
             'created_at' => $model->created_at->getTimestamp(),

--- a/packages/core/src/Search/OrderIndexer.php
+++ b/packages/core/src/Search/OrderIndexer.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Core\Search;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Shopper\Core\Models\Order;
+
+class OrderIndexer extends ScoutIndexer
+{
+    /**
+     * @param  Builder<covariant Model>  $query
+     * @return Builder<covariant Model>
+     */
+    public function makeAllSearchableUsing(Builder $query): Builder
+    {
+        return $query->with('customer');
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getSearchableFields(): array
+    {
+        return ['number', 'email', 'customer'];
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getFilterableFields(): array
+    {
+        return ['status'];
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getSortableFields(): array
+    {
+        return ['created_at', 'total'];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toSearchableArray(Model $model): array
+    {
+        /** @var Order $model */
+        return [
+            'id' => (string) $model->getKey(),
+            'number' => $model->number,
+            'email' => $model->email,
+            'status' => $model->status->value,
+            'customer' => $model->customer?->full_name,
+            'total' => $model->price_amount,
+            'currency_code' => $model->currency_code,
+            'created_at' => $model->created_at->getTimestamp(),
+        ];
+    }
+}

--- a/packages/core/src/Search/ProductIndexer.php
+++ b/packages/core/src/Search/ProductIndexer.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Core\Search;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Shopper\Core\Models\Product;
+
+class ProductIndexer extends ScoutIndexer
+{
+    public function shouldBeSearchable(Model $model): bool
+    {
+        /** @var Product $model */
+        return $model->is_visible
+            && $model->published_at !== null
+            && $model->published_at->isPast();
+    }
+
+    /**
+     * @param  Builder<covariant Model>  $query
+     * @return Builder<covariant Model>
+     */
+    public function makeAllSearchableUsing(Builder $query): Builder
+    {
+        return $query->with(['brand', 'categories', 'variants']);
+    }
+
+    /** @return list<string> */
+    public function getSearchableFields(): array
+    {
+        return ['name', 'sku', 'skus', 'description', 'brand', 'categories'];
+    }
+
+    /** @return list<string> */
+    public function getSortableFields(): array
+    {
+        return ['created_at', 'published_at'];
+    }
+
+    /** @return list<string> */
+    public function getFilterableFields(): array
+    {
+        return ['brand', 'categories', 'type'];
+    }
+
+    /** @return array<string, mixed> */
+    public function toSearchableArray(Model $model): array
+    {
+        /** @var Product $model */
+        return [
+            'id' => (string) $model->getKey(),
+            'name' => $model->name,
+            'slug' => $model->slug,
+            'sku' => $model->sku,
+            'skus' => $model->variants->pluck('sku')->filter()->values()->all(),
+            'description' => strip_tags((string) $model->description),
+            'summary' => strip_tags((string) $model->summary) ?: null,
+            'type' => $model->type?->value,
+            'brand' => $model->brand?->name,
+            'categories' => $model->categories->pluck('name')->all(),
+            'published_at' => $model->published_at?->getTimestamp(),
+            'created_at' => $model->created_at->getTimestamp(),
+        ];
+    }
+}

--- a/packages/core/src/Search/ScoutIndexer.php
+++ b/packages/core/src/Search/ScoutIndexer.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Core\Search;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+class ScoutIndexer
+{
+    public function searchableAs(Model $model): string
+    {
+        $name = str_replace(
+            (string) config('shopper.core.table_prefix'),
+            '',
+            $model->getTable()
+        );
+
+        return config('scout.prefix').$name;
+    }
+
+    public function shouldBeSearchable(Model $model): bool
+    {
+        return true;
+    }
+
+    /**
+     * @param  Builder<covariant Model>  $query
+     * @return Builder<covariant Model>
+     */
+    public function makeAllSearchableUsing(Builder $query): Builder
+    {
+        return $query;
+    }
+
+    public function getScoutKey(Model $model): mixed
+    {
+        return $model->getKey();
+    }
+
+    public function getScoutKeyName(Model $model): string
+    {
+        return $model->getKeyName();
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getSearchableFields(): array
+    {
+        return ['name'];
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getSortableFields(): array
+    {
+        return ['created_at', 'updated_at'];
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getFilterableFields(): array
+    {
+        return [];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toSearchableArray(Model $model): array
+    {
+        return array_merge(
+            ['id' => (string) $model->getKey()],
+            $model->toArray(),
+            array_filter([
+                'created_at' => $model->created_at?->getTimestamp(),
+                'updated_at' => $model->updated_at?->getTimestamp(),
+            ]),
+        );
+    }
+}

--- a/packages/core/src/Search/ScoutIndexer.php
+++ b/packages/core/src/Search/ScoutIndexer.php
@@ -77,8 +77,8 @@ class ScoutIndexer
             ['id' => (string) $model->getKey()],
             $model->toArray(),
             array_filter([
-                'created_at' => $model->created_at?->getTimestamp(),
-                'updated_at' => $model->updated_at?->getTimestamp(),
+                'created_at' => $model->getAttribute('created_at')?->getTimestamp(),
+                'updated_at' => $model->getAttribute('updated_at')?->getTimestamp(),
             ]),
         );
     }

--- a/tests/Core/Search/ProductIndexerTest.php
+++ b/tests/Core/Search/ProductIndexerTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+use Shopper\Core\Models\Brand;
+use Shopper\Core\Models\Category;
+use Shopper\Core\Models\Collection;
+use Shopper\Core\Models\Order;
+use Shopper\Core\Models\Product;
+use Shopper\Core\Search\CustomerIndexer;
+use Shopper\Core\Search\ProductIndexer;
+use Shopper\Core\Search\ScoutIndexer;
+use Tests\Core\Stubs\User;
+
+uses(Tests\Core\TestCase::class);
+
+it('resolves the product indexer from config', function (): void {
+    $product = Product::factory()->create();
+
+    expect($product->indexer())->toBeInstanceOf(ProductIndexer::class);
+});
+
+it('falls back to the base indexer for unmapped models', function (): void {
+    config(['shopper.search.indexers' => []]);
+
+    $product = Product::factory()->create();
+
+    expect($product->indexer())->toBeInstanceOf(ScoutIndexer::class);
+});
+
+it('builds the searchable payload with brand and categories', function (): void {
+    $brand = Brand::factory()->create(['name' => 'Nike']);
+    $category = Category::factory()->create(['name' => 'Shoes', 'is_enabled' => true]);
+
+    $product = Product::factory()->publish()->create([
+        'name' => 'Air Max',
+        'brand_id' => $brand->id,
+        'description' => '<p>Great <strong>shoes</strong></p>',
+    ]);
+    $product->categories()->attach($category);
+
+    $payload = $product->refresh()->toSearchableArray();
+
+    expect($payload)
+        ->id->toBe((string) $product->id)
+        ->name->toBe('Air Max')
+        ->brand->toBe('Nike')
+        ->categories->toBe(['Shoes'])
+        ->description->toBe('Great shoes')
+        ->and($payload['published_at'])->toBeInt();
+});
+
+it('only marks visible products as searchable', function (): void {
+    $visible = Product::factory()->publish()->create();
+    $hidden = Product::factory()->create(['is_visible' => false]);
+
+    expect($visible->shouldBeSearchable())->toBeTrue()
+        ->and($hidden->shouldBeSearchable())->toBeFalse();
+});
+
+it('does not mark a scheduled product as searchable before its publish date', function (): void {
+    $scheduled = Product::factory()->create([
+        'is_visible' => true,
+        'published_at' => now()->addWeek(),
+    ]);
+
+    expect($scheduled->shouldBeSearchable())->toBeFalse();
+});
+
+it('does not override an indexer already configured for the user model', function (): void {
+    $userModel = (string) config('auth.providers.users.model');
+    config(['shopper.search.indexers.'.$userModel => 'App\CustomCustomerIndexer']);
+
+    (new Shopper\Core\CoreServiceProvider(app()))->packageBooted();
+
+    expect(config('shopper.search.indexers.'.$userModel))->toBe('App\CustomCustomerIndexer');
+});
+
+it('only marks enabled brands and categories as searchable', function (): void {
+    $enabledBrand = Brand::factory()->create(['is_enabled' => true]);
+    $disabledBrand = Brand::factory()->create(['is_enabled' => false]);
+    $enabledCategory = Category::factory()->create(['is_enabled' => true]);
+    $disabledCategory = Category::factory()->create(['is_enabled' => false]);
+
+    expect($enabledBrand->shouldBeSearchable())->toBeTrue()
+        ->and($disabledBrand->shouldBeSearchable())->toBeFalse()
+        ->and($enabledCategory->shouldBeSearchable())->toBeTrue()
+        ->and($disabledCategory->shouldBeSearchable())->toBeFalse();
+});
+
+it('only marks published collections as searchable', function (): void {
+    $published = Collection::factory()->create(['published_at' => now()->subDay()]);
+    $scheduled = Collection::factory()->create(['published_at' => now()->addDay()]);
+
+    expect($published->shouldBeSearchable())->toBeTrue()
+        ->and($scheduled->shouldBeSearchable())->toBeFalse();
+});
+
+it('builds the order searchable payload', function (): void {
+    $order = Order::factory()->create();
+
+    $payload = $order->toSearchableArray();
+
+    expect($payload)
+        ->id->toBe((string) $order->id)
+        ->number->toBe($order->number)
+        ->status->toBe($order->status->value)
+        ->and($payload['created_at'])->toBeInt();
+});
+
+it('resolves the customer indexer for the configured user model', function (): void {
+    $user = User::factory()->create();
+
+    expect($user->indexer())->toBeInstanceOf(CustomerIndexer::class)
+        ->and($user->toSearchableArray())
+        ->email->toBe($user->email)
+        ->id->toBe((string) $user->id);
+});


### PR DESCRIPTION
## What

Adds the search indexing foundation to the core package, powered by Laravel Scout. Models are indexed by the core, while querying (engines, facets, storefront endpoints) lives in the upcoming `shopper/search` addon that consumes these indexes.

## How

- New `Shopper\Core\Models\Traits\Searchable` trait wrapping Scout, applied to Product, Brand, Category, Collection and Order. User and Customer are covered through `InteractsWithShopper`.
- One indexer per model in `packages/core/src/Search` defining the searchable payload. The customer indexer is mapped at boot on `auth.providers.users.model`, so swapped user models keep working.
- Indexing conditions per model: products must be visible and published, brands and categories enabled, collections published, orders and customers always indexed.
- New `shopper/search.php` config published by the core: engine map, indexers and facet definitions in one place, consumed by both the core and the addon.
- The `search` scope on Product is renamed `matching`, since Scout's static `search()` would be shadowed by the local scope.
- Scout ships with the `collection` driver by default, so existing stores upgrade without any indexing side effect until an engine is configured.
