### PR TITLE
feat(api): scope the store catalog to a sales channel

### DIFF
--- a/packages/api/config/api.php
+++ b/packages/api/config/api.php
@@ -50,34 +50,35 @@ return [
                 'categories',
                 'collections',
                 'options',
-                'relatedProducts',
+                'relatedProducts' => Shopper\Api\Http\Includes\PublicProducts::class,
                 'rating' => Shopper\Api\Http\Includes\RatingAggregate::class,
             ],
             'include_loads' => [
                 'variants' => ['variants.prices.currency', 'variants.values.attribute'],
                 'options' => ['options.values', 'attributeProducts.media'],
-                'relatedProducts' => ['relatedProducts.prices.currency'],
             ],
         ],
         'category' => [
             'filters' => ['name' => 'partial'],
             'sorts' => ['name', 'position'],
-            'includes' => ['parent', 'children', 'products'],
-            'include_loads' => [
-                'products' => ['products.prices.currency'],
+            'includes' => [
+                'parent',
+                'children',
+                'products' => Shopper\Api\Http\Includes\PublicProducts::class,
             ],
         ],
         'collection' => [
             'filters' => ['name' => 'partial'],
             'sorts' => ['name'],
-            'includes' => [],
+            'includes' => [
+                'products' => Shopper\Api\Http\Includes\PublicProducts::class,
+            ],
         ],
         'brand' => [
             'filters' => ['name' => 'partial'],
             'sorts' => ['name', 'position'],
-            'includes' => ['products'],
-            'include_loads' => [
-                'products' => ['products.prices.currency'],
+            'includes' => [
+                'products' => Shopper\Api\Http\Includes\PublicProducts::class,
             ],
         ],
         'attribute' => [

--- a/packages/api/src/Concerns/ResolvesChannel.php
+++ b/packages/api/src/Concerns/ResolvesChannel.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Api\Concerns;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Shopper\Api\Http\Includes\PublicProducts;
+use Shopper\Core\Models\Contracts\Channel;
+
+trait ResolvesChannel
+{
+    /**
+     * Restrict the catalog to the sales channel resolved for the request,
+     * when one is. The channel is a soft context: without one the catalog
+     * stays unfiltered, mirroring how the zone drives pricing.
+     *
+     * @template TModel of Model
+     *
+     * @param  Builder<TModel>  $query
+     * @return Builder<TModel>
+     */
+    protected function applyChannelScope(Builder $query): Builder
+    {
+        $channel = $this->resolvedChannel();
+
+        if ($channel !== null) {
+            $query->scopes(['channel' => [[$channel->id]]]);
+        }
+
+        return $query;
+    }
+
+    /**
+     * Eager-load a products relation through the public catalog constraints on
+     * the endpoints that read a single record, where no query builder installs
+     * the custom include. Without it the relation is lazy-loaded at
+     * serialization time, unfiltered.
+     *
+     * @template TModel of Model
+     *
+     * @param  Builder<TModel>  $query
+     * @return Builder<TModel>
+     */
+    protected function withPublicProducts(Builder $query, string $relation = 'products'): Builder
+    {
+        if (! $this->requestedIncludes()->contains($relation)) {
+            return $query;
+        }
+
+        return $query->with([$relation => PublicProducts::constraint()]);
+    }
+
+    protected function resolvedChannel(): ?Channel
+    {
+        $channel = request()->attributes->get('shopper_channel');
+
+        return $channel instanceof Channel ? $channel : null;
+    }
+}

--- a/packages/api/src/Http/Controllers/Catalog/BrandController.php
+++ b/packages/api/src/Http/Controllers/Catalog/BrandController.php
@@ -6,6 +6,7 @@ namespace Shopper\Api\Http\Controllers\Catalog;
 
 use Shopper\Api\Concerns\BuildsApiQueries;
 use Shopper\Api\Concerns\LoadsStock;
+use Shopper\Api\Concerns\ResolvesChannel;
 use Shopper\Api\Http\Resources\BrandResource;
 use Shopper\Core\Models\Contracts\Brand;
 use TiMacDonald\JsonApi\JsonApiResource;
@@ -15,6 +16,7 @@ final class BrandController
 {
     use BuildsApiQueries;
     use LoadsStock;
+    use ResolvesChannel;
 
     public function index(): JsonApiResourceCollection
     {
@@ -29,8 +31,10 @@ final class BrandController
 
     public function show(string $slug): JsonApiResource
     {
-        $brand = $this->withMediaIfSupported(resolve(Brand::class)::query()->enabled())
-            ->with($this->requestedIncludeLoads('brand'))
+        $brand = $this->withPublicProducts(
+            $this->withMediaIfSupported(resolve(Brand::class)::query()->enabled())
+                ->with($this->requestedIncludeLoads('brand'))
+        )
             ->where('slug', $slug)
             ->firstOrFail();
 

--- a/packages/api/src/Http/Controllers/Catalog/CategoryController.php
+++ b/packages/api/src/Http/Controllers/Catalog/CategoryController.php
@@ -6,6 +6,7 @@ namespace Shopper\Api\Http\Controllers\Catalog;
 
 use Shopper\Api\Concerns\BuildsApiQueries;
 use Shopper\Api\Concerns\LoadsStock;
+use Shopper\Api\Concerns\ResolvesChannel;
 use Shopper\Api\Http\Resources\CategoryResource;
 use Shopper\Core\Models\Contracts\Category;
 use TiMacDonald\JsonApi\JsonApiResource;
@@ -15,6 +16,7 @@ final class CategoryController
 {
     use BuildsApiQueries;
     use LoadsStock;
+    use ResolvesChannel;
 
     public function index(): JsonApiResourceCollection
     {
@@ -29,8 +31,10 @@ final class CategoryController
 
     public function show(string $slug): JsonApiResource
     {
-        $category = $this->withMediaIfSupported(resolve(Category::class)::query()->enabled())
-            ->with($this->requestedIncludeLoads('category'))
+        $category = $this->withPublicProducts(
+            $this->withMediaIfSupported(resolve(Category::class)::query()->enabled())
+                ->with($this->requestedIncludeLoads('category'))
+        )
             ->where('slug', $slug)
             ->firstOrFail();
 

--- a/packages/api/src/Http/Controllers/Catalog/CollectionController.php
+++ b/packages/api/src/Http/Controllers/Catalog/CollectionController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Shopper\Api\Http\Controllers\Catalog;
 
 use Shopper\Api\Concerns\BuildsApiQueries;
+use Shopper\Api\Concerns\ResolvesChannel;
 use Shopper\Api\Http\Resources\CollectionResource;
 use Shopper\Core\Models\Contracts\Collection;
 use TiMacDonald\JsonApi\JsonApiResource;
@@ -13,6 +14,7 @@ use TiMacDonald\JsonApi\JsonApiResourceCollection;
 final class CollectionController
 {
     use BuildsApiQueries;
+    use ResolvesChannel;
 
     public function index(): JsonApiResourceCollection
     {
@@ -23,7 +25,9 @@ final class CollectionController
 
     public function show(string $slug): JsonApiResource
     {
-        $collection = $this->withMediaIfSupported(resolve(Collection::class)::query()->published())
+        $collection = $this->withPublicProducts(
+            $this->withMediaIfSupported(resolve(Collection::class)::query()->published())
+        )
             ->where('slug', $slug)
             ->firstOrFail();
 

--- a/packages/api/src/Http/Controllers/Catalog/ProductController.php
+++ b/packages/api/src/Http/Controllers/Catalog/ProductController.php
@@ -9,6 +9,7 @@ use Shopper\Api\Concerns\BuildsApiQueries;
 use Shopper\Api\Concerns\HandlesPriceQueries;
 use Shopper\Api\Concerns\LoadsPriceRange;
 use Shopper\Api\Concerns\LoadsStock;
+use Shopper\Api\Concerns\ResolvesChannel;
 use Shopper\Api\Concerns\ResolvesCurrency;
 use Shopper\Api\Http\Includes\RatingAggregate;
 use Shopper\Api\Http\Resources\ProductResource;
@@ -22,6 +23,7 @@ final class ProductController
     use HandlesPriceQueries;
     use LoadsPriceRange;
     use LoadsStock;
+    use ResolvesChannel;
     use ResolvesCurrency;
 
     public function index(): JsonApiResourceCollection
@@ -37,6 +39,8 @@ final class ProductController
         $query = $this->withMediaIfSupported(
             resolve(Product::class)::query()->publish()->with('prices.currency')
         );
+
+        $this->applyChannelScope($query);
 
         if ($currency !== null && $this->wantsPriceQuery()) {
             $this->applyPriceAggregate($query, $currency->id);
@@ -64,6 +68,9 @@ final class ProductController
         )
             ->with($this->requestedIncludeLoads('product'))
             ->where('slug', $slug);
+
+        $this->applyChannelScope($query);
+        $this->withPublicProducts($query, 'relatedProducts');
 
         if ($this->requestedIncludes()->contains('rating')) {
             (new RatingAggregate)($query, 'rating');

--- a/packages/api/src/Http/Includes/PublicProducts.php
+++ b/packages/api/src/Http/Includes/PublicProducts.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Api\Http\Includes;
+
+use Closure;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Shopper\Core\Models\Contracts\Channel;
+use Spatie\QueryBuilder\Includes\IncludeInterface;
+
+final class PublicProducts implements IncludeInterface
+{
+    public function __invoke(Builder $query, string $include): void
+    {
+        $query->with([$include => self::constraint()]);
+    }
+
+    /**
+     * Published, restricted to the sales channel resolved for the request, and
+     * carrying the prices the resources serialize.
+     */
+    public static function constraint(): Closure
+    {
+        return function (Relation $products): void {
+            $query = $products->getQuery()->scopes(['publish'])->with('prices.currency');
+
+            $channel = request()->attributes->get('shopper_channel');
+
+            if ($channel instanceof Channel) {
+                $query->scopes(['channel' => [[$channel->id]]]);
+            }
+        };
+    }
+}

--- a/packages/http/config/http.php
+++ b/packages/http/config/http.php
@@ -56,6 +56,25 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Channel resolution
+    |--------------------------------------------------------------------------
+    |
+    | The sales channel is a soft catalog context, never a hard gate. Channels
+    | are matched by their unique "slug". The resolver is swappable: provide
+    | your own implementation to resolve a channel from a domain, an API key,
+    | or any custom strategy. When nothing resolves, the request proceeds with
+    | a null channel and the catalog stays unfiltered.
+    |
+    */
+    'channel' => [
+        'resolver' => Shopper\Http\Channel\DefaultChannelResolver::class,
+        'header' => 'X-Shopper-Channel',
+        'default_slug' => env('SHOPPER_API_DEFAULT_CHANNEL'),
+        'cache_ttl' => 60,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Extra middleware
     |--------------------------------------------------------------------------
     |

--- a/packages/http/src/Channel/DefaultChannelResolver.php
+++ b/packages/http/src/Channel/DefaultChannelResolver.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Http\Channel;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+use Shopper\Core\Models\Contracts\Channel as ChannelContract;
+use Shopper\Http\Contracts\ChannelResolver;
+
+final class DefaultChannelResolver implements ChannelResolver
+{
+    /**
+     * The header value is attacker-controlled: hashing keeps the cache key at
+     * a fixed length and free of characters a store could reject, no matter
+     * what the client sends.
+     */
+    public static function cacheKey(string $slug): string
+    {
+        return 'shopper.http.channel.'.hash('xxh128', $slug);
+    }
+
+    public function resolve(Request $request): ?ChannelContract
+    {
+        $slug = $request->header((string) config('shopper.http.channel.header', 'X-Shopper-Channel'));
+
+        if (filled($slug)) {
+            $channel = $this->channelBySlug((string) $slug);
+
+            if ($channel !== null) {
+                return $channel;
+            }
+        }
+
+        $default = config('shopper.http.channel.default_slug');
+
+        if (filled($default)) {
+            return $this->channelBySlug((string) $default);
+        }
+
+        return null;
+    }
+
+    private function channelBySlug(string $slug): ?ChannelContract
+    {
+        if (mb_strlen($slug) > 64) {
+            return null;
+        }
+
+        $ttl = (int) config('shopper.http.channel.cache_ttl', 60);
+
+        $query = fn (): ?ChannelContract => resolve(ChannelContract::class)::query()
+            ->where('is_enabled', true)
+            ->where('slug', $slug)
+            ->first();
+
+        if ($ttl <= 0) {
+            return $query();
+        }
+
+        return Cache::remember(self::cacheKey($slug), $ttl, $query);
+    }
+}

--- a/packages/http/src/Contracts/ChannelResolver.php
+++ b/packages/http/src/Contracts/ChannelResolver.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Http\Contracts;
+
+use Illuminate\Http\Request;
+use Shopper\Core\Models\Contracts\Channel;
+
+interface ChannelResolver
+{
+    public function resolve(Request $request): ?Channel;
+}

--- a/packages/http/src/HttpServiceProvider.php
+++ b/packages/http/src/HttpServiceProvider.php
@@ -11,12 +11,16 @@ use Illuminate\Http\Request;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\RateLimiter;
+use Shopper\Core\Models\Channel;
 use Shopper\Core\Models\Zone;
+use Shopper\Http\Channel\DefaultChannelResolver;
+use Shopper\Http\Contracts\ChannelResolver;
 use Shopper\Http\Contracts\ZoneResolver;
 use Shopper\Http\Enum\RateLimit;
 use Shopper\Http\Exceptions\JsonApiErrorRenderer;
 use Shopper\Http\Middleware\EnsureJsonApiResponse;
 use Shopper\Http\Middleware\NegotiateLocale;
+use Shopper\Http\Middleware\ResolveChannel;
 use Shopper\Http\Middleware\ResolveCustomer;
 use Shopper\Http\Middleware\ResolveZone;
 use Shopper\Http\Zone\DefaultZoneResolver;
@@ -40,6 +44,11 @@ final class HttpServiceProvider extends PackageServiceProvider
             fn ($app): ZoneResolver => $app->make((string) config('shopper.http.zone.resolver', DefaultZoneResolver::class)),
         );
 
+        $this->app->bind(
+            ChannelResolver::class,
+            fn ($app): ChannelResolver => $app->make((string) config('shopper.http.channel.resolver', DefaultChannelResolver::class)),
+        );
+
         $this->app->singleton(ShopperApiRouter::class);
     }
 
@@ -54,6 +63,21 @@ final class HttpServiceProvider extends PackageServiceProvider
         $this->registerMiddleware();
         $this->registerExceptionRenderer();
         $this->registerZoneCacheInvalidation();
+        $this->registerChannelCacheInvalidation();
+    }
+
+    private function registerChannelCacheInvalidation(): void
+    {
+        $forget = static function (Channel $channel): void {
+            Cache::forget(DefaultChannelResolver::cacheKey((string) $channel->slug));
+
+            if ($channel->wasChanged('slug')) {
+                Cache::forget(DefaultChannelResolver::cacheKey((string) $channel->getOriginal('slug')));
+            }
+        };
+
+        Channel::saved($forget);
+        Channel::deleted($forget);
     }
 
     private function registerZoneCacheInvalidation(): void
@@ -113,6 +137,7 @@ final class HttpServiceProvider extends PackageServiceProvider
             EnsureJsonApiResponse::class,
             NegotiateLocale::class,
             ResolveZone::class,
+            ResolveChannel::class,
         ], (array) config('shopper.http.middleware.store', [])));
 
         $router->middlewareGroup('shopper:store-auth', array_merge([
@@ -120,6 +145,7 @@ final class HttpServiceProvider extends PackageServiceProvider
             EnsureJsonApiResponse::class,
             NegotiateLocale::class,
             ResolveZone::class,
+            ResolveChannel::class,
             'auth:sanctum',
             ResolveCustomer::class,
         ], (array) config('shopper.http.middleware.authenticated', [])));

--- a/packages/http/src/Middleware/ResolveChannel.php
+++ b/packages/http/src/Middleware/ResolveChannel.php
@@ -6,21 +6,21 @@ namespace Shopper\Http\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;
-use Shopper\Http\Contracts\ZoneResolver;
+use Shopper\Http\Contracts\ChannelResolver;
 use Shopper\Http\Support\Vary;
 use Symfony\Component\HttpFoundation\Response;
 
-final class ResolveZone
+final class ResolveChannel
 {
-    public function __construct(private readonly ZoneResolver $resolver) {}
+    public function __construct(private readonly ChannelResolver $resolver) {}
 
     public function handle(Request $request, Closure $next): Response
     {
-        $request->attributes->set('shopper_zone', $this->resolver->resolve($request));
+        $request->attributes->set('shopper_channel', $this->resolver->resolve($request));
 
         $response = $next($request);
 
-        Vary::add($response, (string) config('shopper.http.zone.header', 'X-Shopper-Zone'));
+        Vary::add($response, (string) config('shopper.http.channel.header', 'X-Shopper-Channel'));
 
         return $response;
     }

--- a/packages/http/src/Support/Vary.php
+++ b/packages/http/src/Support/Vary.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Http\Support;
+
+use Symfony\Component\HttpFoundation\Response;
+
+final class Vary
+{
+    /**
+     * Merge a header name into the response Vary list, keeping it a single
+     * comma separated line. Symfony appends a second Vary header instead
+     * when asked not to replace, a shape shared caches handle poorly.
+     */
+    public static function add(Response $response, string $header): void
+    {
+        $response->setVary(implode(', ', array_unique([...$response->getVary(), $header])));
+    }
+}

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -39,6 +39,12 @@ export interface ShopperConfig {
    * translated content (country names, translatable addons, ...).
    */
   locale?: string
+  /**
+   * Sales channel slug sent as the X-Shopper-Channel header on every
+   * request. The catalog endpoints then only return the products attached
+   * to that channel; without it the catalog stays unfiltered.
+   */
+  channel?: string
   /** Extra headers merged into every request (auth tokens, locale, ...). */
   headers?: Record<string, string>
   /** Custom fetch implementation (defaults to the global fetch). */
@@ -66,10 +72,13 @@ export class HttpClient {
 
   private locale: string | null
 
+  private channel: string | null
+
   public constructor(config: ShopperConfig) {
     this.baseUrl = config.baseUrl.replace(/\/$/, '')
     this.storePrefix = (config.storePrefix ?? 'store').replace(/^\/|\/$/g, '')
     this.locale = config.locale ?? null
+    this.channel = config.channel ?? null
     this.headers = config.headers ?? {}
     this.tokens = config.tokenStorage ?? new MemoryTokenStorage()
     // Bind to the global so the browser fetch keeps `this === window`
@@ -83,6 +92,15 @@ export class HttpClient {
 
   public getLocale(): string | null {
     return this.locale
+  }
+
+  /** Switch the sales channel of subsequent calls; null reverts to the unfiltered catalog. */
+  public setChannel(channel: string | null): void {
+    this.channel = channel
+  }
+
+  public getChannel(): string | null {
+    return this.channel
   }
 
   public async request(path: string, options?: FetchOptions, init?: FetchInit): Promise<JsonApiDocument> {
@@ -114,6 +132,7 @@ export class HttpClient {
         ...(body !== undefined && ! isForm ? { 'Content-Type': 'application/json' } : {}),
         ...(token !== null ? { Authorization: `Bearer ${token}` } : {}),
         ...(this.locale !== null ? { 'Accept-Language': this.locale } : {}),
+        ...(this.channel !== null ? { 'X-Shopper-Channel': this.channel } : {}),
         ...this.headers,
         ...initHeaders,
       },

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -37,6 +37,15 @@ export default class Shopper {
   public getLocale(): string | null {
     return this.client.getLocale()
   }
+
+  /** Switch the sales channel of subsequent calls; null reverts to the unfiltered catalog. */
+  public setChannel(channel: string | null): void {
+    this.client.setChannel(channel)
+  }
+
+  public getChannel(): string | null {
+    return this.client.getChannel()
+  }
 }
 
 export type { ShopperConfig, TokenStorage } from './client'

--- a/tests/Api/Feature/ProductChannelScopingTest.php
+++ b/tests/Api/Feature/ProductChannelScopingTest.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+use Shopper\Core\Enum\ProductType;
+use Shopper\Core\Models\Brand;
+use Shopper\Core\Models\Category;
+use Shopper\Core\Models\Channel;
+use Shopper\Core\Models\Collection;
+use Shopper\Core\Models\Product;
+
+uses(Tests\Api\TestCase::class);
+
+function channelProduct(string $name, ?Channel $channel = null): Product
+{
+    $product = Product::factory()->publish()->create(['name' => $name, 'type' => ProductType::Standard]);
+
+    if ($channel !== null) {
+        $product->channels()->attach($channel->id);
+    }
+
+    return $product;
+}
+
+function hiddenProduct(string $name): Product
+{
+    return Product::factory()->create(['name' => $name, 'type' => ProductType::Standard, 'is_visible' => false]);
+}
+
+/**
+ * @return array<int, string>
+ */
+function includedProductNames(object $test, string $path, array $headers = []): array
+{
+    return collect($test->getJson($path, $headers)->assertOk()->json('included'))
+        ->where('type', 'products')
+        ->pluck('attributes.name')
+        ->all();
+}
+
+function webstoreChannel(): Channel
+{
+    return Channel::factory()->create(['slug' => 'webstore', 'is_enabled' => true, 'is_default' => false]);
+}
+
+it('restricts the products listing to the channel resolved from the header', function (): void {
+    $channel = webstoreChannel();
+
+    channelProduct('On Webstore', $channel);
+    channelProduct('Unattached');
+
+    $response = $this->getJson('/store/products', ['X-Shopper-Channel' => 'webstore'])->assertOk();
+
+    $names = collect($response->json('data'))->pluck('attributes.name');
+
+    expect($names->all())->toBe(['On Webstore'])
+        ->and($response->headers->all('Vary'))->toHaveCount(1)
+        ->and($response->headers->get('Vary'))->toContain('X-Shopper-Channel')
+        ->toContain('X-Shopper-Zone');
+});
+
+it('keeps the catalog unfiltered without a channel header or when the slug is unknown', function (): void {
+    channelProduct('On Webstore', webstoreChannel());
+    channelProduct('Unattached');
+
+    $this->getJson('/store/products')->assertOk()->assertJsonCount(2, 'data');
+    $this->getJson('/store/products', ['X-Shopper-Channel' => 'unknown'])->assertOk()->assertJsonCount(2, 'data');
+});
+
+it('returns a 404 for a product not attached to the resolved channel', function (): void {
+    $channel = webstoreChannel();
+    $product = channelProduct('Unattached');
+
+    $this->getJson('/store/products/'.$product->slug, ['X-Shopper-Channel' => 'webstore'])->assertNotFound();
+    $this->getJson('/store/products/'.$product->slug)->assertOk();
+
+    $attached = channelProduct('On Webstore', $channel);
+
+    $this->getJson('/store/products/'.$attached->slug, ['X-Shopper-Channel' => 'webstore'])->assertOk();
+});
+
+it('scopes the products included through a category or a brand to the same channel', function (): void {
+    $channel = webstoreChannel();
+    $category = Category::factory()->create(['slug' => 'lighting', 'is_enabled' => true]);
+    $brand = Brand::factory()->create(['slug' => 'aurora', 'is_enabled' => true]);
+
+    $onChannel = channelProduct('On Webstore', $channel);
+    $offChannel = channelProduct('Unattached');
+    $hidden = hiddenProduct('Hidden');
+
+    foreach ([$onChannel, $offChannel, $hidden] as $product) {
+        $product->categories()->attach($category->id);
+        $product->update(['brand_id' => $brand->id]);
+    }
+
+    $headers = ['X-Shopper-Channel' => 'webstore'];
+
+    expect(includedProductNames($this, '/store/categories/lighting?include=products', $headers))->toBe(['On Webstore'])
+        ->and(includedProductNames($this, '/store/brands/aurora?include=products', $headers))->toBe(['On Webstore'])
+        ->and(includedProductNames($this, '/store/categories?include=products', $headers))->toBe(['On Webstore'])
+        ->and(includedProductNames($this, '/store/brands?include=products', $headers))->toBe(['On Webstore']);
+});
+
+it('never exposes an unpublished product through an include', function (): void {
+    $brand = Brand::factory()->create(['slug' => 'aurora', 'is_enabled' => true]);
+
+    Product::factory()->publish()->create(['name' => 'Published', 'type' => ProductType::Standard, 'brand_id' => $brand->id]);
+    Product::factory()->create(['name' => 'Hidden', 'type' => ProductType::Standard, 'is_visible' => false, 'brand_id' => $brand->id]);
+
+    expect(includedProductNames($this, '/store/brands/aurora?include=products'))->toBe(['Published'])
+        ->and(includedProductNames($this, '/store/brands?include=products'))->toBe(['Published']);
+});
+
+it('scopes the products included through a collection to the same channel', function (): void {
+    $channel = webstoreChannel();
+    $collection = Collection::factory()->create(['slug' => 'summer', 'published_at' => now()->subDay()]);
+
+    $onChannel = channelProduct('On Webstore', $channel);
+    $offChannel = channelProduct('Unattached');
+    $hidden = hiddenProduct('Hidden');
+
+    foreach ([$onChannel, $offChannel, $hidden] as $product) {
+        $product->collections()->attach($collection->id);
+    }
+
+    expect(includedProductNames($this, '/store/collections/summer?include=products', ['X-Shopper-Channel' => 'webstore']))
+        ->toBe(['On Webstore'])
+        ->and(includedProductNames($this, '/store/collections/summer?include=products'))
+        ->toBe(['On Webstore', 'Unattached']);
+});
+
+it('scopes the related products of a product to the same channel', function (): void {
+    $channel = webstoreChannel();
+
+    $product = channelProduct('Main', $channel);
+    $onChannel = channelProduct('Related On Webstore', $channel);
+    $offChannel = channelProduct('Related Unattached');
+    $hidden = hiddenProduct('Related Hidden');
+
+    $product->relatedProducts()->attach([$onChannel->id, $offChannel->id, $hidden->id]);
+
+    $headers = ['X-Shopper-Channel' => 'webstore'];
+
+    expect(includedProductNames($this, '/store/products/'.$product->slug.'?include=relatedProducts', $headers))
+        ->toBe(['Related On Webstore'])
+        ->and(includedProductNames($this, '/store/products?include=relatedProducts', $headers))
+        ->toBe(['Related On Webstore']);
+});
+
+it('never resolves a disabled channel', function (): void {
+    $channel = Channel::factory()->create(['slug' => 'webstore', 'is_enabled' => false, 'is_default' => false]);
+
+    channelProduct('On Webstore', $channel);
+    channelProduct('Unattached');
+
+    $this->getJson('/store/products', ['X-Shopper-Channel' => 'webstore'])->assertOk()->assertJsonCount(2, 'data');
+});

--- a/tests/Http/Feature/ChannelResolutionTest.php
+++ b/tests/Http/Feature/ChannelResolutionTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Http\Request;
+use Shopper\Core\Models\Channel;
+use Shopper\Http\Contracts\ChannelResolver;
+
+uses(Tests\Http\TestCase::class);
+
+function resolvableChannel(string $slug, bool $enabled = true): Channel
+{
+    return Channel::factory()->create([
+        'slug' => $slug,
+        'is_enabled' => $enabled,
+        'is_default' => false,
+    ]);
+}
+
+it('resolves an enabled channel by its slug from the request header', function (): void {
+    $channel = resolvableChannel('webstore');
+
+    $request = Request::create('/store/anything');
+    $request->headers->set('X-Shopper-Channel', 'webstore');
+
+    expect(app(ChannelResolver::class)->resolve($request)?->getKey())->toBe($channel->getKey());
+});
+
+it('falls back to the configured default slug when no header is present', function (): void {
+    config()->set('shopper.http.channel.default_slug', 'mobile-app');
+    resolvableChannel('mobile-app');
+
+    $resolved = app(ChannelResolver::class)->resolve(Request::create('/store/anything'));
+
+    expect($resolved?->slug)->toBe('mobile-app');
+});
+
+it('returns null when no channel resolves and no default is configured', function (): void {
+    $request = Request::create('/store/anything');
+    $request->headers->set('X-Shopper-Channel', 'unknown-channel');
+
+    expect(app(ChannelResolver::class)->resolve($request))->toBeNull();
+});
+
+it('ignores disabled channels', function (): void {
+    resolvableChannel('webstore', enabled: false);
+
+    $request = Request::create('/store/anything');
+    $request->headers->set('X-Shopper-Channel', 'webstore');
+
+    expect(app(ChannelResolver::class)->resolve($request))->toBeNull();
+});


### PR DESCRIPTION
Resolves a sales channel per request and restricts the store catalog to it, mirroring how the zone is already resolved for pricing.

## Channel resolution

A `ChannelResolver` contract, resolved through config, reads the `X-Shopper-Channel` header and matches an enabled channel by its slug. The resolution is cached, keyed by a hash of the header value so a client controlled string can never shape the cache key, and invalidated whenever a channel is saved or deleted, including under its previous slug after a rename.

The resolver is swappable: an implementation can resolve the channel from a domain, an API key, or any strategy the shop needs.

```php
'channel' => [
    'resolver' => Shopper\Http\Channel\DefaultChannelResolver::class,
    'header' => 'X-Shopper-Channel',
    'default_slug' => env('SHOPPER_API_DEFAULT_CHANNEL'),
    'cache_ttl' => 60,
],
```

The channel is a soft context, never an access gate: when nothing resolves, the catalog stays unfiltered and the request proceeds, exactly like a request without a zone.

## Public catalog constraint

Every products relation exposed through an include now goes through a single constraint: published, restricted to the resolved channel, with the prices the resources serialize. It is applied as a custom include so the query builder installs it last.

This closes a way around the scoping that a relationship include left open. Eloquent merges eager loads by relation name, so an include registered by the query builder overwrote a constraint set on the query beforehand and the relation went out unfiltered, unpublished products included. The constraint now covers `products` on categories, brands and collections, and `relatedProducts` on products, on both the listing and the single record endpoints.

## SDK

The channel travels as a header, so a storefront sets it once:

```ts
const sdk = new Shopper({ baseUrl: 'https://my-store.com', channel: 'webstore' })

const { data } = await sdk.store.product.list()
```

`sdk.setChannel()` switches it at runtime, and `null` reverts to the unfiltered catalog.

## Vary

Two middleware now contribute to `Vary`. Symfony appends a second header line rather than extending the list, a shape shared caches handle inconsistently, so the header is merged into a single comma separated line.

## Upgrading

Nothing changes for a shop that sets neither the header nor `SHOPPER_API_DEFAULT_CHANNEL`: the catalog is served exactly as before.

Products carry channels through an opt-in relation, and only the admin product form pre-fills the default channel. A catalog created by CSV import, a seeder or the API has no channel attached, and those products stop being served once a default channel is configured. Attach them before enabling one:

```php
$channelId = Channel::query()->where('slug', 'webstore')->value('id');

Product::query()
    ->whereDoesntHave('channels')
    ->each(fn (Product $product) => $product->channels()->attach($channelId));
```

Shared caches keyed before this change are not partitioned by channel, so purging `/store/*` is recommended when rolling it out behind a CDN.
