### PR TITLE
feat(api): store product reviews endpoints

### DIFF
--- a/packages/admin/src/Traits/HasProfilePhoto.php
+++ b/packages/admin/src/Traits/HasProfilePhoto.php
@@ -9,6 +9,11 @@ use Illuminate\Support\Facades\Storage;
 
 trait HasProfilePhoto
 {
+    public function initializeHasProfilePhoto(): void
+    {
+        $this->append('picture');
+    }
+
     protected function picture(): Attribute
     {
         return Attribute::make(

--- a/packages/api/config/api.php
+++ b/packages/api/config/api.php
@@ -111,5 +111,11 @@ return [
             'sorts' => ['created_at'],
             'includes' => ['items'],
         ],
+        'review' => [
+            'filters' => ['rating' => 'exact'],
+            'sorts' => ['created_at', 'rating'],
+            'includes' => [],
+            'latest_limit' => 20,
+        ],
     ],
 ];

--- a/packages/api/routes/store/catalog.php
+++ b/packages/api/routes/store/catalog.php
@@ -8,9 +8,12 @@ use Shopper\Api\Http\Controllers\Catalog\BrandController;
 use Shopper\Api\Http\Controllers\Catalog\CategoryController;
 use Shopper\Api\Http\Controllers\Catalog\CollectionController;
 use Shopper\Api\Http\Controllers\Catalog\ProductController;
+use Shopper\Api\Http\Controllers\Catalog\ReviewController;
 
 Route::get('/products', [ProductController::class, 'index']);
 Route::get('/products/{slug}', [ProductController::class, 'show']);
+Route::get('/products/{slug}/reviews', [ReviewController::class, 'index']);
+Route::get('/reviews', [ReviewController::class, 'latest']);
 Route::get('/categories', [CategoryController::class, 'index']);
 Route::get('/categories/{slug}', [CategoryController::class, 'show']);
 Route::get('/collections', [CollectionController::class, 'index']);

--- a/packages/api/src/Http/Controllers/Catalog/ReviewController.php
+++ b/packages/api/src/Http/Controllers/Catalog/ReviewController.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Api\Http\Controllers\Catalog;
+
+use Illuminate\Database\Eloquent\Model;
+use Shopper\Api\Concerns\BuildsApiQueries;
+use Shopper\Api\Http\Resources\ReviewResource;
+use Shopper\Core\Models\Contracts\Product;
+use Shopper\Core\Models\Review;
+use TiMacDonald\JsonApi\JsonApiResourceCollection;
+
+final class ReviewController
+{
+    use BuildsApiQueries;
+
+    public function index(string $slug): JsonApiResourceCollection
+    {
+        $product = resolve(Product::class)::query()
+            ->publish()
+            ->where('slug', $slug)
+            ->firstOrFail();
+
+        $query = Review::query()
+            ->approved()
+            ->where('reviewrateable_type', $product->getMorphClass())
+            ->where('reviewrateable_id', $product->getKey())
+            ->with('author');
+
+        $reviews = $this->paginated('review', $query, defaultSort: '-created_at');
+
+        return ReviewResource::collection($reviews)
+            ->additional(['meta' => $this->aggregates($product)]);
+    }
+
+    /**
+     * The most recent approved reviews across the shop, capped server-side
+     * and never paginated: the shape a testimonials widget needs, without
+     * exposing the full review corpus to enumeration.
+     */
+    public function latest(): JsonApiResourceCollection
+    {
+        $limit = max(1, (int) config('shopper.api.resources.review.latest_limit', 20));
+
+        $reviews = Review::query()
+            ->approved()
+            ->with('author')
+            ->latest()
+            ->limit($limit)
+            ->get();
+
+        return ReviewResource::collection($reviews);
+    }
+
+    /**
+     * Count, average and star distribution in one aggregate query over the
+     * exact predicate the listing paginates, so the numbers can never
+     * disagree with the rows.
+     *
+     * @return array<string, mixed>
+     */
+    private function aggregates(Model $product): array
+    {
+        $distribution = Review::query()
+            ->approved()
+            ->where('reviewrateable_type', $product->getMorphClass())
+            ->where('reviewrateable_id', $product->getKey())
+            ->toBase()
+            ->selectRaw('rating, COUNT(*) as total')
+            ->groupBy('rating')
+            ->pluck('total', 'rating');
+
+        $count = (int) $distribution->sum();
+        $weighted = $distribution->reduce(
+            fn (int $carry, mixed $total, mixed $rating): int => $carry + ((int) $rating * (int) $total),
+            0,
+        );
+
+        return [
+            'reviews_count' => $count,
+            'average_rating' => $count > 0 ? round($weighted / $count, 1) : null,
+            'rating_distribution' => collect(range(1, 5))
+                ->mapWithKeys(fn (int $rating): array => [$rating => (int) $distribution->get($rating, 0)])
+                ->all(),
+        ];
+    }
+}

--- a/packages/api/src/Http/Resources/ReviewResource.php
+++ b/packages/api/src/Http/Resources/ReviewResource.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Api\Http\Resources;
+
+use Illuminate\Http\Request;
+use Shopper\Core\Models\Review;
+
+/**
+ * @mixin Review
+ */
+final class ReviewResource extends JsonApiResource
+{
+    public function toType(Request $request): string
+    {
+        return 'reviews';
+    }
+
+    public function toAttributes(Request $request): array
+    {
+        return [
+            'title' => $this->title,
+            'content' => $this->content,
+            'rating' => $this->rating,
+            'is_recommended' => $this->is_recommended,
+            'author_name' => $this->authorName(),
+            'created_at' => $this->created_at->toIso8601String(),
+        ];
+    }
+
+    /**
+     * The reviewer reduced to a display name (first name and last initial).
+     * The author id, type, full surname or avatar never reach the public
+     * payload: published together they would let anyone rebuild a customer's
+     * purchase history.
+     */
+    private function authorName(): ?string
+    {
+        $author = $this->author;
+
+        if ($author === null) {
+            return null;
+        }
+
+        $first = (string) $author->getAttribute('first_name');
+        $lastInitial = mb_substr((string) $author->getAttribute('last_name'), 0, 1);
+
+        $name = mb_trim($first.' '.($lastInitial !== '' ? $lastInitial.'.' : ''));
+
+        return $name !== '' ? $name : null;
+    }
+}

--- a/packages/api/src/Http/Resources/ReviewResource.php
+++ b/packages/api/src/Http/Resources/ReviewResource.php
@@ -24,18 +24,21 @@ final class ReviewResource extends JsonApiResource
             'content' => $this->content,
             'rating' => $this->rating,
             'is_recommended' => $this->is_recommended,
-            'author_name' => $this->authorName(),
+            'author' => $this->authorPayload(),
             'created_at' => $this->created_at->toIso8601String(),
         ];
     }
 
     /**
-     * The reviewer reduced to a display name (first name and last initial).
-     * The author id, type, full surname or avatar never reach the public
-     * payload: published together they would let anyone rebuild a customer's
+     * The reviewer reduced to a display name (first name and last initial)
+     * and their picture, uploaded file or generated fallback alike. The
+     * author id, type and full surname never reach the public payload:
+     * published together they would let anyone rebuild a customer's
      * purchase history.
+     *
+     * @return array{name: ?string, avatar: ?string}|null
      */
