### PR TITLE
feat(api): expose the generated image conversions on media payloads

### DIFF
--- a/packages/api/src/Concerns/SerializesMedia.php
+++ b/packages/api/src/Concerns/SerializesMedia.php
@@ -81,10 +81,27 @@ trait SerializesMedia
         return [
             'id' => $media->uuid,
             'url' => $media->getFullUrl(),
+            'conversions' => $this->conversionUrls($media),
             'name' => $media->name,
             'extension' => $media->extension,
             'created_at' => $media->created_at?->toIso8601String(),
             'updated_at' => $media->updated_at?->toIso8601String(),
         ];
+    }
+
+    /**
+     * The resized variants a storefront should display instead of the original.
+     * Read from the media row rather than from the configured conversions, so
+     * an image uploaded before a conversion existed never advertises a url
+     * pointing at a file that was never written.
+     *
+     * @return array<string, string>
+     */
+    private function conversionUrls(Media $media): array
+    {
+        return $media->getGeneratedConversions()
+            ->filter()
+            ->map(fn (mixed $generated, string $name): string => $media->getFullUrl($name))
+            ->all();
     }
 }

--- a/packages/types/src/media.ts
+++ b/packages/types/src/media.ts
@@ -1,6 +1,14 @@
 export interface Media {
   id: string | number
+  /** The original file, at the size it was uploaded. */
   url: string
+  /**
+   * The resized variants, keyed by the conversion names configured for the
+   * shop (`large` and `medium` out of the box). Display these rather than
+   * `url` on listings and thumbnails. A conversion added after an image was
+   * uploaded stays absent until the media is regenerated, so read defensively.
+   */
+  conversions?: Record<string, string>
   name?: string | null
   extension?: string | null
   created_at?: string

--- a/tests/Api/Feature/MediaConversionsTest.php
+++ b/tests/Api/Feature/MediaConversionsTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Http\UploadedFile;
+use Shopper\Core\Enum\ProductType;
+use Tests\Core\Stubs\Product;
+
+uses(Tests\Api\TestCase::class);
+
+function productWithImage(string $name): Product
+{
+    $product = Product::factory()->publish()->create(['name' => $name, 'type' => ProductType::Standard]);
+
+    $product->addMedia(UploadedFile::fake()->image('shot.png', 900, 900))
+        ->toMediaCollection((string) config('shopper.media.storage.collection_name'));
+
+    return $product;
+}
+
+it('serves every generated conversion next to the original image', function (): void {
+    $product = productWithImage('Camera');
+
+    $thumbnail = $this->getJson('/store/products/'.$product->slug)
+        ->assertOk()
+        ->json('data.attributes.thumbnail');
+
+    expect($thumbnail['conversions'])->toHaveKeys(['large', 'medium'])
+        ->and($thumbnail['conversions']['medium'])->toContain('conversions/shot-medium.png')
+        ->and($thumbnail['conversions']['medium'])->not->toBe($thumbnail['url']);
+});
+
+it('never serves a conversion that was not generated for the media', function (): void {
+    config(['shopper.media.conversions' => []]);
+
+    $product = productWithImage('Lens');
+
+    $this->getJson('/store/products/'.$product->slug)
+        ->assertOk()
+        ->assertJsonPath('data.attributes.thumbnail.conversions', []);
+});


### PR DESCRIPTION
The shop already configures two image conversions through `shopper.media.conversions`, `large` at 800px and `medium` at 500px. The `HasMedia` trait registers them and media library writes them to disk on every upload.

Nothing ever served them. The admin calls `getThumbnailUrl()` without a conversion name everywhere, and the media payload carried only the original url. Every variant was generated on every upload and reached no one, so a storefront downloaded a full size image for each thumbnail in a product grid.

## What changes

Media payloads carry a `conversions` map next to the original, on the five resources that serialize media: product, variant, category, brand and collection.

```json
"thumbnail": {
  "id": "7857d969-18b6-43bc-be51-615f02157098",
  "url": "https://shop.test/storage/1/shot.png",
  "conversions": {
    "large": "https://shop.test/storage/1/conversions/shot-large.png",
    "medium": "https://shop.test/storage/1/conversions/shot-medium.png"
  }
}
```

The list is read from the media row through `getGeneratedConversions()` rather than from the configured conversions. That keeps the `api` package away from the media config owned by the `admin` package, it is true per media rather than globally, and an image uploaded before a conversion existed never advertises a url pointing at a file that was never written.

Emptying `shopper.media.conversions` still disables the whole thing with no extra code: nothing is generated, so the map comes back empty.

`Media.conversions` is added to `@shopperlabs/shopper-types` as an optional record, since a client must read it defensively for the case above.

## Upgrading

Nothing to run. The conversions this exposes are the ones every installation has been generating all along.

A shop whose oldest media predate a given conversion will see the key missing for those, until `php artisan media-library:regenerate --only-missing` is run.
