### PR TITLE
feat: storefront listing API

### DIFF
--- a/packages/api/config/api.php
+++ b/packages/api/config/api.php
@@ -37,7 +37,9 @@ return [
                 'sku' => 'exact',
                 'q' => ['scope', 'matching'],
                 'featured' => 'exact',
+                'in_stock' => ['scope', 'availability'],
                 'category' => 'scope',
+                'category_tree' => ['scope', 'categoryTree'],
                 'collection' => ['scope', 'collection'],
                 'brand' => ['scope', 'byBrand'],
                 'tag' => ['scope', 'tag'],
@@ -47,11 +49,13 @@ return [
             'includes' => [
                 'brand' => Shopper\Api\Http\Includes\EnabledRelation::class,
                 'variants',
-                'categories' => Shopper\Api\Http\Includes\EnabledRelation::class,
+                'categories' => Shopper\Api\Http\Includes\VisibleCategories::class,
                 'collections' => Shopper\Api\Http\Includes\PublishedRelation::class,
                 'options',
+                'tags',
                 'relatedProducts' => Shopper\Api\Http\Includes\PublicProducts::class,
                 'rating' => Shopper\Api\Http\Includes\RatingAggregate::class,
+                'price_range' => Shopper\Api\Http\Includes\ListingPriceRange::class,
             ],
             'include_loads' => [
                 'variants' => ['variants.prices.currency', 'variants.values.attribute'],
@@ -65,11 +69,14 @@ return [
             'includes' => [
                 'parent' => Shopper\Api\Http\Includes\EnabledRelation::class,
                 'children' => Shopper\Api\Http\Includes\EnabledRelation::class,
+                'ancestors' => Shopper\Api\Http\Includes\EnabledRelation::class,
                 'products' => Shopper\Api\Http\Includes\PublicProducts::class,
+                'products_count' => Shopper\Api\Http\Includes\SubtreeProductsCount::class,
             ],
             'include_loads' => [
                 'parent' => ['parent.parent'],
                 'children' => ['children.parent'],
+                'ancestors' => ['ancestors.parent', 'ancestors.media'],
             ],
         ],
         'collection' => [
@@ -90,6 +97,13 @@ return [
             'filters' => ['name' => 'partial'],
             'sorts' => ['name', 'position'],
             'includes' => [],
+        ],
+        'tag' => [
+            'filters' => ['name' => 'partial'],
+            'sorts' => ['name'],
+            'includes' => [
+                'products' => Shopper\Api\Http\Includes\PublicProducts::class,
+            ],
         ],
         'country' => [
             'filters' => [

--- a/packages/api/resources/lang/en/messages.php
+++ b/packages/api/resources/lang/en/messages.php
@@ -43,6 +43,7 @@ return [
     'catalog' => [
         'unknown_currency' => 'The ":code" currency is unknown or not enabled on this shop.',
         'no_currency' => 'Price sorting and filtering need a configured currency on the shop.',
+        'filter_too_wide' => 'A filter accepts at most :max values.',
     ],
 
     'promotion' => [

--- a/packages/api/resources/lang/es/messages.php
+++ b/packages/api/resources/lang/es/messages.php
@@ -43,6 +43,7 @@ return [
     'catalog' => [
         'unknown_currency' => 'La moneda ":code" es desconocida o no está habilitada en esta tienda.',
         'no_currency' => 'Ordenar y filtrar por precio requiere una moneda configurada en la tienda.',
+        'filter_too_wide' => 'Un filtro acepta como máximo :max valores.',
     ],
 
     'promotion' => [

--- a/packages/api/resources/lang/fr/messages.php
+++ b/packages/api/resources/lang/fr/messages.php
@@ -43,6 +43,7 @@ return [
     'catalog' => [
         'unknown_currency' => 'La devise ":code" est inconnue ou non activée sur cette boutique.',
         'no_currency' => 'Le tri et le filtre par prix nécessitent une devise configurée sur la boutique.',
+        'filter_too_wide' => 'Un filtre accepte au plus :max valeurs.',
     ],
 
     'promotion' => [

--- a/packages/api/resources/lang/sv/messages.php
+++ b/packages/api/resources/lang/sv/messages.php
@@ -43,6 +43,7 @@ return [
     'catalog' => [
         'unknown_currency' => 'Valutan ":code" är okänd eller inte aktiverad i denna butik.',
         'no_currency' => 'Sortering och filtrering efter pris kräver en konfigurerad valuta i butiken.',
+        'filter_too_wide' => 'Ett filter accepterar högst :max värden.',
     ],
 
     'promotion' => [

--- a/packages/api/routes/store/catalog.php
+++ b/packages/api/routes/store/catalog.php
@@ -9,13 +9,16 @@ use Shopper\Api\Http\Controllers\Catalog\CategoryController;
 use Shopper\Api\Http\Controllers\Catalog\CollectionController;
 use Shopper\Api\Http\Controllers\Catalog\ProductController;
 use Shopper\Api\Http\Controllers\Catalog\ReviewController;
+use Shopper\Api\Http\Controllers\Catalog\TagController;
 
 Route::get('/products', [ProductController::class, 'index']);
 Route::get('/products/{slug}', [ProductController::class, 'show']);
 Route::get('/products/{slug}/reviews', [ReviewController::class, 'index']);
 Route::get('/reviews', [ReviewController::class, 'latest']);
 Route::get('/categories', [CategoryController::class, 'index']);
+Route::get('/categories/tree', [CategoryController::class, 'tree']);
 Route::get('/categories/{slug}', [CategoryController::class, 'show']);
+Route::get('/tags', [TagController::class, 'index']);
 Route::get('/collections', [CollectionController::class, 'index']);
 Route::get('/collections/{slug}', [CollectionController::class, 'show']);
 Route::get('/brands', [BrandController::class, 'index']);

--- a/packages/api/src/Concerns/BuildsApiQueries.php
+++ b/packages/api/src/Concerns/BuildsApiQueries.php
@@ -9,7 +9,9 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Pagination\Cursor;
 use Illuminate\Pagination\CursorPaginator;
 use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
+use Illuminate\Validation\ValidationException;
 use Spatie\QueryBuilder\AllowedFilter;
 use Spatie\QueryBuilder\AllowedInclude;
 use Spatie\QueryBuilder\AllowedSort;
@@ -19,6 +21,8 @@ use Spatie\QueryBuilder\QueryBuilderRequest;
 
 trait BuildsApiQueries
 {
+    private const int MAX_FILTER_VALUES = 50;
+
     /**
      * Wrap an Eloquent query with the spatie query builder, applying the
      * filter / sort / include allowlist configured for the given resource.
@@ -30,6 +34,8 @@ trait BuildsApiQueries
      */
     protected function apiQuery(string $resource, Builder $query, array $extraFilters = []): QueryBuilder
     {
+        $this->guardFilterBreadth();
+
         $allowlist = (array) config('shopper.api.resources.'.$resource, []);
         $request = QueryBuilderRequest::fromRequest(request());
 
@@ -176,6 +182,21 @@ trait BuildsApiQueries
             ->orderBy($query->qualifyColumn($query->getModel()->getKeyName()))
             ->paginate(perPage: $size, pageName: 'page[number]', page: $page)
             ->withQueryString();
+    }
+
+    private function guardFilterBreadth(): void
+    {
+        QueryBuilderRequest::fromRequest(request())->filters()
+            ->each(function (mixed $values, string $filter): void {
+                $breadth = (new Collection(Arr::flatten([$values])))
+                    ->sum(fn (mixed $value): int => mb_substr_count((string) $value, ',') + 1);
+
+                if ($breadth > self::MAX_FILTER_VALUES) {
+                    throw ValidationException::withMessages([
+                        'filter.'.$filter => __('shopper-api::messages.catalog.filter_too_wide', ['max' => self::MAX_FILTER_VALUES]),
+                    ]);
+                }
+            });
     }
 
     /**

--- a/packages/api/src/Concerns/HandlesPriceQueries.php
+++ b/packages/api/src/Concerns/HandlesPriceQueries.php
@@ -39,6 +39,38 @@ trait HandlesPriceQueries
         return $filters->has('price_min') || $filters->has('price_max');
     }
 
+    protected function wantsPriceRange(): bool
+    {
+        return QueryBuilderRequest::fromRequest(request())->includes()->contains('price_range');
+    }
+
+    /**
+     * @param  Builder<Model>  $query
+     * @return array{min: int, max: int}|null
+     */
+    protected function priceRange(string $resource, Builder $query, int $currencyId): ?array
+    {
+        $sql = $this->minPriceExpression($query, $currencyId);
+
+        $row = $this->apiQuery($resource, $query, [
+            AllowedFilter::callback('currency', static function (): void {}),
+            AllowedFilter::callback('price_min', static function (): void {}),
+            AllowedFilter::callback('price_max', static function (): void {}),
+        ])
+            ->getEloquentBuilder()
+            ->reorder()
+            ->toBase()
+            ->select([])
+            ->selectRaw("MIN({$sql}) as min_amount, MAX({$sql}) as max_amount")
+            ->first();
+
+        if ($row === null || $row->min_amount === null) {
+            return null;
+        }
+
+        return ['min' => (int) $row->min_amount, 'max' => (int) $row->max_amount];
+    }
+
     /**
      * Add the `min_price` aggregate to the select, branched by product type
      * exactly like stock is: a variant product aggregates its variants'

--- a/packages/api/src/Http/Controllers/Catalog/CategoryController.php
+++ b/packages/api/src/Http/Controllers/Catalog/CategoryController.php
@@ -6,12 +6,16 @@ namespace Shopper\Api\Http\Controllers\Catalog;
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Collection;
 use Shopper\Api\Concerns\BuildsApiQueries;
 use Shopper\Api\Concerns\LoadsStock;
 use Shopper\Api\Concerns\ResolvesChannel;
 use Shopper\Api\Http\Includes\EnabledRelation;
+use Shopper\Api\Http\Includes\SubtreeProductsCount;
 use Shopper\Api\Http\Resources\CategoryResource;
-use Shopper\Core\Models\Contracts\Category;
+use Shopper\Core\Models\Contracts\Category as CategoryContract;
+use Shopper\Core\Queries\CategoryTree;
 use TiMacDonald\JsonApi\JsonApiResource;
 use TiMacDonald\JsonApi\JsonApiResourceCollection;
 
@@ -26,8 +30,25 @@ final class CategoryController
         $categories = $this->paginated('category', $this->publicQuery());
 
         $this->loadStockThroughRelation($categories->getCollection());
+        $this->loadDepth($categories->getCollection());
+        $this->loadSubtreeProductsCount($categories->getCollection());
 
         return CategoryResource::collection($categories);
+    }
+
+    public function tree(): JsonResponse
+    {
+        $hidden = resolve(CategoryTree::class)->hiddenIds();
+
+        $rows = resolve(CategoryContract::class)::query()
+            ->when($hidden !== [], fn (Builder $query) => $query->whereKeyNot($hidden))
+            ->orderBy('position')
+            ->toBase()
+            ->get(['id', 'public_id', 'name', 'slug', 'position', 'parent_id']);
+
+        $byParent = $rows->groupBy(fn (object $row) => $row->parent_id ?? 0);
+
+        return response()->json(['data' => $this->buildTree($byParent, 0)]);
     }
 
     public function show(string $slug): JsonApiResource
@@ -39,23 +60,66 @@ final class CategoryController
         $category = $query->where('slug', $slug)->firstOrFail();
 
         $this->loadStockThroughRelation(collect([$category]));
+        $this->loadDepth(collect([$category]));
+        $this->loadSubtreeProductsCount(collect([$category]));
 
         return CategoryResource::make($category);
     }
 
     /**
-     * The parent is eager-loaded for the `parent_id` attribute, through the
-     * same constraint as the include so a disabled parent is reported as no
-     * parent rather than as a node the client cannot fetch.
-     *
+     * @param  Collection<int|string, Collection<int, object>>  $byParent
+     * @return array<int, array<string, mixed>>
+     */
+    private function buildTree(Collection $byParent, int|string $parent): array
+    {
+        $nodes = [];
+
+        foreach ($byParent->get($parent) ?? [] as $row) {
+            $nodes[] = [
+                'id' => $row->public_id ?? (string) $row->id,
+                'name' => $row->name,
+                'slug' => $row->slug,
+                'position' => $row->position,
+                'children' => $this->buildTree($byParent, $row->id),
+            ];
+        }
+
+        return $nodes;
+    }
+
+    /**
+     * @param  Collection<int, Model>  $categories
+     */
+    private function loadDepth(Collection $categories): void
+    {
+        $tree = resolve(CategoryTree::class);
+
+        $categories->each(
+            fn (Model $category) => $category->setAttribute('depth', $tree->depth($category->getKey()))
+        );
+    }
+
+    /**
+     * @param  Collection<int, Model>  $categories
+     */
+    private function loadSubtreeProductsCount(Collection $categories): void
+    {
+        if ($this->requestedIncludes()->contains('products_count')) {
+            SubtreeProductsCount::load($categories);
+        }
+    }
+
+    /**
      * @return Builder<Model>
      */
     private function publicQuery(): Builder
     {
-        return $this->withMediaIfSupported(
-            resolve(Category::class)::query()
-                ->enabled()
-                ->with(['parent' => EnabledRelation::constraint()])
-        );
+        $hidden = resolve(CategoryTree::class)->hiddenIds();
+
+        $query = resolve(CategoryContract::class)::query()
+            ->when($hidden !== [], fn (Builder $query) => $query->whereKeyNot($hidden))
+            ->with(['parent' => EnabledRelation::constraint()]);
+
+        return $this->withMediaIfSupported($query);
     }
 }

--- a/packages/api/src/Http/Controllers/Catalog/ProductController.php
+++ b/packages/api/src/Http/Controllers/Catalog/ProductController.php
@@ -45,6 +45,10 @@ final class ProductController
             $this->applyPriceAggregate($query, $currency->id);
         }
 
+        $range = $this->wantsPriceRange() && $currency !== null
+            ? $this->priceRange('product', clone $query, $currency->id)
+            : null;
+
         $products = $this->paginated(
             'product',
             $query,
@@ -55,7 +59,12 @@ final class ProductController
         $this->loadPriceRangeForProducts($products->getCollection(), $currency?->id);
 
         return ProductResource::collection($products)
-            ->additional(['meta' => ['currency' => $currency?->code]]);
+            ->additional(['meta' => [
+                'currency' => $currency?->code,
+                ...($this->wantsPriceRange()
+                    ? ['price_range' => $range === null ? null : [...$range, 'currency_code' => $currency->code]]
+                    : []),
+            ]]);
     }
 
     public function show(string $slug): JsonApiResource

--- a/packages/api/src/Http/Controllers/Catalog/TagController.php
+++ b/packages/api/src/Http/Controllers/Catalog/TagController.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Api\Http\Controllers\Catalog;
+
+use Shopper\Api\Concerns\BuildsApiQueries;
+use Shopper\Api\Http\Resources\TagResource;
+use Shopper\Core\Models\ProductTag;
+use TiMacDonald\JsonApi\JsonApiResourceCollection;
+
+final class TagController
+{
+    use BuildsApiQueries;
+
+    public function index(): JsonApiResourceCollection
+    {
+        return TagResource::collection($this->paginated('tag', ProductTag::query()));
+    }
+}

--- a/packages/api/src/Http/Includes/ListingPriceRange.php
+++ b/packages/api/src/Http/Includes/ListingPriceRange.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Api\Http\Includes;
+
+use Illuminate\Database\Eloquent\Builder;
+use Spatie\QueryBuilder\Includes\IncludeInterface;
+
+final class ListingPriceRange implements IncludeInterface
+{
+    public function __invoke(Builder $query, string $include): void {}
+}

--- a/packages/api/src/Http/Includes/SubtreeProductsCount.php
+++ b/packages/api/src/Http/Includes/SubtreeProductsCount.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Api\Http\Includes;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
+use Shopper\Core\Models\Contracts\Category as CategoryContract;
+use Shopper\Core\Models\Contracts\Channel;
+use Shopper\Core\Models\Contracts\Product as ProductContract;
+use Spatie\QueryBuilder\Includes\IncludeInterface;
+
+final class SubtreeProductsCount implements IncludeInterface
+{
+    public function __invoke(Builder $query, string $include): void {}
+
+    /**
+     * @param  Collection<int, Model>  $categories
+     */
+    public static function load(Collection $categories): void
+    {
+        if ($categories->isEmpty()) {
+            return;
+        }
+
+        $roots = $categories->filter(fn (Model $category): bool => (bool) $category->getAttribute('is_enabled'));
+
+        $counts = $roots->isEmpty() ? [] : self::counts($roots);
+
+        $categories->each(function (Model $category) use ($counts): void {
+            $category->setAttribute('products_count', (int) ($counts[$category->getKey()] ?? 0));
+        });
+    }
+
+    /**
+     * @param  Collection<int, Model>  $roots
+     * @return array<int|string, int>
+     */
+    private static function counts(Collection $roots): array
+    {
+        $pivot = shopper_table('product_has_relations');
+        $products = resolve(ProductContract::class)::query()->getModel()->getTable();
+        $morphClass = $roots->first()->getMorphClass();
+        $channel = request()->attributes->get('shopper_channel');
+
+        $selects = [];
+        $bindings = [];
+        $keys = [];
+        $subtreeIds = [];
+
+        foreach ($roots as $root) {
+            if (! $root instanceof CategoryContract) {
+                continue;
+            }
+
+            $ids = $root->enabledSubtreeIds()->values()->all();
+
+            if ($ids === []) {
+                continue;
+            }
+
+            $alias = 'c'.count($keys);
+            $keys[$alias] = $root->getKey();
+            $placeholders = implode(', ', array_fill(0, count($ids), '?'));
+            $selects[] = "COUNT(DISTINCT CASE WHEN {$pivot}.productable_id IN ({$placeholders}) THEN {$pivot}.product_id END) AS {$alias}";
+            $bindings = [...$bindings, ...$ids];
+            $subtreeIds = [...$subtreeIds, ...$ids];
+        }
+
+        if ($selects === []) {
+            return [];
+        }
+
+        $row = resolve(ProductContract::class)::query()
+            ->scopes(['publish'])
+            ->when($channel instanceof Channel, fn (Builder $query) => $query->scopes(['channel' => [[$channel->id]]]))
+            ->join($pivot, $pivot.'.product_id', '=', $products.'.id')
+            ->where($pivot.'.productable_type', $morphClass)
+            ->whereIn($pivot.'.productable_id', array_values(array_unique($subtreeIds)))
+            ->toBase()
+            ->selectRaw(implode(', ', $selects), $bindings)
+            ->first();
+
+        $counts = [];
+
+        foreach ($keys as $alias => $key) {
+            $counts[$key] = (int) ($row->{$alias} ?? 0);
+        }
+
+        return $counts;
+    }
+}

--- a/packages/api/src/Http/Includes/VisibleCategories.php
+++ b/packages/api/src/Http/Includes/VisibleCategories.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Api\Http\Includes;
+
+use Closure;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Shopper\Core\Queries\CategoryTree;
+use Spatie\QueryBuilder\Includes\IncludeInterface;
+
+final class VisibleCategories implements IncludeInterface
+{
+    public function __invoke(Builder $query, string $include): void
+    {
+        $query->with([$include => self::constraint()]);
+    }
+
+    public static function constraint(): Closure
+    {
+        return function (Relation $categories): void {
+            $hidden = resolve(CategoryTree::class)->hiddenIds();
+
+            $categories->getQuery()->when(
+                $hidden !== [],
+                fn (Builder $query) => $query->whereKeyNot($hidden)
+            );
+        };
+    }
+}

--- a/packages/api/src/Http/Resources/CategoryResource.php
+++ b/packages/api/src/Http/Resources/CategoryResource.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 
 namespace Shopper\Api\Http\Resources;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
 use Shopper\Api\Concerns\SerializesMedia;
 use Shopper\Core\Models\Category;
 
 /**
  * @mixin Category
+ *
+ * @property-read ?int $depth
  */
 final class CategoryResource extends JsonApiResource
 {
@@ -28,6 +31,9 @@ final class CategoryResource extends JsonApiResource
             'description' => $this->description,
             'position' => $this->position,
             'parent_id' => $this->parent?->public_id,
+            'is_enabled' => $this->is_enabled,
+            'depth' => $this->depth,
+            ...$this->productsCountPayload(),
             'seo_title' => $this->seo_title,
             'seo_description' => $this->seo_description,
             'metadata' => $this->metadata,
@@ -42,7 +48,24 @@ final class CategoryResource extends JsonApiResource
         return [
             'parent' => fn () => CategoryResource::make($this->parent),
             'children' => fn () => CategoryResource::collection($this->children),
+            'ancestors' => fn () => CategoryResource::collection(
+                $this->ancestors->sortBy('depth')->values()->each(function (Model $ancestor): void {
+                    $ancestor->setAttribute('depth', null);
+                })
+            ),
             'products' => fn () => ProductResource::collection($this->products),
         ];
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function productsCountPayload(): array
+    {
+        $raw = $this->resource->getAttributes();
+
+        return array_key_exists('products_count', $raw)
+            ? ['products_count' => (int) $raw['products_count']]
+            : [];
     }
 }

--- a/packages/api/src/Http/Resources/ProductResource.php
+++ b/packages/api/src/Http/Resources/ProductResource.php
@@ -62,6 +62,7 @@ final class ProductResource extends JsonApiResource
             'brand' => fn () => BrandResource::make($this->brand),
             'categories' => fn () => CategoryResource::collection($this->categories),
             'collections' => fn () => CollectionResource::collection($this->collections),
+            'tags' => fn () => TagResource::collection($this->tags),
             'relatedProducts' => fn () => ProductResource::collection($this->relatedProducts),
         ];
 
@@ -82,7 +83,7 @@ final class ProductResource extends JsonApiResource
     private function stockPayload(): array
     {
         if ($this->isExternal()) {
-            return [];
+            return ['in_stock' => true];
         }
 
         $raw = $this->resource->getAttributes();

--- a/packages/api/src/Http/Resources/TagResource.php
+++ b/packages/api/src/Http/Resources/TagResource.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Api\Http\Resources;
+
+use Illuminate\Http\Request;
+use Shopper\Core\Models\ProductTag;
+
+/**
+ * @mixin ProductTag
+ */
+final class TagResource extends JsonApiResource
+{
+    public function toType(Request $request): string
+    {
+        return 'tags';
+    }
+
+    public function toAttributes(Request $request): array
+    {
+        return [
+            'name' => $this->name,
+            'slug' => $this->slug,
+            'created_at' => $this->created_at->toIso8601String(),
+            'updated_at' => $this->updated_at->toIso8601String(),
+        ];
+    }
+
+    public function toRelationships(Request $request): array
+    {
+        return [
+            'products' => fn () => ProductResource::collection($this->products),
+        ];
+    }
+}

--- a/packages/core/config/core.php
+++ b/packages/core/config/core.php
@@ -46,4 +46,20 @@ return [
         'chunk_size' => 25,
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Cache
+    |--------------------------------------------------------------------------
+    |
+    | Here you may define how long, in seconds, the category tree stays
+    | cached. Saving or deleting a category refreshes it, so this duration
+    | only bounds a change made without going through the models. Set it to
+    | null to always read the tree from the database.
+    |
+    */
+
+    'cache' => [
+        'category_tree' => 3600,
+    ],
+
 ];

--- a/packages/core/database/migrations/2026_08_03_000001_add_value_index_to_attribute_values_table.php
+++ b/packages/core/database/migrations/2026_08_03_000001_add_value_index_to_attribute_values_table.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table(shopper_table('attribute_values'), function (Blueprint $table): void {
+            $table->index('value');
+        });
+    }
+};

--- a/packages/core/src/CoreServiceProvider.php
+++ b/packages/core/src/CoreServiceProvider.php
@@ -113,6 +113,7 @@ final class CoreServiceProvider extends PackageServiceProvider
     public function packageRegistered(): void
     {
         $this->app->register(EventServiceProvider::class);
+        $this->app->scoped(Queries\CategoryTree::class);
 
         $this->registerConfigFiles();
         $this->registerDatabase();

--- a/packages/core/src/Models/Category.php
+++ b/packages/core/src/Models/Category.php
@@ -11,6 +11,7 @@ use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
+use Illuminate\Support\Collection as SupportCollection;
 use Shopper\Core\Contracts\Media\HasMedia as ShopperHasMedia;
 use Shopper\Core\Database\Factories\CategoryFactory;
 use Shopper\Core\Models\Contracts\Category as CategoryContract;
@@ -18,6 +19,7 @@ use Shopper\Core\Models\Traits\HasMediaCollections;
 use Shopper\Core\Models\Traits\HasPublicId;
 use Shopper\Core\Models\Traits\HasSlug;
 use Shopper\Core\Models\Traits\Searchable;
+use Shopper\Core\Queries\CategoryTree;
 use Shopper\Core\Traits\HasModelContract;
 use Staudenmeir\LaravelAdjacencyList\Eloquent\HasRecursiveRelationships;
 use Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\HasManyOfDescendants;
@@ -80,6 +82,14 @@ class Category extends Model implements CategoryContract, ShopperHasMedia
     public function updateStatus(bool $status = true): void
     {
         $this->update(['is_enabled' => $status]);
+    }
+
+    /**
+     * @return SupportCollection<int, int>
+     */
+    public function enabledSubtreeIds(): SupportCollection
+    {
+        return new SupportCollection(resolve(CategoryTree::class)->subtreeIds($this->getKey()));
     }
 
     public function getLabelOptionName(): string

--- a/packages/core/src/Models/Contracts/Category.php
+++ b/packages/core/src/Models/Contracts/Category.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Shopper\Core\Models\Contracts;
 
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
+use Illuminate\Support\Collection as SupportCollection;
 use Staudenmeir\LaravelAdjacencyList\Eloquent\Relations\HasManyOfDescendants;
 
 interface Category
@@ -12,6 +13,11 @@ interface Category
     public function getLabelOptionName(): string;
 
     public function descendantCategories(): HasManyOfDescendants;
+
+    /**
+     * @return SupportCollection<int, int>
+     */
+    public function enabledSubtreeIds(): SupportCollection;
 
     public function products(): MorphToMany;
 }

--- a/packages/core/src/Models/Product.php
+++ b/packages/core/src/Models/Product.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Shopper\Core\Models;
 
 use Carbon\CarbonInterface;
+use Closure;
 use Illuminate\Database\Eloquent\Attributes\Scope;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute as LaravelAttribute;
@@ -15,7 +16,9 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Collection as SupportCollection;
 use Shopper\Core\Contracts\HasReviews;
 use Shopper\Core\Contracts\Media\HasMedia as ShopperHasMedia;
 use Shopper\Core\Contracts\Priceable;
@@ -25,7 +28,9 @@ use Shopper\Core\Enum\Dimension\Volume;
 use Shopper\Core\Enum\Dimension\Weight;
 use Shopper\Core\Enum\ProductType;
 use Shopper\Core\Media\MediaCollectionConfig;
+use Shopper\Core\Models\Contracts\Category as CategoryContract;
 use Shopper\Core\Models\Contracts\Product as ProductContract;
+use Shopper\Core\Models\Contracts\ProductVariant as ProductVariantContract;
 use Shopper\Core\Models\Traits\HasDimensions;
 use Shopper\Core\Models\Traits\HasDiscounts;
 use Shopper\Core\Models\Traits\HasMediaCollections;
@@ -35,6 +40,7 @@ use Shopper\Core\Models\Traits\HasSlug;
 use Shopper\Core\Models\Traits\HasStock;
 use Shopper\Core\Models\Traits\InteractsWithReviews;
 use Shopper\Core\Models\Traits\Searchable;
+use Shopper\Core\Queries\CategoryTree;
 use Shopper\Core\Traits\HasModelContract;
 
 /**
@@ -271,48 +277,114 @@ class Product extends Model implements HasReviews, Priceable, ProductContract, S
      * @param  Builder<Product>  $query
      */
     #[Scope]
-    protected function collection(Builder $query, string $value): void
+    protected function collection(Builder $query, string|array ...$values): void
     {
-        $query->whereHas('collections', fn (Builder $query): Builder => $query->where('slug', $value)->orWhere('public_id', $value));
+        $values = Arr::flatten($values);
+
+        $query->whereHas('collections', fn (Builder $query): Builder => $query
+            ->scopes(['published'])
+            ->where(fn (Builder $query): Builder => $query
+                ->whereIn('slug', $values)
+                ->orWhereIn('public_id', $values)));
     }
 
     /**
      * @param  Builder<Product>  $query
      */
     #[Scope]
-    protected function byBrand(Builder $query, string $value): void
+    protected function byBrand(Builder $query, string|array ...$values): void
     {
-        $query->whereHas('brand', fn (Builder $query): Builder => $query->where('slug', $value)->orWhere('public_id', $value));
+        $values = Arr::flatten($values);
+
+        $query->whereHas('brand', fn (Builder $query): Builder => $query
+            ->scopes(['enabled'])
+            ->where(fn (Builder $query): Builder => $query
+                ->whereIn('slug', $values)
+                ->orWhereIn('public_id', $values)));
     }
 
     /**
      * @param  Builder<Product>  $query
      */
     #[Scope]
-    protected function tag(Builder $query, string $value): void
+    protected function tag(Builder $query, string|array ...$values): void
     {
-        $query->whereHas('tags', fn (Builder $query): Builder => $query->where('slug', $value)->orWhere('public_id', $value));
-    }
+        $values = Arr::flatten($values);
 
-    /**
-     * Products having a variant carrying the given attribute value (by key or
-     * value), e.g. filter[option]=red. Powers faceted listing filters.
-     *
-     * @param  Builder<Product>  $query
-     */
-    #[Scope]
-    protected function option(Builder $query, string $value): void
-    {
-        $query->whereHas('variants.values', fn (Builder $query): Builder => $query->where('key', $value)->orWhere('value', $value));
+        $query->whereHas('tags', fn (Builder $query): Builder => $query
+            ->whereIn('slug', $values)
+            ->orWhereIn('public_id', $values));
     }
 
     /**
      * @param  Builder<Product>  $query
      */
     #[Scope]
-    protected function category(Builder $query, string $value): void
+    protected function option(Builder $query, string|array ...$values): void
     {
-        $query->whereHas('categories', fn (Builder $query): Builder => $query->where('slug', $value)->orWhere('public_id', $value));
+        $values = Arr::flatten($values);
+
+        $match = fn (Builder $query): Builder => $query
+            ->whereIn('key', $values)
+            ->orWhereIn('value', $values);
+
+        $query->where(fn (Builder $query): Builder => $query
+            ->whereHas('variants.values', $match)
+            ->orWhereHas('attributeProducts.value', $match));
+    }
+
+    /**
+     * @param  Builder<Product>  $query
+     */
+    #[Scope]
+    protected function category(Builder $query, string|array ...$values): void
+    {
+        $values = Arr::flatten($values);
+        $hidden = resolve(CategoryTree::class)->hiddenIds();
+
+        $query->whereHas('categories', fn (Builder $query): Builder => $query
+            ->when($hidden !== [], fn (Builder $query): Builder => $query->whereKeyNot($hidden))
+            ->where(fn (Builder $query): Builder => $query
+                ->whereIn('slug', $values)
+                ->orWhereIn('public_id', $values)));
+    }
+
+    /**
+     * @param  Builder<Product>  $query
+     */
+    #[Scope]
+    protected function categoryTree(Builder $query, string|array ...$values): void
+    {
+        $values = Arr::flatten($values);
+
+        $ids = resolve(CategoryContract::class)::query()
+            ->where(
+                fn (Builder $query): Builder => $query->whereIn('slug', $values)->orWhereIn('public_id', $values)
+            )
+            ->get()
+            ->flatMap(fn (CategoryContract $category): SupportCollection => $category->enabledSubtreeIds())
+            ->unique()
+            ->values();
+
+        $query->whereHas('categories', fn (Builder $query): Builder => $query->whereIn($query->qualifyColumn('id'), $ids));
+    }
+
+    /**
+     * @param  Builder<Product>  $query
+     */
+    #[Scope]
+    protected function availability(Builder $query, bool|string $value = true): void
+    {
+        $available = fn (Builder $query): Builder => $query
+            ->where(fn (Builder $query): Builder => $query
+                ->whereNotNull('type')
+                ->where('type', ProductType::External))
+            ->orWhere($this->whereVariantsInStock(...))
+            ->orWhere($this->whereOwnStockLeft(...));
+
+        filter_var($value, FILTER_VALIDATE_BOOLEAN)
+            ? $query->where($available)
+            : $query->whereNot($available);
     }
 
     /**
@@ -389,5 +461,51 @@ class Product extends Model implements HasReviews, Priceable, ProductContract, S
             'volume_value' => 'decimal:2',
             'type' => ProductType::class,
         ];
+    }
+
+    /**
+     * @param  Builder<Product>  $query
+     */
+    private function whereVariantsInStock(Builder $query): void
+    {
+        $query
+            ->whereNotNull('type')
+            ->where('type', ProductType::Variant)
+            ->where(fn (Builder $query): Builder => $query
+                ->whereHas('variants', fn (Builder $query): Builder => $query->where('allow_backorder', true))
+                ->orWhereExists($this->hasVariantStockQuery()));
+    }
+
+    /**
+     * @param  Builder<Product>  $query
+     */
+    private function whereOwnStockLeft(Builder $query): void
+    {
+        $query
+            ->where(fn (Builder $query): Builder => $query
+                ->whereNot('type', ProductType::Variant)
+                ->orWhereNull('type'))
+            ->where(fn (Builder $query): Builder => $query
+                ->where('allow_backorder', true)
+                ->orWhereExists($this->hasStockQuery()));
+    }
+
+    /**
+     * @return Closure(QueryBuilder): QueryBuilder
+     */
+    private function hasVariantStockQuery(): Closure
+    {
+        /** @var Model $variant */
+        $variant = resolve(ProductVariantContract::class);
+
+        return fn (QueryBuilder $query): QueryBuilder => $query
+            ->selectRaw('SUM(quantity)')
+            ->from((new StockLevel)->getTable())
+            ->where('stockable_type', $variant->getMorphClass())
+            ->whereIn(
+                'stockable_id',
+                $variant->newQuery()->select('id')->whereColumn('product_id', $this->qualifyColumn('id'))
+            )
+            ->havingRaw('SUM(quantity) > 0');
     }
 }

--- a/packages/core/src/Models/Traits/HasStock.php
+++ b/packages/core/src/Models/Traits/HasStock.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace Shopper\Core\Models\Traits;
 
+use Closure;
 use DateTimeInterface;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Database\QueryException;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
@@ -78,6 +80,19 @@ trait HasStock
     public function inStock(int $quantity = 1): bool
     {
         return $this->stock > 0 && $this->stock >= $quantity;
+    }
+
+    /**
+     * @return Closure(QueryBuilder): QueryBuilder
+     */
+    public function hasStockQuery(): Closure
+    {
+        return fn (QueryBuilder $query): QueryBuilder => $query
+            ->selectRaw('SUM(quantity)')
+            ->from((new StockLevel)->getTable())
+            ->where('stockable_type', $this->getMorphClass())
+            ->whereColumn('stockable_id', $this->qualifyColumn('id'))
+            ->havingRaw('SUM(quantity) > 0');
     }
 
     /**

--- a/packages/core/src/Observers/CategoryObserver.php
+++ b/packages/core/src/Observers/CategoryObserver.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace Shopper\Core\Observers;
 
+use Illuminate\Database\Eloquent\Model;
+use RuntimeException;
 use Shopper\Core\Models\Contracts\Category;
+use Shopper\Core\Queries\CategoryTree;
 
 class CategoryObserver
 {
@@ -15,7 +18,37 @@ class CategoryObserver
 
     public function updating(Category $category): void
     {
+        $this->ensureTheParentIsNotADescendant($category);
         $this->ensureParentSlugIsCorrectlySet($category);
+    }
+
+    public function saved(Category $category): void
+    {
+        CategoryTree::flush();
+    }
+
+    public function deleted(Category $category): void
+    {
+        CategoryTree::flush();
+    }
+
+    private function ensureTheParentIsNotADescendant(Category $category): void
+    {
+        if (! $category instanceof Model || ! $category->isDirty('parent_id') || blank($category->getAttribute('parent_id'))) {
+            return;
+        }
+
+        $ancestor = (int) $category->getAttribute('parent_id');
+        $visited = [];
+
+        while ($ancestor !== 0 && ! in_array($ancestor, $visited, true)) {
+            if ($ancestor === (int) $category->getKey()) {
+                throw new RuntimeException('A category cannot be moved under one of its own descendants.');
+            }
+
+            $visited[] = $ancestor;
+            $ancestor = (int) resolve(Category::class)::query()->whereKey($ancestor)->value('parent_id');
+        }
     }
 
     /**

--- a/packages/core/src/Queries/CategoryTree.php
+++ b/packages/core/src/Queries/CategoryTree.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Core\Queries;
+
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\Cache;
+use Shopper\Core\Models\Contracts\Category;
+
+final class CategoryTree
+{
+    private const string VERSION_KEY = 'shopper.categories.version';
+
+    /**
+     * @var array{depth: array<int|string, int>, children: array<int|string, array<int, int|string>>, hidden: array<int, int|string>}|null
+     */
+    private ?array $memo = null;
+
+    public static function flush(): void
+    {
+        Cache::add(self::VERSION_KEY, 0);
+        Cache::increment(self::VERSION_KEY);
+
+        if (app()->resolved(self::class)) {
+            resolve(self::class)->memo = null;
+        }
+    }
+
+    public function depth(int|string $id): ?int
+    {
+        return $this->tree()['depth'][$id] ?? null;
+    }
+
+    /**
+     * @return array<int, int|string>
+     */
+    public function hiddenIds(): array
+    {
+        return $this->tree()['hidden'];
+    }
+
+    /**
+     * @return array<int, int|string>
+     */
+    public function subtreeIds(int|string $id): array
+    {
+        $tree = $this->tree();
+
+        if (! array_key_exists($id, $tree['depth'])) {
+            return [];
+        }
+
+        $ids = [$id];
+
+        for ($index = 0; $index < count($ids); $index++) {
+            foreach ($tree['children'][$ids[$index]] ?? [] as $child) {
+                $ids[] = $child;
+            }
+        }
+
+        return $ids;
+    }
+
+    /**
+     * @return array{depth: array<int|string, int>, children: array<int|string, array<int, int|string>>, hidden: array<int, int|string>}
+     */
+    private function tree(): array
+    {
+        if ($this->memo !== null) {
+            return $this->memo;
+        }
+
+        $ttl = config('shopper.core.cache.category_tree');
+
+        if (blank($ttl)) {
+            return $this->memo = $this->build();
+        }
+
+        $version = (int) Cache::get(self::VERSION_KEY, 0);
+
+        /** @var array{depth: array<int|string, int>, children: array<int|string, array<int, int|string>>, hidden: array<int, int|string>} $tree */
+        $tree = Cache::flexible(
+            'shopper.category-tree.'.$version,
+            [(int) $ttl, (int) $ttl * 24],
+            fn (): array => $this->build(),
+        );
+
+        return $this->memo = $tree;
+    }
+
+    /**
+     * @return array{depth: array<int|string, int>, children: array<int|string, array<int, int|string>>, hidden: array<int, int|string>}
+     */
+    private function build(): array
+    {
+        /** @var Collection<\Shopper\Core\Models\Category> $rows */
+        $rows = resolve(Category::class)::query()
+            ->toBase()
+            ->get(['id', 'parent_id', 'is_enabled']);
+
+        $children = [];
+        $queue = [];
+
+        foreach ($rows as $row) {
+            if (! $row->is_enabled) {
+                continue;
+            }
+
+            if (blank($row->parent_id)) {
+                $queue[] = [$row->id, 0];
+
+                continue;
+            }
+
+            $children[$row->parent_id][] = $row->id;
+        }
+
+        $depth = [];
+
+        for ($index = 0; $index < count($queue); $index++) {
+            [$id, $level] = $queue[$index];
+
+            $depth[$id] = $level;
+
+            foreach ($children[$id] ?? [] as $child) {
+                $queue[] = [$child, $level + 1];
+            }
+        }
+
+        $hidden = [];
+
+        foreach ($rows as $row) {
+            if (! array_key_exists($row->id, $depth)) {
+                $hidden[] = $row->id;
+            }
+        }
+
+        return ['depth' => $depth, 'children' => $children, 'hidden' => $hidden];
+    }
+}

--- a/packages/sdk/src/store/category.ts
+++ b/packages/sdk/src/store/category.ts
@@ -1,0 +1,13 @@
+import type { Category, CategoryTreeNode } from '@shopperlabs/shopper-types'
+
+import type { FetchInit } from '../http'
+import { CollectionResource } from './collection'
+
+export class CategoryResource extends CollectionResource<Category> {
+  /** The full nested tree of visible categories, ordered by position. */
+  public async tree(init?: FetchInit): Promise<CategoryTreeNode[]> {
+    const document = await this.client.request(`${this.path}/tree`, undefined, init)
+
+    return (document.data ?? []) as unknown as CategoryTreeNode[]
+  }
+}

--- a/packages/sdk/src/store/index.ts
+++ b/packages/sdk/src/store/index.ts
@@ -1,11 +1,11 @@
 import type {
   Attribute,
   Brand,
-  Category,
   Collection,
   Country,
   Currency,
   Legal,
+  ProductTag,
   StoreSettings,
   Zone,
 } from '@shopperlabs/shopper-types'
@@ -14,6 +14,7 @@ import type { HttpClient } from '../client'
 import type { FetchInit, FetchRequestOptions } from '../http'
 import { flatten } from '../json-api'
 import { CartModule } from './cart'
+import { CategoryResource } from './category'
 import { CollectionResource } from './collection'
 import { CustomerModule } from './customer'
 import { OrderModule } from './order'
@@ -31,6 +32,7 @@ export type {
   UpdateCartLinePayload,
   UpdateCartPayload,
 } from './cart'
+export { CategoryResource } from './category'
 export { CollectionResource } from './collection'
 export type { Paginated } from './collection'
 export { CustomerModule } from './customer'
@@ -54,13 +56,15 @@ export class StoreModule {
 
   public readonly review: ReviewModule
 
-  public readonly category: CollectionResource<Category>
+  public readonly category: CategoryResource
 
   public readonly collection: CollectionResource<Collection>
 
   public readonly brand: CollectionResource<Brand>
 
   public readonly attribute: Pick<CollectionResource<Attribute>, 'list'>
+
+  public readonly tag: Pick<CollectionResource<ProductTag>, 'list'>
 
   public readonly setting: SingletonResource<StoreSettings>
 
@@ -83,10 +87,11 @@ export class StoreModule {
 
     this.product = new ProductResource(client, `${prefix}/products`)
     this.review = new ReviewModule(client)
-    this.category = new CollectionResource<Category>(client, `${prefix}/categories`)
+    this.category = new CategoryResource(client, `${prefix}/categories`)
     this.collection = new CollectionResource<Collection>(client, `${prefix}/collections`)
     this.brand = new CollectionResource<Brand>(client, `${prefix}/brands`)
     this.attribute = new CollectionResource<Attribute>(client, `${prefix}/attributes`)
+    this.tag = new CollectionResource<ProductTag>(client, `${prefix}/tags`)
     this.setting = new SingletonResource<StoreSettings>(client, `${prefix}/settings`)
     this.legal = new CollectionResource<Legal>(client, `${prefix}/legals`)
     this.country = new CollectionResource<Country>(client, `${prefix}/countries`)

--- a/packages/sdk/src/store/product.ts
+++ b/packages/sdk/src/store/product.ts
@@ -6,10 +6,15 @@ import { CollectionResource, type Paginated } from './collection'
 
 /**
  * A paginated products listing: the rows plus the currency every price-aware
- * value of the response is expressed in (`price_range`, price sorting).
+ * value of the response is expressed in. `price_range` bounds the whole
+ * filtered result, is only present with `include: 'price_range'`, and
+ * ignores `price_min`/`price_max`.
  */
 export interface ProductList extends Paginated<Product> {
-  meta: { currency: string | null } & Record<string, unknown>
+  meta: {
+    currency: string | null
+    price_range?: { min: number; max: number; currency_code: string | null } | null
+  } & Record<string, unknown>
 }
 
 /**

--- a/packages/types/src/category.ts
+++ b/packages/types/src/category.ts
@@ -26,8 +26,23 @@ export interface Category extends Entity, SEOFields {
   parent?: Category
   /** The children categories. */
   children?: Category[]
+  /** The enabled ancestors of the category, root first. */
+  ancestors?: Category[]
   /** The products of the category. */
   products?: Product[]
-  /** The slug path of the category. */
-  slug_path?: string
+  /** The number of ancestors above the category, zero on a root. */
+  depth?: number | null
+  /** The number of distinct public products in the category subtree. */
+  products_count?: number
+}
+
+/**
+ * A node of the public category tree, children nested recursively.
+ */
+export interface CategoryTreeNode {
+  id: ResourceId
+  name: string
+  slug: string
+  position: number
+  children: CategoryTreeNode[]
 }

--- a/tests/Api/Feature/CatalogEndpointsTest.php
+++ b/tests/Api/Feature/CatalogEndpointsTest.php
@@ -9,6 +9,7 @@ use Shopper\Core\Models\Brand;
 use Shopper\Core\Models\Category;
 use Shopper\Core\Models\Collection;
 use Shopper\Core\Models\Product;
+use Shopper\Core\Models\ProductTag;
 
 uses(Tests\Api\TestCase::class);
 
@@ -59,6 +60,32 @@ it('hides disabled brands from the listing', function (): void {
 
     $ids = collect($this->getJson('/store/brands?filter[name]=Brand')->assertOk()->json('data'))->pluck('id');
     expect($ids)->toContain($enabled->public_id)->and($ids)->not->toContain($disabled->public_id);
+});
+
+it('lists tags and exposes them on a product through the include', function (): void {
+    $tag = ProductTag::factory()->create(['name' => 'TagSummer']);
+    $other = ProductTag::factory()->create(['name' => 'TagWinter']);
+    $product = Product::factory()->publish()->create();
+    $product->tags()->attach($tag->id);
+
+    $ids = collect($this->getJson('/store/tags?filter[name]=Tag')->assertOk()->json('data'))->pluck('id');
+    expect($ids)->toContain($tag->public_id)->and($ids)->toContain($other->public_id);
+
+    $this->getJson('/store/products/'.$product->slug.'?include=tags')
+        ->assertOk()
+        ->assertJsonPath('included.0.type', 'tags')
+        ->assertJsonPath('included.0.id', $tag->public_id)
+        ->assertJsonPath('included.0.attributes.name', 'TagSummer');
+});
+
+it('shows only public products through the tag products include', function (): void {
+    $tag = ProductTag::factory()->create(['name' => 'TagVisible']);
+    $published = Product::factory()->publish()->create();
+    $draft = Product::factory()->create(['published_at' => now()->addYear()]);
+    $tag->products()->attach([$published->id, $draft->id]);
+
+    $ids = collect($this->getJson('/store/tags?filter[name]=TagVisible&include=products')->assertOk()->json('included') ?? [])->pluck('id');
+    expect($ids)->toContain($published->public_id)->and($ids)->not->toContain($draft->public_id);
 });
 
 it('lists only filterable facet attributes with their embedded values', function (): void {

--- a/tests/Api/Feature/CategoryMerchandisingTest.php
+++ b/tests/Api/Feature/CategoryMerchandisingTest.php
@@ -1,0 +1,297 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Shopper\Core\Models\Channel;
+use Shopper\Core\Models\Product;
+use Tests\Core\Stubs\Category;
+
+uses(Tests\Api\TestCase::class);
+
+function node(string $name, ?Category $parent = null): Category
+{
+    return Category::factory()->create([
+        'name' => $name,
+        'slug' => $name,
+        'is_enabled' => true,
+        'parent_id' => $parent?->id,
+    ]);
+}
+
+it('exposes the depth of a category', function (): void {
+    $furniture = node('Furniture');
+    $sofas = node('Sofas', $furniture);
+    $corner = node('Corner', $sofas);
+
+    $this->getJson('/store/categories/'.$furniture->slug)
+        ->assertOk()
+        ->assertJsonPath('data.attributes.depth', 0);
+
+    $this->getJson('/store/categories/'.$corner->slug)
+        ->assertOk()
+        ->assertJsonPath('data.attributes.depth', 2);
+});
+
+it('computes the depth beyond three levels', function (): void {
+    $level = node('LevelA');
+
+    foreach (['LevelB', 'LevelC', 'LevelD', 'LevelE'] as $name) {
+        $level = node($name, $level);
+    }
+
+    $this->getJson('/store/categories/'.$level->slug)
+        ->assertOk()
+        ->assertJsonPath('data.attributes.depth', 4);
+});
+
+it('carries the depth on every row of the listing without a query per row', function (): void {
+    $furniture = node('Furniture');
+
+    foreach (['Sofas', 'Tables', 'Chairs'] as $name) {
+        node($name, $furniture);
+    }
+
+    DB::enableQueryLog();
+
+    $data = collect($this->getJson('/store/categories')->assertOk()->json('data'));
+
+    $queries = count(DB::getQueryLog());
+
+    expect($data)->toHaveCount(4)
+        ->and($data->every(fn (array $row): bool => $row['attributes']['depth'] !== null))->toBeTrue()
+        ->and($queries)->toBeLessThan(6);
+});
+
+it('includes the ancestors root first for the breadcrumb', function (): void {
+    $furniture = node('Furniture');
+    $sofas = node('Sofas', $furniture);
+    $corner = node('Corner', $sofas);
+    node('Garden');
+
+    $response = $this->getJson('/store/categories/'.$corner->slug.'?include=ancestors')->assertOk();
+
+    $ids = collect($response->json('data.relationships.ancestors.data'))->pluck('id');
+
+    $included = collect($response->json('included'))->firstWhere('id', $furniture->public_id);
+
+    expect($ids->all())->toBe([$furniture->public_id, $sofas->public_id])
+        ->and($included['attributes']['depth'])->toBeNull();
+});
+
+it('prunes a category under a disabled ancestor from every response', function (): void {
+    $furniture = node('Furniture');
+    $sofas = node('Sofas', $furniture);
+    $corner = node('Corner', $sofas);
+
+    $sofas->update(['is_enabled' => false]);
+
+    $this->getJson('/store/categories/'.$corner->slug)->assertNotFound();
+
+    $ids = collect($this->getJson('/store/categories')->assertOk()->json('data'))->pluck('id');
+
+    expect($ids)->toContain($furniture->public_id)
+        ->and($ids)->not->toContain($sofas->public_id)
+        ->and($ids)->not->toContain($corner->public_id);
+});
+
+it('cursor-paginates the listing without gaps or duplicates', function (): void {
+    $furniture = node('Furniture');
+
+    foreach (['Sofas', 'Tables', 'Chairs', 'Lamps', 'Rugs'] as $name) {
+        node($name, $furniture);
+    }
+
+    $ids = [];
+    $url = '/store/categories?page[size]=2&page[cursor]=';
+
+    do {
+        $response = $this->getJson($url)->assertOk();
+
+        foreach ($response->json('data') as $row) {
+            $ids[] = $row['id'];
+        }
+
+        $url = $response->json('links.next');
+    } while ($url !== null);
+
+    expect(collect($ids)->unique())->toHaveCount(6);
+});
+
+it('combines a sort and a filter on the listing', function (): void {
+    node('Alpha');
+    node('Beta');
+    node('Alphabet');
+
+    $names = collect($this->getJson('/store/categories?sort=name&filter[name]=Alpha')->assertOk()->json('data'))
+        ->pluck('attributes.name');
+
+    expect($names->all())->toBe(['Alpha', 'Alphabet']);
+});
+
+it('counts the published products of the whole subtree once each', function (): void {
+    $furniture = node('Furniture');
+    $sofas = node('Sofas', $furniture);
+    $garden = node('Garden');
+
+    Product::factory()->create()->categories()->attach([$furniture->id, $sofas->id]);
+    Product::factory()->create()->categories()->attach($sofas->id);
+    Product::factory()->unpublished()->create()->categories()->attach($sofas->id);
+    Product::factory()->create()->categories()->attach($garden->id);
+
+    $this->getJson('/store/categories/'.$furniture->slug.'?include=products_count')
+        ->assertOk()
+        ->assertJsonPath('data.attributes.products_count', 2);
+});
+
+it('excludes disabled branches from the subtree products count', function (): void {
+    $furniture = node('Furniture');
+    $hidden = node('Hidden', $furniture);
+
+    Product::factory()->create()->categories()->attach($furniture->id);
+    Product::factory()->create()->categories()->attach($hidden->id);
+
+    $hidden->update(['is_enabled' => false]);
+
+    $this->getJson('/store/categories/'.$furniture->slug.'?include=products_count')
+        ->assertOk()
+        ->assertJsonPath('data.attributes.products_count', 1);
+});
+
+it('scopes the subtree products count to the resolved channel', function (): void {
+    $channel = Channel::factory()->create(['slug' => 'webstore', 'is_enabled' => true, 'is_default' => false]);
+    $furniture = node('Furniture');
+
+    $onChannel = Product::factory()->create();
+    $onChannel->categories()->attach($furniture->id);
+    $onChannel->channels()->attach($channel->id);
+
+    Product::factory()->create()->categories()->attach($furniture->id);
+
+    $this->getJson('/store/categories/'.$furniture->slug.'?include=products_count')
+        ->assertOk()
+        ->assertJsonPath('data.attributes.products_count', 2);
+
+    $this->getJson('/store/categories/'.$furniture->slug.'?include=products_count', ['X-Shopper-Channel' => 'webstore'])
+        ->assertOk()
+        ->assertJsonPath('data.attributes.products_count', 1);
+});
+
+it('carries the subtree products count on the listing only when requested', function (): void {
+    $furniture = node('Furniture');
+    $sofas = node('Sofas', $furniture);
+
+    Product::factory()->create()->categories()->attach($sofas->id);
+
+    $rows = collect($this->getJson('/store/categories?include=products_count')->assertOk()->json('data'))
+        ->keyBy('attributes.slug');
+
+    expect($rows[$furniture->slug]['attributes']['products_count'])->toBe(1)
+        ->and($rows[$sofas->slug]['attributes']['products_count'])->toBe(1);
+
+    $bare = collect($this->getJson('/store/categories')->assertOk()->json('data'))->first();
+
+    expect($bare['attributes'])->not->toHaveKey('products_count');
+});
+
+it('counts the subtrees of a page without a recursive query per row', function (): void {
+    $furniture = node('Furniture');
+
+    foreach (['Sofas', 'Tables', 'Chairs', 'Lamps'] as $name) {
+        Product::factory()->create()->categories()->attach(node($name, $furniture)->id);
+    }
+
+    $this->getJson('/store/categories?include=products_count')->assertOk();
+
+    DB::enableQueryLog();
+
+    $this->getJson('/store/categories?include=products_count')->assertOk();
+
+    $queries = collect(DB::getQueryLog())->pluck('query');
+
+    expect($queries->filter(fn (string $sql): bool => str_contains($sql, 'recursive')))->toBeEmpty()
+        ->and($queries)->toHaveCount(5);
+});
+
+it('drops a category from the listing as soon as the merchant disables it', function (): void {
+    $furniture = node('Furniture');
+    $sofas = node('Sofas', $furniture);
+
+    $before = collect($this->getJson('/store/categories')->assertOk()->json('data'))->pluck('id');
+
+    $sofas->update(['is_enabled' => false]);
+
+    $after = collect($this->getJson('/store/categories')->assertOk()->json('data'))->pluck('id');
+
+    expect($before)->toContain($sofas->public_id)
+        ->and($after)->not->toContain($sofas->public_id);
+});
+
+it('makes a category visible again once re-enabled', function (): void {
+    $furniture = node('Furniture');
+    $sofas = node('Sofas', $furniture);
+
+    $sofas->update(['is_enabled' => false]);
+    $this->getJson('/store/categories/'.$sofas->slug)->assertNotFound();
+
+    $sofas->update(['is_enabled' => true]);
+    $this->getJson('/store/categories/'.$sofas->slug)->assertOk();
+});
+
+it('invalidates the cached tree on the database cache store', function (): void {
+    if (! Schema::hasTable('cache')) {
+        Schema::create('cache', function (Blueprint $table): void {
+            $table->string('key')->primary();
+            $table->mediumText('value');
+            $table->integer('expiration');
+        });
+    }
+
+    config(['cache.default' => 'database']);
+
+    $furniture = node('Furniture');
+    $sofas = node('Sofas', $furniture);
+
+    $this->getJson('/store/categories')->assertOk()->assertJsonCount(2, 'data');
+
+    $sofas->update(['is_enabled' => false]);
+
+    $ids = collect($this->getJson('/store/categories')->assertOk()->json('data'))->pluck('id');
+
+    expect($ids->all())->toBe([$furniture->public_id]);
+});
+
+it('prunes the same branches with the tree cache turned off', function (): void {
+    config(['shopper.core.cache.category_tree' => null]);
+
+    $furniture = node('Furniture');
+    $hidden = node('Hidden', $furniture);
+    node('Deep', $hidden);
+
+    $hidden->update(['is_enabled' => false]);
+
+    $ids = collect($this->getJson('/store/categories')->assertOk()->json('data'))->pluck('id');
+
+    expect($ids->all())->toBe([$furniture->public_id]);
+});
+
+it('keeps the subtree count equal to what the tree filter lists', function (): void {
+    $furniture = node('Furniture');
+    $sofas = node('Sofas', $furniture);
+
+    Product::factory()->create()->categories()->attach([$furniture->id, $sofas->id]);
+    Product::factory()->create()->categories()->attach($sofas->id);
+    Product::factory()->unpublished()->create()->categories()->attach($sofas->id);
+
+    $count = $this->getJson('/store/categories/'.$furniture->slug.'?include=products_count')
+        ->assertOk()
+        ->json('data.attributes.products_count');
+
+    $listed = $this->getJson('/store/products?filter[category_tree]='.$furniture->slug.'&page[size]=100')
+        ->assertOk()
+        ->json('data');
+
+    expect($count)->toBe(count($listed));
+});

--- a/tests/Api/Feature/CategoryTreeTest.php
+++ b/tests/Api/Feature/CategoryTreeTest.php
@@ -62,3 +62,39 @@ it('resolves the parent identifier through the children include too', function (
 
     expect($included['attributes']['parent_id'])->toBe($parent->public_id);
 });
+
+it('returns the nested public tree in one call', function (): void {
+    $root = category('TreeRoot');
+    $child = category('TreeChild', $root);
+    $grandchild = category('TreeGrand', $child);
+
+    $disabledRoot = Category::factory()->create(['name' => 'TreeHidden', 'is_enabled' => false]);
+    Category::factory()->create(['name' => 'TreeOrphan', 'is_enabled' => true, 'parent_id' => $disabledRoot->id]);
+
+    $data = collect($this->getJson('/store/categories/tree')->assertOk()->json('data'));
+
+    $names = $data->pluck('name');
+    expect($names)->toContain('TreeRoot')
+        ->and($names)->not->toContain('TreeHidden')
+        ->and($names)->not->toContain('TreeOrphan');
+
+    $rootNode = $data->firstWhere('name', 'TreeRoot');
+    expect($rootNode['id'])->toBe($root->public_id)
+        ->and($rootNode['slug'])->toBe($root->fresh()->slug)
+        ->and($rootNode['children'][0]['id'])->toBe($child->public_id)
+        ->and($rootNode['children'][0]['children'][0]['id'])->toBe($grandchild->public_id)
+        ->and($rootNode['children'][0]['children'][0]['children'])->toBe([]);
+});
+
+it('orders the tree nodes by position on every level', function (): void {
+    $root = category('PosRoot');
+    $second = category('PosSecond', $root);
+    $first = category('PosFirst', $root);
+    $second->update(['position' => 2]);
+    $first->update(['position' => 1]);
+
+    $rootNode = collect($this->getJson('/store/categories/tree')->assertOk()->json('data'))
+        ->firstWhere('name', 'PosRoot');
+
+    expect(collect($rootNode['children'])->pluck('name')->all())->toBe(['PosFirst', 'PosSecond']);
+});

--- a/tests/Api/Feature/IncludeVisibilityTest.php
+++ b/tests/Api/Feature/IncludeVisibilityTest.php
@@ -39,6 +39,17 @@ it('never includes a disabled category', function (): void {
     expect(includedNames($this, '/store/products/'.$product->slug.'?include=categories'))->toBe(['Visible']);
 });
 
+it('never includes a category hidden through a disabled ancestor', function (): void {
+    $disabledRoot = Category::factory()->create(['name' => 'AncestorOff', 'slug' => 'ancestor-off', 'is_enabled' => false]);
+    $orphan = Category::factory()->create(['name' => 'OrphanOn', 'slug' => 'orphan-on', 'is_enabled' => true, 'parent_id' => $disabledRoot->id]);
+    $visible = Category::factory()->create(['name' => 'StillOn', 'slug' => 'still-on', 'is_enabled' => true]);
+
+    $product = Product::factory()->publish()->create(['name' => 'P2', 'type' => ProductType::Standard]);
+    $product->categories()->attach([$visible->id, $orphan->id]);
+
+    expect(includedNames($this, '/store/products/'.$product->slug.'?include=categories'))->toBe(['StillOn']);
+});
+
 it('never includes a collection that is not published yet', function (): void {
     $live = Collection::factory()->create(['name' => 'Live', 'slug' => 'live', 'published_at' => now()->subDay()]);
     $embargoed = Collection::factory()->create(['name' => 'Embargoed', 'slug' => 'embargoed', 'published_at' => now()->addYear()]);
@@ -59,10 +70,7 @@ it('never includes a disabled child or parent category', function (): void {
     $hiddenRoot = Category::factory()->create(['name' => 'HiddenRoot', 'slug' => 'hidden-root', 'is_enabled' => false]);
     $child = Category::factory()->create(['name' => 'Orphan', 'slug' => 'orphan', 'is_enabled' => true, 'parent_id' => $hiddenRoot->id]);
 
-    $this->getJson('/store/categories/'.$child->slug.'?include=parent')
-        ->assertOk()
-        ->assertJsonPath('included', null)
-        ->assertJsonPath('data.attributes.parent_id', null);
+    $this->getJson('/store/categories/'.$child->slug.'?include=parent')->assertNotFound();
 });
 
 it('never includes a disabled zone', function (): void {

--- a/tests/Api/Feature/ProductCatalogTest.php
+++ b/tests/Api/Feature/ProductCatalogTest.php
@@ -10,8 +10,10 @@ use Shopper\Core\Models\Attribute;
 use Shopper\Core\Models\AttributeValue;
 use Shopper\Core\Models\Brand;
 use Shopper\Core\Models\Category;
+use Shopper\Core\Models\Collection;
 use Shopper\Core\Models\Contracts\AttributeProduct as AttributeProductContract;
 use Shopper\Core\Models\Currency;
+use Shopper\Core\Models\Inventory;
 use Shopper\Core\Models\Price;
 use Shopper\Core\Models\Product;
 use Shopper\Core\Models\ProductVariant;
@@ -19,15 +21,15 @@ use Shopper\Core\Models\Review;
 
 uses(Tests\Api\TestCase::class);
 
-function publishedProduct(array $attributes = []): Product
+function publishedProduct(array $attributes = [], int $amount = 2999): Product
 {
     $product = Product::factory()->publish()->create($attributes + ['type' => ProductType::Standard]);
 
     Price::factory()->create([
         'priceable_id' => $product->id,
         'priceable_type' => $product->getMorphClass(),
-        'currency_id' => Currency::query()->value('id'),
-        'amount' => 2999,
+        'currency_id' => Currency::query()->where('code', shopper_currency())->value('id'),
+        'amount' => $amount,
         'compare_amount' => 3999,
     ]);
 
@@ -167,6 +169,70 @@ it('filters products by category', function (): void {
     expect($names)->toContain('Pixel')->and($names)->not->toContain('Sneaker');
 });
 
+it('filters products by category subtree', function (): void {
+    $furniture = Category::factory()->create(['name' => 'Furniture', 'slug' => 'furniture']);
+    $sofas = Category::factory()->create(['name' => 'Sofas', 'parent_id' => $furniture->id]);
+    $corner = Category::factory()->create(['name' => 'Corner', 'parent_id' => $sofas->id]);
+    $garden = Category::factory()->create(['name' => 'Garden', 'slug' => 'garden']);
+    $pots = Category::factory()->create(['name' => 'Pots', 'parent_id' => $garden->id]);
+
+    $direct = publishedProduct(['name' => 'Bookshelf']);
+    $direct->categories()->attach($furniture);
+
+    $deep = publishedProduct(['name' => 'Corner Sofa']);
+    $deep->categories()->attach($corner);
+
+    $foreign = publishedProduct(['name' => 'Flower Pot']);
+    $foreign->categories()->attach($pots);
+
+    $names = collect($this->getJson('/store/products?filter[category_tree]=furniture')->assertOk()->json('data'))
+        ->pluck('attributes.name');
+
+    expect($names)->toContain('Bookshelf')
+        ->and($names)->toContain('Corner Sofa')
+        ->and($names)->not->toContain('Flower Pot');
+});
+
+it('returns no products for an unknown category subtree', function (): void {
+    publishedProduct(['name' => 'Pixel']);
+
+    $this->getJson('/store/products?filter[category_tree]=nope')
+        ->assertOk()
+        ->assertJsonCount(0, 'data');
+});
+
+it('filters products by category subtree through the public identifier', function (): void {
+    $furniture = Category::factory()->create(['name' => 'Furniture', 'slug' => 'furniture']);
+    $sofas = Category::factory()->create(['name' => 'Sofas', 'parent_id' => $furniture->id]);
+
+    publishedProduct(['name' => 'Bookshelf'])->categories()->attach($sofas);
+    publishedProduct(['name' => 'Flower Pot']);
+
+    $names = collect($this->getJson('/store/products?filter[category_tree]='.$furniture->public_id)->assertOk()->json('data'))
+        ->pluck('attributes.name');
+
+    expect($names)->toContain('Bookshelf')->and($names)->not->toContain('Flower Pot');
+});
+
+it('hides the products of a disabled category subtree', function (): void {
+    $furniture = Category::factory()->create(['name' => 'Furniture', 'slug' => 'furniture']);
+    $unreleased = Category::factory()->create(['name' => 'Unreleased', 'parent_id' => $furniture->id]);
+
+    publishedProduct(['name' => 'Secret Sofa'])->categories()->attach($unreleased);
+    publishedProduct(['name' => 'Bookshelf'])->categories()->attach($furniture);
+
+    $unreleased->update(['is_enabled' => false]);
+
+    $names = collect($this->getJson('/store/products?filter[category_tree]='.$furniture->slug)->assertOk()->json('data'))
+        ->pluck('attributes.name');
+
+    expect($names)->toContain('Bookshelf')->and($names)->not->toContain('Secret Sofa');
+
+    $this->getJson('/store/products?filter[category_tree]='.$unreleased->slug)
+        ->assertOk()
+        ->assertJsonCount(0, 'data');
+});
+
 it('searches products by term', function (): void {
     publishedProduct(['name' => 'Wireless Headphones']);
     publishedProduct(['name' => 'Running Shoes']);
@@ -300,8 +366,8 @@ it('shapes the payload by product type', function (): void {
         ->and($products->get('ShapeVariant'))->toHaveKey('in_stock')
         ->not->toHaveKeys(['stock', 'variants_stock', 'files'])
         ->and($products->get('ShapeVirtual'))->toHaveKeys(['files', 'stock', 'in_stock'])
-        ->and($products->get('ShapeExternal'))->toMatchArray(['external_id' => 'ext-42'])
-        ->not->toHaveKeys(['stock', 'variants_stock', 'in_stock', 'files']);
+        ->and($products->get('ShapeExternal'))->toMatchArray(['external_id' => 'ext-42', 'in_stock' => true])
+        ->not->toHaveKeys(['stock', 'variants_stock', 'files']);
 });
 
 it('only exposes the variants and options relationships for capable product types', function (): void {
@@ -380,4 +446,168 @@ it('filters and sorts the product list through the allowlist', function (): void
     )->pluck('attributes.name');
 
     expect($names->toArray())->toBe(['ZzzCatalogAlpha', 'ZzzCatalogBeta']);
+});
+
+it('lists the products matching any value of a multi-valued facet', function (): void {
+    $color = Attribute::factory()->create(['name' => 'Color']);
+    $red = AttributeValue::factory()->create(['attribute_id' => $color->id, 'value' => 'Red', 'key' => 'red']);
+    $blue = AttributeValue::factory()->create(['attribute_id' => $color->id, 'value' => 'Blue', 'key' => 'blue']);
+
+    $both = publishedProduct(['name' => 'FacetBoth', 'type' => ProductType::Variant]);
+    ProductVariant::factory()->create(['product_id' => $both->id])->values()->attach([$red->id, $blue->id]);
+
+    $blueOnly = publishedProduct(['name' => 'FacetBlue', 'type' => ProductType::Variant]);
+    ProductVariant::factory()->create(['product_id' => $blueOnly->id])->values()->attach($blue->id);
+
+    publishedProduct(['name' => 'FacetNone', 'type' => ProductType::Variant]);
+
+    $names = collect($this->getJson('/store/products?filter[option]=red,blue')->assertOk()->json('data'))
+        ->pluck('attributes.name')
+        ->sort()
+        ->values();
+
+    expect($names->all())->toBe(['FacetBlue', 'FacetBoth']);
+});
+
+it('keeps two different facets an intersection', function (): void {
+    $nordika = Brand::factory()->create(['name' => 'Nordika', 'slug' => 'nordika', 'is_enabled' => true]);
+    $hem = Brand::factory()->create(['name' => 'Hem', 'slug' => 'hem', 'is_enabled' => true]);
+
+    $color = Attribute::factory()->create(['name' => 'Color']);
+    $red = AttributeValue::factory()->create(['attribute_id' => $color->id, 'value' => 'Red', 'key' => 'red']);
+
+    $match = publishedProduct(['name' => 'IntersectHit', 'type' => ProductType::Variant, 'brand_id' => $nordika->id]);
+    ProductVariant::factory()->create(['product_id' => $match->id])->values()->attach($red->id);
+
+    $otherBrand = publishedProduct(['name' => 'IntersectMiss', 'type' => ProductType::Variant, 'brand_id' => $hem->id]);
+    ProductVariant::factory()->create(['product_id' => $otherBrand->id])->values()->attach($red->id);
+
+    $names = collect(
+        $this->getJson('/store/products?filter[option]=red&filter[brand]=nordika,unknown')->assertOk()->json('data')
+    )->pluck('attributes.name');
+
+    expect($names->all())->toBe(['IntersectHit']);
+});
+
+it('matches an option declared on a product that has no variants', function (): void {
+    $product = publishedProduct(['name' => 'StandardOption', 'type' => ProductType::Standard]);
+    $color = Attribute::factory()->create(['name' => 'Color']);
+    $green = AttributeValue::factory()->create(['attribute_id' => $color->id, 'value' => 'Green', 'key' => 'green']);
+    $product->options()->attach($color->id, ['attribute_value_id' => $green->id]);
+
+    publishedProduct(['name' => 'StandardPlain', 'type' => ProductType::Standard]);
+
+    $names = collect($this->getJson('/store/products?filter[option]=green')->assertOk()->json('data'))
+        ->pluck('attributes.name');
+
+    expect($names->all())->toBe(['StandardOption']);
+});
+
+it('never contradicts the in_stock attribute of the rows it filters', function (): void {
+    $inventory = Inventory::factory()->create();
+
+    publishedProduct(['name' => 'StockEmpty', 'type' => ProductType::Standard]);
+    publishedProduct(['name' => 'StockBackorder', 'type' => ProductType::Standard, 'allow_backorder' => true]);
+    publishedProduct(['name' => 'StockExternal', 'type' => ProductType::External]);
+    publishedProduct(['name' => 'StockLegacy', 'type' => null]);
+    publishedProduct(['name' => 'StockFilled', 'type' => ProductType::Standard])->mutateStock($inventory->id, 4);
+    publishedProduct(['name' => 'StockVirtual', 'type' => ProductType::Virtual])->mutateStock($inventory->id, 1);
+    publishedProduct(['name' => 'StockVariantEmpty', 'type' => ProductType::Variant]);
+
+    $negative = publishedProduct(['name' => 'StockNegative', 'type' => ProductType::Standard]);
+    $negative->mutateStock($inventory->id, 2);
+    $negative->decreaseStock($inventory->id, 5);
+
+    $variantProduct = publishedProduct(['name' => 'StockVariant', 'type' => ProductType::Variant]);
+    ProductVariant::factory()->create(['product_id' => $variantProduct->id])->mutateStock($inventory->id, 2);
+
+    $all = collect($this->getJson('/store/products?page[size]=50')->assertOk()->json('data'));
+    $available = collect($this->getJson('/store/products?filter[in_stock]=1&page[size]=50')->assertOk()->json('data'));
+    $unavailable = collect($this->getJson('/store/products?filter[in_stock]=false&page[size]=50')->assertOk()->json('data'));
+
+    expect($available->pluck('attributes.name')->sort()->values()->all())
+        ->toBe(['StockBackorder', 'StockExternal', 'StockFilled', 'StockVariant', 'StockVirtual'])
+        ->and($unavailable->pluck('attributes.name')->sort()->values()->all())
+        ->toBe(['StockEmpty', 'StockLegacy', 'StockNegative', 'StockVariantEmpty'])
+        ->and($available->count() + $unavailable->count())->toBe($all->count())
+        ->and($available->firstWhere('attributes.name', 'StockExternal')['attributes']['in_stock'])->toBeTrue()
+        ->and($available->pluck('attributes.in_stock')->filter(fn (?bool $value): bool => $value === false))->toBeEmpty()
+        ->and($unavailable->pluck('attributes.in_stock')->filter(fn (?bool $value): bool => $value === true))->toBeEmpty();
+});
+
+it('hides the products reached through a disabled category, brand or unpublished collection facet', function (): void {
+    $staged = Category::factory()->create(['name' => 'Staged', 'slug' => 'staged', 'is_enabled' => false]);
+    publishedProduct(['name' => 'StagedProduct'])->categories()->attach($staged);
+
+    $ghost = Brand::factory()->create(['name' => 'Ghost', 'slug' => 'ghost', 'is_enabled' => false]);
+    publishedProduct(['name' => 'GhostProduct', 'brand_id' => $ghost->id]);
+
+    $embargoed = Collection::factory()->create(['name' => 'Embargoed', 'slug' => 'embargoed', 'published_at' => now()->addYear()]);
+    publishedProduct(['name' => 'EmbargoedProduct'])->collections()->attach($embargoed->id);
+
+    $this->getJson('/store/products?filter[category]=staged')->assertOk()->assertJsonCount(0, 'data');
+    $this->getJson('/store/products?filter[brand]=ghost')->assertOk()->assertJsonCount(0, 'data');
+    $this->getJson('/store/products?filter[collection]=embargoed')->assertOk()->assertJsonCount(0, 'data');
+});
+
+it('unions the subtrees of two category_tree values and skips an unknown one', function (): void {
+    $furniture = Category::factory()->create(['name' => 'Furniture', 'slug' => 'furniture']);
+    $garden = Category::factory()->create(['name' => 'Garden', 'slug' => 'garden']);
+
+    publishedProduct(['name' => 'Bookshelf'])->categories()->attach($furniture);
+    publishedProduct(['name' => 'FlowerPot'])->categories()->attach($garden);
+    publishedProduct(['name' => 'Standalone']);
+
+    $names = collect(
+        $this->getJson('/store/products?filter[category_tree]=furniture,garden,nope')->assertOk()->json('data')
+    )->pluck('attributes.name')->sort()->values();
+
+    expect($names->all())->toBe(['Bookshelf', 'FlowerPot']);
+});
+
+it('refuses a filter carrying more values than the allowed breadth', function (): void {
+    publishedProduct(['name' => 'Pixel']);
+
+    $this->getJson('/store/products?filter[option]='.implode(',', range(1, 51)))->assertStatus(422);
+
+    $this->getJson('/store/products?filter[option]='.implode(',', range(1, 50)))
+        ->assertOk()
+        ->assertJsonCount(0, 'data');
+});
+
+it('bounds the listing prices on the result before the price filters narrow it', function (): void {
+    publishedProduct(['name' => 'BoundCheap'], amount: 1000);
+    publishedProduct(['name' => 'BoundMid'], amount: 5000);
+    publishedProduct(['name' => 'BoundPricey'], amount: 245000);
+
+    $response = $this->getJson('/store/products?include=price_range&filter[price_min]=4000')->assertOk();
+
+    expect($response->json('meta.price_range'))->toBe([
+        'min' => 1000,
+        'max' => 245000,
+        'currency_code' => $response->json('meta.currency'),
+    ])
+        ->and(collect($response->json('data'))->pluck('attributes.name')->sort()->values()->all())
+        ->toBe(['BoundMid', 'BoundPricey']);
+});
+
+it('bounds the listing prices within the other filters and omits them unless asked', function (): void {
+    $nordika = Brand::factory()->create(['name' => 'Nordika', 'slug' => 'nordika', 'is_enabled' => true]);
+
+    publishedProduct(['name' => 'ScopedIn', 'brand_id' => $nordika->id], amount: 1000);
+    publishedProduct(['name' => 'ScopedOut'], amount: 900000);
+
+    $scoped = $this->getJson('/store/products?include=price_range&filter[brand]=nordika')->assertOk();
+
+    expect($scoped->json('meta.price_range.min'))->toBe(1000)
+        ->and($scoped->json('meta.price_range.max'))->toBe(1000)
+        ->and($this->getJson('/store/products')->assertOk()->json('meta'))->not->toHaveKey('price_range');
+});
+
+it('returns a null price range when nothing in the result carries a price', function (): void {
+    Product::factory()->publish()->create(['name' => 'Unpriced', 'type' => ProductType::Standard]);
+
+    $this->getJson('/store/products?include=price_range&filter[name]=Unpriced')
+        ->assertOk()
+        ->assertJsonPath('meta.price_range', null);
 });

--- a/tests/Core/Models/CategoryTest.php
+++ b/tests/Core/Models/CategoryTest.php
@@ -119,4 +119,20 @@ describe(Category::class, function (): void {
         expect($category->metadata)->toBeArray()
             ->and($category->metadata)->toBe($metadata);
     });
+
+    it('rejects moving a category under one of its own descendants', function (): void {
+        $furniture = Category::factory()->create(['slug' => 'furniture']);
+        $sofas = Category::factory()->create(['slug' => 'sofas', 'parent_id' => $furniture->id]);
+        $corner = Category::factory()->create(['slug' => 'corner', 'parent_id' => $sofas->id]);
+
+        expect(fn () => $furniture->update(['parent_id' => (string) $corner->id]))
+            ->toThrow(RuntimeException::class);
+    });
+
+    it('rejects a category submitted as its own parent, even as a string', function (): void {
+        $furniture = Category::factory()->create(['slug' => 'furniture']);
+
+        expect(fn () => $furniture->update(['parent_id' => (string) $furniture->id]))
+            ->toThrow(RuntimeException::class);
+    });
 })->group('category', 'models');


### PR DESCRIPTION
## What

Builds the storefront listing surface of the Store API so a headless frontend can render category pages, filters and navigation without custom queries.

### Products
* `filter[in_stock]` availability filter branched by product type, external products always count as available
* `filter[category_tree]` subtree filter resolved through the cached category tree
* `filter[tag]`, `filter[option]` and multi value filters guarded by a breadth ceiling (50 values per filter, 422 above)
* `sort=price` and `include=price_range` on the filtered listing, expressed in the resolved currency
* `include=tags` on listings and detail

### Categories
* `GET /store/categories/tree` returns the full nested visible tree in one call and one query
* `depth` and opt-in `products_count` (distinct public products in the subtree, computed in SQL) on category payloads
* disabled categories and every descendant of a disabled ancestor are hidden consistently across listings, detail, filters and includes, backed by a cached category tree invalidated on save and delete

### Tags
* `GET /store/tags` public listing, `include=products` restricted to public products

### SDK
* `sdk.store.tag.list()`, `sdk.store.category.tree()`, `CategoryTreeNode` and listing meta types

## Breaking changes

* `Category` contract gains `enabledSubtreeIds()`
* `GET /store/categories/{slug}` now returns 404 for a category under a disabled ancestor
* published `api.php` config files need the new `resources` keys to expose the added filters and includes