-    private function authorName(): ?string
+    private function authorPayload(): ?array
     {
         $author = $this->author;
 
@@ -45,9 +48,11 @@ final class ReviewResource extends JsonApiResource
 
         $first = (string) $author->getAttribute('first_name');
         $lastInitial = mb_substr((string) $author->getAttribute('last_name'), 0, 1);
-
         $name = mb_trim($first.' '.($lastInitial !== '' ? $lastInitial.'.' : ''));
 
-        return $name !== '' ? $name : null;
+        return [
+            'name' => $name !== '' ? $name : null,
+            'avatar' => $author->getAttribute('picture'),
+        ];
     }
 }

--- a/packages/core/database/migrations/2026_07_31_000001_add_unique_currency_index_to_prices_table.php
+++ b/packages/core/database/migrations/2026_07_31_000001_add_unique_currency_index_to_prices_table.php
@@ -34,12 +34,4 @@ return new class extends Migration
             $table->index(['priceable_type', 'priceable_id', 'currency_id', 'amount'], 'prices_priceable_currency_amount_index');
         });
     }
-
-    public function down(): void
-    {
-        Schema::table($this->getTableName('prices'), static function (Blueprint $table): void {
-            $table->dropUnique('prices_priceable_currency_unique');
-            $table->dropIndex('prices_priceable_currency_amount_index');
-        });
-    }
 };

