### PR TITLE
feat(sdk): per-request fetch options and shopper-types re-export

### DIFF
--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -1,4 +1,4 @@
-import { buildQuery, type FetchOptions, toApiError } from './http'
+import { buildQuery, type FetchInit, type FetchOptions, toApiError } from './http'
 import type { JsonApiDocument } from './json-api'
 
 /**
@@ -85,8 +85,8 @@ export class HttpClient {
     return this.locale
   }
 
-  public async request(path: string, options?: FetchOptions): Promise<JsonApiDocument> {
-    return (await this.send('GET', path, undefined, options)) as JsonApiDocument
+  public async request(path: string, options?: FetchOptions, init?: FetchInit): Promise<JsonApiDocument> {
+    return (await this.send('GET', path, undefined, options, init)) as JsonApiDocument
   }
 
   /**
@@ -99,12 +99,15 @@ export class HttpClient {
     path: string,
     body?: Record<string, unknown> | FormData,
     options?: FetchOptions,
+    init?: FetchInit,
   ): Promise<JsonApiDocument | null> {
     const url = `${this.baseUrl}/${path.replace(/^\//, '')}${buildQuery(options)}`
     const token = this.tokens.get()
     const isForm = typeof FormData !== 'undefined' && body instanceof FormData
+    const { headers: initHeaders, ...initRest } = init ?? {}
 
     const response = await this.fetchImpl(url, {
+      ...initRest,
       method,
       headers: {
         Accept: 'application/vnd.api+json',
@@ -112,6 +115,7 @@ export class HttpClient {
         ...(token !== null ? { Authorization: `Bearer ${token}` } : {}),
         ...(this.locale !== null ? { 'Accept-Language': this.locale } : {}),
         ...this.headers,
+        ...initHeaders,
       },
       ...(body !== undefined ? { body: isForm ? (body as FormData) : JSON.stringify(body) } : {}),
     })

--- a/packages/sdk/src/http.ts
+++ b/packages/sdk/src/http.ts
@@ -26,6 +26,23 @@ export interface FetchRequestOptions extends FetchOptions {
   body?: Record<string, unknown> | FormData
 }
 
+/**
+ * Per-request options forwarded to the underlying fetch call: standard
+ * RequestInit fields (cache, signal, ...) plus the Next.js extensions so a
+ * server component can tag or revalidate a single call:
+ *
+ * ```ts
+ * await sdk.store.product.list({ page: { size: 12 } }, { next: { tags: ['products'] } })
+ * ```
+ *
+ * Method, body and the JSON:API headers stay managed by the client; `headers`
+ * given here are merged last and win over the client-level ones.
+ */
+export type FetchInit = Omit<RequestInit, 'method' | 'body' | 'headers'> & {
+  headers?: Record<string, string>
+  next?: { revalidate?: number | false; tags?: string[] }
+}
+
 export function buildQuery(options?: FetchOptions): string {
   if (! options) {
     return ''

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -51,7 +51,8 @@ export type {
   ShippingOptionList,
 } from './store'
 export { ShopperApiError, buildQuery } from './http'
-export type { RequestParams, FetchOptions, FetchRequestOptions } from './http'
+export type { RequestParams, FetchOptions, FetchRequestOptions, FetchInit } from './http'
+export type * from '@shopperlabs/shopper-types'
 export { flatten } from './json-api'
 export type {
   JsonApiDocument,

--- a/packages/sdk/src/store/collection.ts
+++ b/packages/sdk/src/store/collection.ts
@@ -1,5 +1,5 @@
 import type { HttpClient } from '../client'
-import type { RequestParams } from '../http'
+import type { FetchInit, RequestParams } from '../http'
 import { flatten } from '../json-api'
 
 /** A paginated list result: flattened entities plus JSON:API meta and links. */
@@ -19,14 +19,14 @@ export class CollectionResource<T> {
     private readonly path: string,
   ) {}
 
-  public async list(params?: RequestParams): Promise<Paginated<T>> {
-    const document = await this.client.request(this.path, params)
+  public async list(params?: RequestParams, init?: FetchInit): Promise<Paginated<T>> {
+    const document = await this.client.request(this.path, params, init)
 
     return { data: (flatten<T>(document) ?? []) as T[], meta: document.meta, links: document.links }
   }
 
   /** Retrieve a single entity by its public identifier (slug for catalog, code for geo). */
-  public async retrieve(identifier: string, params?: RequestParams): Promise<T> {
-    return flatten<T>(await this.client.request(`${this.path}/${identifier}`, params)) as T
+  public async retrieve(identifier: string, params?: RequestParams, init?: FetchInit): Promise<T> {
+    return flatten<T>(await this.client.request(`${this.path}/${identifier}`, params, init)) as T
   }
 }

--- a/packages/sdk/src/store/index.ts
+++ b/packages/sdk/src/store/index.ts
@@ -10,7 +10,7 @@ import type {
 } from '@shopperlabs/shopper-types'
 
 import type { HttpClient } from '../client'
-import type { FetchRequestOptions } from '../http'
+import type { FetchInit, FetchRequestOptions } from '../http'
 import { flatten } from '../json-api'
 import { CartModule } from './cart'
 import { CollectionResource } from './collection'
@@ -96,6 +96,7 @@ export class StoreModule {
   public async fetch<T = unknown>(
     path: string,
     options?: FetchRequestOptions,
+    init?: FetchInit,
   ): Promise<{ data: T | T[] | null; meta?: Record<string, unknown>; links?: Record<string, unknown> }> {
     const { method = 'GET', body, ...params } = options ?? {}
 
@@ -104,6 +105,7 @@ export class StoreModule {
       `/${this.client.storePrefix}/${path.replace(/^\//, '')}`,
       body,
       params,
+      init,
     )
 
     if (! document) {


### PR DESCRIPTION
Two DX improvements for the SDK. The SDK stays framework agnostic: it runs on the standard fetch API, so Remix, Nuxt, TanStack Start, Angular, Expo or any other JavaScript runtime consumes it the same way.

## Per-request fetch options

Every read call now accepts an optional `FetchInit` argument forwarded to the underlying `fetch`: standard `RequestInit` fields (`cache`, `signal`, ...) plus an optional `next` field typed for the Next.js fetch extensions (`next.tags`, `next.revalidate`). Every framework benefits from per-request `cache`, `signal` or headers; frameworks with their own fetch extensions pass them through the same way:

```ts
await sdk.store.product.list({ page: { size: 12 } }, { next: { tags: ['products'] } })
```

`method`, `body` and the JSON:API headers stay managed by the client. Headers given per request are merged last and win over the client-level ones. Available on `list()`, `retrieve()` and the `store.fetch()` escape hatch.

## Types re-export

The SDK re-exports every type from `@shopperlabs/shopper-types`, so storefronts can write `import type { Product } from '@shopperlabs/shopper-sdk'` without knowing about, or version-pinning, the separate types package.

No breaking change: only optional trailing parameters and an additive type re-export.