--- a/packages/core/database/migrations/2026_07_31_000002_add_public_id_and_indexes_to_reviews_table.php
+++ b/packages/core/database/migrations/2026_07_31_000002_add_public_id_and_indexes_to_reviews_table.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+use Shopper\Core\Helpers\Migration;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $reviews = $this->getTableName('reviews');
+
+        if (! Schema::hasColumn($reviews, 'public_id')) {
+            Schema::table($reviews, static function (Blueprint $table): void {
+                $table->ulid('public_id')
+                    ->nullable()
+                    ->unique()
+                    ->after('id');
+            });
+
+            DB::table($reviews)->whereNull('public_id')->orderBy('id')->lazyById()->each(
+                fn (object $row) => DB::table($reviews)
+                    ->where('id', $row->id)
+                    ->update(['public_id' => (string) Str::ulid()])
+            );
+        }
+
+        Schema::table($reviews, static function (Blueprint $table): void {
+            $table->index(
+                ['reviewrateable_type', 'reviewrateable_id', 'approved', 'created_at'],
+                'reviews_reviewrateable_approved_created_index',
+            );
+        });
+    }
+};

--- a/packages/core/src/Models/Review.php
+++ b/packages/core/src/Models/Review.php
@@ -5,15 +5,19 @@ declare(strict_types=1);
 namespace Shopper\Core\Models;
 
 use Carbon\CarbonInterface;
+use Illuminate\Database\Eloquent\Attributes\Scope;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Shopper\Core\Database\Factories\ReviewFactory;
 use Shopper\Core\Models\Contracts\Review as ReviewContract;
+use Shopper\Core\Models\Traits\HasPublicId;
 
 /**
  * @property-read int $id
+ * @property-read ?string $public_id
  * @property-read bool $approved
  * @property-read bool $is_recommended
  * @property-read ?string $title
@@ -30,6 +34,8 @@ class Review extends Model implements ReviewContract
 {
     /** @use HasFactory<ReviewFactory> */
     use HasFactory;
+
+    use HasPublicId;
 
     protected $guarded = [];
 
@@ -176,6 +182,18 @@ class Review extends Model implements ReviewContract
     protected static function newFactory(): ReviewFactory
     {
         return ReviewFactory::new();
+    }
+
+    /**
+     * @template TModel of Model
+     *
+     * @param  Builder<TModel>  $query
+     * @return Builder<TModel>
+     */
+    #[Scope]
+    protected function approved(Builder $query): Builder
+    {
+        return $query->where('approved', true);
     }
 
     protected function casts(): array

--- a/packages/core/src/Queries/CollectionProductsQuery.php
+++ b/packages/core/src/Queries/CollectionProductsQuery.php
@@ -13,6 +13,7 @@ use Shopper\Core\Enum\Rule;
 use Shopper\Core\Models\CollectionRule;
 use Shopper\Core\Models\Contracts\Collection;
 use Shopper\Core\Models\Contracts\Product;
+use Shopper\Core\Models\Review;
 
 final class CollectionProductsQuery
 {
@@ -225,12 +226,15 @@ final class CollectionProductsQuery
             default => '=',
         };
 
-        $query->whereHas('ratings', function (Builder $subQuery) use ($operator, $rule): void { // @phpstan-ignore-line
-            $subQuery->select('reviewrateable_id')
-                ->where('approved', true)
-                ->groupBy('reviewrateable_id')
-                ->havingRaw('AVG(rating) '.$operator.' ?', [(float) $rule->value]);
-        });
+        /** @var class-string<Product> $productModel */
+        $productModel = config('shopper.models.product');
+
+        $query->whereIn('id', Review::query()
+            ->approved()
+            ->select('reviewrateable_id')
+            ->where('reviewrateable_type', (new $productModel)->getMorphClass())
+            ->groupBy('reviewrateable_id')
+            ->havingRaw('AVG(rating) '.$operator.' '.(float) $rule->value));
     }
 
     /**

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -41,7 +41,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@shopperlabs/shopper-types": "^3.0.0-beta.1"
+    "@shopperlabs/shopper-types": "^3.0.0"
   },
   "devDependencies": {
     "typescript": "^5.2.2"

--- a/packages/sdk/src/store/collection.ts
+++ b/packages/sdk/src/store/collection.ts
@@ -15,8 +15,8 @@ export interface Paginated<T> {
  */
 export class CollectionResource<T> {
   public constructor(
-    private readonly client: HttpClient,
-    private readonly path: string,
+    protected readonly client: HttpClient,
+    protected readonly path: string,
   ) {}
 
   public async list(params?: RequestParams, init?: FetchInit): Promise<Paginated<T>> {

--- a/packages/sdk/src/store/index.ts
+++ b/packages/sdk/src/store/index.ts
@@ -5,7 +5,6 @@ import type {
   Collection,
   Country,
   Currency,
-  Product,
   Zone,
 } from '@shopperlabs/shopper-types'
 
@@ -16,6 +15,8 @@ import { CartModule } from './cart'
 import { CollectionResource } from './collection'
 import { CustomerModule } from './customer'
 import { OrderModule } from './order'
+import { ProductResource } from './product'
+import { ReviewModule } from './review'
 
 export { CartModule } from './cart'
 export type {
@@ -31,6 +32,9 @@ export { CollectionResource } from './collection'
 export type { Paginated } from './collection'
 export { CustomerModule } from './customer'
 export { OrderModule } from './order'
+export { ProductResource } from './product'
+export type { ProductList, ReviewList } from './product'
+export { ReviewModule } from './review'
 
 /**
  * Store API surface, mirroring the catalog and geo endpoints. Resources are
@@ -40,7 +44,9 @@ export { OrderModule } from './order'
  * wrapped, including addon routes registered through shopper/http.
  */
 export class StoreModule {
-  public readonly product: CollectionResource<Product>
+  public readonly product: ProductResource
+
+  public readonly review: ReviewModule
 
   public readonly category: CollectionResource<Category>
 
@@ -65,7 +71,8 @@ export class StoreModule {
   public constructor(private readonly client: HttpClient) {
     const prefix = `/${client.storePrefix}`
 
-    this.product = new CollectionResource<Product>(client, `${prefix}/products`)
+    this.product = new ProductResource(client, `${prefix}/products`)
+    this.review = new ReviewModule(client)
     this.category = new CollectionResource<Category>(client, `${prefix}/categories`)
     this.collection = new CollectionResource<Collection>(client, `${prefix}/collections`)
     this.brand = new CollectionResource<Brand>(client, `${prefix}/brands`)

--- a/packages/sdk/src/store/product.ts
+++ b/packages/sdk/src/store/product.ts
@@ -1,0 +1,54 @@
+import type { Product, Review, ReviewAggregates } from '@shopperlabs/shopper-types'
+
+import type { FetchInit, RequestParams } from '../http'
+import { flatten } from '../json-api'
+import { CollectionResource, type Paginated } from './collection'
+
+/**
+ * A paginated products listing: the rows plus the currency every price-aware
+ * value of the response is expressed in (`price_range`, price sorting).
+ */
+export interface ProductList extends Paginated<Product> {
+  meta: { currency: string | null } & Record<string, unknown>
+}
+
+/**
+ * A paginated reviews listing: the rows plus the server-computed aggregates
+ * (count, average, star distribution) merged into the JSON:API meta.
+ */
+export interface ReviewList extends Paginated<Review> {
+  meta: ReviewAggregates & Record<string, unknown>
+}
+
+/**
+ * The products resource: the shared list/retrieve plus the product-scoped
+ * sub-resources. Reviews belong to products in Shopper, so they are read
+ * from here; an addon exposing reviews on a custom model brings its own
+ * route, consumed through `store.fetch()`.
+ */
+export class ProductResource extends CollectionResource<Product> {
+  public override async list(params?: RequestParams, init?: FetchInit): Promise<ProductList> {
+    return (await super.list(params, init)) as ProductList
+  }
+
+  /**
+   * The approved reviews of a product:
+   *
+   * ```ts
+   * const { data, meta } = await sdk.store.product.reviews(slug, {
+   *   filter: { rating: 5 },
+   *   page: { size: 10 },
+   * })
+   * // meta.reviews_count, meta.average_rating, meta.rating_distribution
+   * ```
+   */
+  public async reviews(slug: string, params?: RequestParams, init?: FetchInit): Promise<ReviewList> {
+    const document = await this.client.request(`${this.path}/${slug}/reviews`, params, init)
+
+    return {
+      data: (flatten<Review>(document) ?? []) as Review[],
+      meta: (document.meta ?? {}) as ReviewList['meta'],
+      links: document.links,
+    }
+  }
+}

--- a/packages/sdk/src/store/review.ts
+++ b/packages/sdk/src/store/review.ts
@@ -1,0 +1,24 @@
+import type { Review } from '@shopperlabs/shopper-types'
+
+import type { HttpClient } from '../client'
+import type { FetchInit, RequestParams } from '../http'
+import { flatten } from '../json-api'
+
+/**
+ * Shop-wide reviews. Product reviews live on the product resource
+ * (`sdk.store.product.reviews(slug)`); this module carries what is not
+ * scoped to a single product.
+ */
+export class ReviewModule {
+  public constructor(private readonly client: HttpClient) {}
+
+  /**
+   * The most recent approved reviews across the shop, capped server-side and
+   * never paginated: the shape a testimonials widget needs.
+   */
+  public async latest(params?: RequestParams, init?: FetchInit): Promise<Review[]> {
+    const document = await this.client.request(`/${this.client.storePrefix}/reviews`, params, init)
+
+    return (flatten<Review>(document) ?? []) as Review[]
+  }
+}

--- a/packages/types/src/review.ts
+++ b/packages/types/src/review.ts
@@ -1,37 +1,31 @@
 import type { Entity } from './common'
 
 /**
- * Review model.
+ * A product review as the store API exposes it: approved reviews only, the
+ * author reduced to a display name.
  */
 export interface Review extends Entity {
-  /** Whether the review is recommended. */
-  is_recommended: boolean
-  /** The rating (usually 1-5). */
-  rating: number
   /** The title of the review. */
   title: string | null
   /** The content of the review. */
   content: string | null
-  /** Whether the review is approved. */
-  approved: boolean
-  /** The ID of the reviewable entity. */
-  reviewrateable_id: number
-  /** The type of the reviewable entity. */
-  reviewrateable_type: string
-  /** The ID of the author. */
-  author_id: number
-  /** The type of the author. */
-  author_type: string
-  /** The author of the review. */
-  author?: ReviewAuthor
+  /** The rating (1-5). */
+  rating: number
+  /** Whether the reviewer recommends the product. */
+  is_recommended: boolean
+  /** Display name of the reviewer (first name and last initial). */
+  author_name: string | null
 }
 
 /**
- * ReviewAuthor type for author information.
+ * Review aggregates returned in the `meta` of a product's reviews listing,
+ * computed server-side over the same approved predicate as the rows.
  */
-export type ReviewAuthor = {
-  last_name: string
-  first_name: string
-  /** The avatar URL (uploaded file, or a generated fallback). */
-  avatar: string
+export interface ReviewAggregates {
+  /** Total number of approved reviews. */
+  reviews_count: number
+  /** Average rating rounded to one decimal, null without reviews. */
+  average_rating: number | null
+  /** Number of approved reviews per rating value (1-5). */
+  rating_distribution: Record<number, number>
 }

--- a/packages/types/src/review.ts
+++ b/packages/types/src/review.ts
@@ -2,7 +2,7 @@ import type { Entity } from './common'
 
 /**
  * A product review as the store API exposes it: approved reviews only, the
- * author reduced to a display name.
+ * author reduced to a public-safe display identity.
  */
 export interface Review extends Entity {
   /** The title of the review. */
@@ -13,8 +13,20 @@ export interface Review extends Entity {
   rating: number
   /** Whether the reviewer recommends the product. */
   is_recommended: boolean
-  /** Display name of the reviewer (first name and last initial). */
-  author_name: string | null
+  /** The reviewer's public identity, null when the account no longer exists. */
+  author: ReviewAuthor | null
+}
+
+/**
+ * The reviewer as shown next to a review. The avatar is only present when
+ * one was uploaded; build the fallback (initials, generated image) from
+ * `name` on the storefront.
+ */
+export interface ReviewAuthor {
+  /** Display name (first name and last initial). */
+  name: string | null
+  /** URL of the uploaded avatar, null when none was uploaded. */
+  avatar: string | null
 }
 
 /**

--- a/tests/Api/Feature/ProductReviewsTest.php
+++ b/tests/Api/Feature/ProductReviewsTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+use Shopper\Core\Enum\ProductType;
+use Shopper\Core\Models\Product;
+use Shopper\Core\Models\Review;
+use Tests\Core\Stubs\User;
+
+uses(Tests\Api\TestCase::class);
+
+function reviewedProduct(): Product
+{
+    return Product::factory()->publish()->create(['type' => ProductType::Standard]);
+}
+
+function approvedReview(Product $product, array $attributes = [], ?User $author = null): Review
+{
+    return Review::factory()->create($attributes + [
+        'reviewrateable_id' => $product->id,
+        'reviewrateable_type' => $product->getMorphClass(),
+        'author_id' => ($author ?? User::factory()->create())->id,
+        'author_type' => User::class,
+        'approved' => true,
+    ]);
+}
+
+it('lists only approved reviews for a product with an anonymized author', function (): void {
+    $product = reviewedProduct();
+    $author = User::factory()->create(['first_name' => 'Arthur', 'last_name' => 'Monney']);
+
+    $review = approvedReview($product, ['rating' => 5, 'title' => 'Great'], $author);
+    approvedReview($product, ['approved' => false, 'title' => 'Pending']);
+
+    $response = $this->getJson('/store/products/'.$product->slug.'/reviews')
+        ->assertOk()
+        ->assertHeader('Content-Type', 'application/vnd.api+json')
+        ->assertJsonCount(1, 'data')
+        ->assertJsonPath('data.0.type', 'reviews')
+        ->assertJsonPath('data.0.id', $review->refresh()->public_id)
+        ->assertJsonPath('data.0.attributes.title', 'Great')
+        ->assertJsonPath('data.0.attributes.rating', 5)
+        ->assertJsonPath('data.0.attributes.author_name', 'Arthur M.');
+
+    $attributes = $response->json('data.0.attributes');
+
+    expect($attributes)->not->toHaveKeys(['author_id', 'author_type', 'approved'])
+        ->and($response->json('data.0.id'))->not->toBe((string) $review->id);
+});
+
+it('returns count, average and star distribution over the same approved predicate', function (): void {
+    $product = reviewedProduct();
+
+    foreach ([5, 5, 4, 2] as $rating) {
+        approvedReview($product, ['rating' => $rating]);
+    }
+
+    approvedReview($product, ['rating' => 1, 'approved' => false]);
+
+    $this->getJson('/store/products/'.$product->slug.'/reviews?page[size]=2')
+        ->assertOk()
+        ->assertJsonCount(2, 'data')
+        ->assertJsonPath('meta.reviews_count', 4)
+        ->assertJsonPath('meta.average_rating', 4)
+        ->assertJsonPath('meta.rating_distribution.5', 2)
+        ->assertJsonPath('meta.rating_distribution.4', 1)
+        ->assertJsonPath('meta.rating_distribution.2', 1)
+        ->assertJsonPath('meta.rating_distribution.1', 0);
+});
+
+it('filters by rating and sorts through the review allowlist', function (): void {
+    $product = reviewedProduct();
+
+    approvedReview($product, ['rating' => 5]);
+    approvedReview($product, ['rating' => 3]);
+    approvedReview($product, ['rating' => 5]);
+
+    $this->getJson('/store/products/'.$product->slug.'/reviews?filter[rating]=5')
+        ->assertOk()
+        ->assertJsonCount(2, 'data');
+
+    $ratings = collect(
+        $this->getJson('/store/products/'.$product->slug.'/reviews?sort=rating')->assertOk()->json('data')
+    )->pluck('attributes.rating');
+
+    expect($ratings->toArray())->toBe([3, 5, 5]);
+});
+
+it('returns a 404 for an unpublished product reviews listing', function (): void {
+    $product = Product::factory()->create(['type' => ProductType::Standard, 'is_visible' => false]);
+
+    $this->getJson('/store/products/'.$product->slug.'/reviews')->assertNotFound();
+});
+
+it('caps the latest reviews endpoint and never paginates it', function (): void {
+    config(['shopper.api.resources.review.latest_limit' => 3]);
+
+    $product = reviewedProduct();
+
+    foreach (range(1, 5) as $i) {
+        approvedReview($product, ['rating' => 5]);
+    }
+
+    approvedReview($product, ['approved' => false]);
+
+    $response = $this->getJson('/store/reviews?page[size]=50')
+        ->assertOk()
+        ->assertJsonCount(3, 'data');
+
+    expect($response->json('links.next'))->toBeNull();
+});
+
+it('anonymizes gracefully when the author is missing', function (): void {
+    $product = reviewedProduct();
+    $review = approvedReview($product);
+
+    $review->author()->delete();
+
+    $this->getJson('/store/products/'.$product->slug.'/reviews')
+        ->assertOk()
+        ->assertJsonPath('data.0.attributes.author_name', null);
+});

--- a/tests/Api/Feature/ProductReviewsTest.php
+++ b/tests/Api/Feature/ProductReviewsTest.php
@@ -40,7 +40,7 @@ it('lists only approved reviews for a product with an anonymized author', functi
         ->assertJsonPath('data.0.id', $review->refresh()->public_id)
         ->assertJsonPath('data.0.attributes.title', 'Great')
         ->assertJsonPath('data.0.attributes.rating', 5)
-        ->assertJsonPath('data.0.attributes.author_name', 'Arthur M.');
+        ->assertJsonPath('data.0.attributes.author.name', 'Arthur M.');
 
     $attributes = $response->json('data.0.attributes');
 
@@ -110,6 +110,27 @@ it('caps the latest reviews endpoint and never paginates it', function (): void 
     expect($response->json('links.next'))->toBeNull();
 });
 
+it('exposes the uploaded avatar or the generated fallback through the picture attribute', function (): void {
+    $product = reviewedProduct();
+
+    $withUpload = User::factory()->create([
+        'first_name' => 'Jane',
+        'last_name' => 'Doe',
+        'avatar_type' => 'storage',
+        'avatar_location' => 'avatars/jane.jpg',
+    ]);
+
+    approvedReview($product, ['rating' => 4], $withUpload);
+    approvedReview($product, ['rating' => 5]);
+
+    $avatars = collect(
+        $this->getJson('/store/products/'.$product->slug.'/reviews?sort=rating')->assertOk()->json('data')
+    )->pluck('attributes.author.avatar');
+
+    expect($avatars[0])->toContain('avatars/jane.jpg')
+        ->and($avatars[1])->toContain('ui-avatars.com');
+});
+
 it('anonymizes gracefully when the author is missing', function (): void {
     $product = reviewedProduct();
     $review = approvedReview($product);
@@ -118,5 +139,5 @@ it('anonymizes gracefully when the author is missing', function (): void {
 
     $this->getJson('/store/products/'.$product->slug.'/reviews')
         ->assertOk()
-        ->assertJsonPath('data.0.attributes.author_name', null);
+        ->assertJsonPath('data.0.attributes.author', null);
 });

--- a/tests/Core/Models/CollectionTest.php
+++ b/tests/Core/Models/CollectionTest.php
@@ -150,4 +150,44 @@ describe(Collection::class, function (): void {
 
         expect($collection)->toBeInstanceOf(Spatie\MediaLibrary\HasMedia::class);
     });
+
+    it('resolves the products of an automatic rating rule over approved reviews only', function (): void {
+        $collection = Collection::factory()->create(['type' => CollectionType::Auto, 'match_conditions' => 'all']);
+
+        CollectionRule::factory()->create([
+            'collection_id' => $collection->id,
+            'rule' => Rule::ProductRating,
+            'operator' => Operator::GreaterThan,
+            'value' => '3',
+        ]);
+
+        $highRated = Product::factory()->publish()->create();
+        $lowRated = Product::factory()->publish()->create();
+        $pendingOnly = Product::factory()->publish()->create();
+
+        Shopper\Core\Models\Review::factory()->create([
+            'reviewrateable_id' => $highRated->id,
+            'reviewrateable_type' => $highRated->getMorphClass(),
+            'rating' => 5,
+            'approved' => true,
+        ]);
+
+        Shopper\Core\Models\Review::factory()->create([
+            'reviewrateable_id' => $lowRated->id,
+            'reviewrateable_type' => $lowRated->getMorphClass(),
+            'rating' => 2,
+            'approved' => true,
+        ]);
+
+        Shopper\Core\Models\Review::factory()->create([
+            'reviewrateable_id' => $pendingOnly->id,
+            'reviewrateable_type' => $pendingOnly->getMorphClass(),
+            'rating' => 5,
+            'approved' => false,
+        ]);
+
+        $products = (new Shopper\Core\Queries\CollectionProductsQuery)->get($collection->refresh());
+
+        expect($products->pluck('id')->all())->toBe([$highRated->id]);
+    });
 })->group('collection', 'models');


### PR DESCRIPTION
Reviews already live in core with moderation built in. This exposes them to the storefront, whatever framework it is built with.

## Endpoints

- `GET /store/products/{slug}/reviews`: approved reviews of a published product, paginated, with `filter[rating]` and `sort=created_at|rating` through the config allowlist (newest first by default). The `meta` carries `reviews_count`, `average_rating` and the star `rating_distribution`, computed server-side in one aggregate query over the exact predicate the listing paginates, so the histogram can never disagree with the rows.
- `GET /store/reviews`: the most recent approved reviews across the shop, capped server-side (`latest_limit`, 20 by default, configurable) and never paginated. The shape a testimonials widget needs, without exposing the full review corpus to enumeration.

## Author identity

Each review carries `author: { name, avatar }`: a display name (first name and last initial) and the user's picture through the `picture` attribute, uploaded file or generated fallback alike. `picture` is now appended dynamically by the `HasProfilePhoto` trait, so every user serialization exposes it without per-class `$appends`. The author id, morph type and full surname never reach the public payload: published together they would let anyone rebuild a customer's purchase history. Locked by test.

## Core

`Review` gains `HasPublicId` (the JSON:API `data.id` is a stable ULID, sequential ids are no longer enumerable, same pattern as every other exposed table) and an `approved()` scope. The migration follows the `2026_06_11` precedent: `public_id` column with backfill, plus a composite index on `(reviewrateable_type, reviewrateable_id, approved, created_at)` so the per-product listing stops filesorting.

The automatic collection rating rule now builds a typed subquery through the scope, which removed a legacy phpstan suppression, and fixed a latent bug on SQLite: PDO binds floats as strings and SQLite orders any number below any text, so the `AVG(rating)` comparison never matched. The threshold is now inlined as a cast float and the rule is covered by a test.

## Types and SDK

`review.ts` is rewritten to match what the API actually serves: `Review`, `ReviewAuthor { name, avatar }` and `ReviewAggregates` for the listing meta. The previous shape (`author_id`, `author_type`, `approved`, `reviewrateable_*`) described a model no endpoint ever exposed. The SDK dependency on `@shopperlabs/shopper-types` moves from the stale `^3.0.0-beta.1` to `^3.0.0`, matching the released stable version.

The SDK gains dedicated review resources, so a storefront never touches raw URLs. Reviews belong to products in Shopper, so they read from the product resource; an addon exposing reviews on a custom model brings its own route through `store.fetch()`. `sdk.store.product.list()` also returns a typed `ProductList` whose meta carries the resolved `currency`.

The `down()` methods were removed from this branch's migrations, matching the repository convention for additive index migrations.

```ts
const { data, meta } = await sdk.store.product.reviews(slug, {
  filter: { rating: 5 },
  page: { size: 10 },
})
// meta.reviews_count, meta.average_rating, meta.rating_distribution

const latest = await sdk.store.review.latest()
```
