### PR TITLE
feat(api): make the store resources replaceable through a manifest

### DIFF
--- a/packages/api/src/ApiServiceProvider.php
+++ b/packages/api/src/ApiServiceProvider.php
@@ -24,6 +24,8 @@ final class ApiServiceProvider extends PackageServiceProvider
     public function packageRegistered(): void
     {
         $this->mergeConfigFrom(__DIR__.'/../config/api.php', 'shopper.api');
+
+        $this->app->singleton(Support\ResourceManifest::class);
     }
 
     public function packageBooted(): void

--- a/packages/api/src/Concerns/SerializesMedia.php
+++ b/packages/api/src/Concerns/SerializesMedia.php
@@ -47,7 +47,7 @@ trait SerializesMedia
     /**
      * @return array<int, array<string, mixed>>
      */
-    private function mediaPayload(string $collection): array
+    protected function mediaPayload(string $collection): array
     {
         if (! method_exists($this->resource, 'getMedia')) {
             return [];
@@ -62,7 +62,7 @@ trait SerializesMedia
     /**
      * @return array<string, mixed>|null
      */
-    private function firstMediaPayload(string $collection): ?array
+    protected function firstMediaPayload(string $collection): ?array
     {
         if (! method_exists($this->resource, 'getFirstMedia')) {
             return null;
@@ -76,7 +76,7 @@ trait SerializesMedia
     /**
      * @return array<string, mixed>
      */
-    private function mediaToArray(Media $media): array
+    protected function mediaToArray(Media $media): array
     {
         return [
             'id' => $media->uuid,
@@ -97,7 +97,7 @@ trait SerializesMedia
      *
      * @return array<string, string>
      */
-    private function conversionUrls(Media $media): array
+    protected function conversionUrls(Media $media): array
     {
         return $media->getGeneratedConversions()
             ->filter()

--- a/packages/api/src/Facades/ApiResource.php
+++ b/packages/api/src/Facades/ApiResource.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Api\Facades;
+
+use Illuminate\Support\Facades\Facade;
+use Shopper\Api\Support\ResourceManifest;
+
+/**
+ * @method static void replace(string|array $resource, ?string $replacement = null)
+ * @method static string for(string $resource)
+ *
+ * @see ResourceManifest
+ */
+final class ApiResource extends Facade
+{
+    protected static function getFacadeAccessor(): string
+    {
+        return ResourceManifest::class;
+    }
+}

--- a/packages/api/src/Http/Resources/AddressResource.php
+++ b/packages/api/src/Http/Resources/AddressResource.php
@@ -10,9 +10,9 @@ use Shopper\Core\Models\Address;
 /**
  * @mixin Address
  */
-final class AddressResource extends JsonApiResource
+class AddressResource extends JsonApiResource
 {
-    public function toType(Request $request): string
+    final public function toType(Request $request): string
     {
         return 'addresses';
     }

--- a/packages/api/src/Http/Resources/AttributeResource.php
+++ b/packages/api/src/Http/Resources/AttributeResource.php
@@ -11,9 +11,9 @@ use Shopper\Core\Models\AttributeValue;
 /**
  * @mixin Attribute
  */
-final class AttributeResource extends JsonApiResource
+class AttributeResource extends JsonApiResource
 {
-    public function toType(Request $request): string
+    final public function toType(Request $request): string
     {
         return 'attributes';
     }

--- a/packages/api/src/Http/Resources/BrandResource.php
+++ b/packages/api/src/Http/Resources/BrandResource.php
@@ -11,11 +11,11 @@ use Shopper\Core\Models\Brand;
 /**
  * @mixin Brand
  */
-final class BrandResource extends JsonApiResource
+class BrandResource extends JsonApiResource
 {
     use SerializesMedia;
 
-    public function toType(Request $request): string
+    final public function toType(Request $request): string
     {
         return 'brands';
     }

--- a/packages/api/src/Http/Resources/CartAddressResource.php
+++ b/packages/api/src/Http/Resources/CartAddressResource.php
@@ -10,9 +10,9 @@ use Shopper\Cart\Models\CartAddress;
 /**
  * @mixin CartAddress
  */
-final class CartAddressResource extends JsonApiResource
+class CartAddressResource extends JsonApiResource
 {
-    public function toType(Request $request): string
+    final public function toType(Request $request): string
     {
         return 'cart-addresses';
     }

--- a/packages/api/src/Http/Resources/CartLineResource.php
+++ b/packages/api/src/Http/Resources/CartLineResource.php
@@ -14,9 +14,9 @@ use TiMacDonald\JsonApi\JsonApiResource as BaseJsonApiResource;
 /**
  * @mixin CartLine
  */
-final class CartLineResource extends JsonApiResource
+class CartLineResource extends JsonApiResource
 {
-    public function toType(Request $request): string
+    final public function toType(Request $request): string
     {
         return 'cart-lines';
     }

--- a/packages/api/src/Http/Resources/CartResource.php
+++ b/packages/api/src/Http/Resources/CartResource.php
@@ -13,20 +13,20 @@ use TiMacDonald\JsonApi\JsonApiResourceCollection;
 /**
  * @mixin Cart
  */
-final class CartResource extends JsonApiResource
+class CartResource extends JsonApiResource
 {
     private ?CartPipelineContext $totals = null;
+
+    final public function toType(Request $request): string
+    {
+        return 'carts';
+    }
 
     public function withTotals(CartPipelineContext $context): self
     {
         $this->totals = $context;
 
         return $this;
-    }
-
-    public function toType(Request $request): string
-    {
-        return 'carts';
     }
 
     public function toAttributes(Request $request): array

--- a/packages/api/src/Http/Resources/CategoryResource.php
+++ b/packages/api/src/Http/Resources/CategoryResource.php
@@ -14,11 +14,11 @@ use Shopper\Core\Models\Category;
  *
  * @property-read ?int $depth
  */
-final class CategoryResource extends JsonApiResource
+class CategoryResource extends JsonApiResource
 {
     use SerializesMedia;
 
-    public function toType(Request $request): string
+    final public function toType(Request $request): string
     {
         return 'categories';
     }

--- a/packages/api/src/Http/Resources/CollectionResource.php
+++ b/packages/api/src/Http/Resources/CollectionResource.php
@@ -11,11 +11,11 @@ use Shopper\Models\Collection;
 /**
  * @mixin Collection
  */
-final class CollectionResource extends JsonApiResource
+class CollectionResource extends JsonApiResource
 {
     use SerializesMedia;
 
-    public function toType(Request $request): string
+    final public function toType(Request $request): string
     {
         return 'collections';
     }

--- a/packages/api/src/Http/Resources/CountryResource.php
+++ b/packages/api/src/Http/Resources/CountryResource.php
@@ -10,9 +10,9 @@ use Shopper\Core\Models\Country;
 /**
  * @mixin Country
  */
-final class CountryResource extends JsonApiResource
+class CountryResource extends JsonApiResource
 {
-    public function toType(Request $request): string
+    final public function toType(Request $request): string
     {
         return 'countries';
     }

--- a/packages/api/src/Http/Resources/CurrencyResource.php
+++ b/packages/api/src/Http/Resources/CurrencyResource.php
@@ -10,9 +10,9 @@ use Shopper\Core\Models\Currency;
 /**
  * @mixin Currency
  */
-final class CurrencyResource extends JsonApiResource
+class CurrencyResource extends JsonApiResource
 {
-    public function toType(Request $request): string
+    final public function toType(Request $request): string
     {
         return 'currencies';
     }

--- a/packages/api/src/Http/Resources/CustomerResource.php
+++ b/packages/api/src/Http/Resources/CustomerResource.php
@@ -24,9 +24,9 @@ use Shopper\Core\Enum\GenderType;
  * @property-read ?CarbonInterface $email_verified_at
  * @property-read ?CarbonInterface $created_at
  */
-final class CustomerResource extends JsonApiResource
+class CustomerResource extends JsonApiResource
 {
-    public function toType(Request $request): string
+    final public function toType(Request $request): string
     {
         return 'customers';
     }

--- a/packages/api/src/Http/Resources/JsonApiResource.php
+++ b/packages/api/src/Http/Resources/JsonApiResource.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Shopper\Api\Http\Resources;
 
 use Illuminate\Http\Request;
+use Shopper\Api\Support\ResourceManifest;
 use TiMacDonald\JsonApi\JsonApiResource as BaseJsonApiResource;
 
 /**
@@ -15,9 +16,31 @@ use TiMacDonald\JsonApi\JsonApiResource as BaseJsonApiResource;
  * Concrete resources declare their shape with the `$attributes` /
  * `$relationships` properties or by overriding `toAttributes()` /
  * `toRelationships()`.
+ *
+ * A resource registered through ApiResource::replace() is resolved here, so
+ * every call site (controllers, nested relationships, traits) serializes with
+ * the replacement without being aware of it.
  */
 abstract class JsonApiResource extends BaseJsonApiResource
 {
+    public static function make(...$parameters)
+    {
+        $resolved = app(ResourceManifest::class)->for(static::class);
+
+        return $resolved === static::class
+            ? parent::make(...$parameters)
+            : $resolved::make(...$parameters);
+    }
+
+    public static function collection(mixed $resource)
+    {
+        $resolved = app(ResourceManifest::class)->for(static::class);
+
+        return $resolved === static::class
+            ? parent::collection($resource)
+            : $resolved::collection($resource);
+    }
+
     /**
      * The external id is the stable, non-sequential public_id (ULID) rather
      * than the auto-increment primary key. Models without a public_id fall

--- a/packages/api/src/Http/Resources/LegalResource.php
+++ b/packages/api/src/Http/Resources/LegalResource.php
@@ -10,9 +10,9 @@ use Shopper\Core\Models\Legal;
 /**
  * @mixin Legal
  */
-final class LegalResource extends JsonApiResource
+class LegalResource extends JsonApiResource
 {
-    public function toType(Request $request): string
+    final public function toType(Request $request): string
     {
         return 'legals';
     }

--- a/packages/api/src/Http/Resources/OrderAddressResource.php
+++ b/packages/api/src/Http/Resources/OrderAddressResource.php
@@ -10,9 +10,9 @@ use Shopper\Core\Models\OrderAddress;
 /**
  * @mixin OrderAddress
  */
-final class OrderAddressResource extends JsonApiResource
+class OrderAddressResource extends JsonApiResource
 {
-    public function toType(Request $request): string
+    final public function toType(Request $request): string
     {
         return 'order-addresses';
     }

--- a/packages/api/src/Http/Resources/OrderItemResource.php
+++ b/packages/api/src/Http/Resources/OrderItemResource.php
@@ -10,9 +10,9 @@ use Shopper\Core\Models\OrderItem;
 /**
  * @mixin OrderItem
  */
-final class OrderItemResource extends JsonApiResource
+class OrderItemResource extends JsonApiResource
 {
-    public function toType(Request $request): string
+    final public function toType(Request $request): string
     {
         return 'order-items';
     }

--- a/packages/api/src/Http/Resources/OrderRefundResource.php
+++ b/packages/api/src/Http/Resources/OrderRefundResource.php
@@ -10,9 +10,9 @@ use Shopper\Core\Models\OrderRefund;
 /**
  * @mixin OrderRefund
  */
-final class OrderRefundResource extends JsonApiResource
+class OrderRefundResource extends JsonApiResource
 {
-    public function toType(Request $request): string
+    final public function toType(Request $request): string
     {
         return 'order-refunds';
     }

--- a/packages/api/src/Http/Resources/OrderResource.php
+++ b/packages/api/src/Http/Resources/OrderResource.php
@@ -10,9 +10,9 @@ use Shopper\Core\Models\Order;
 /**
  * @mixin Order
  */
-final class OrderResource extends JsonApiResource
+class OrderResource extends JsonApiResource
 {
-    public function toType(Request $request): string
+    final public function toType(Request $request): string
     {
         return 'orders';
     }

--- a/packages/api/src/Http/Resources/OrderShippingEventResource.php
+++ b/packages/api/src/Http/Resources/OrderShippingEventResource.php
@@ -10,9 +10,9 @@ use Shopper\Core\Models\OrderShippingEvent;
 /**
  * @mixin OrderShippingEvent
  */
-final class OrderShippingEventResource extends JsonApiResource
+class OrderShippingEventResource extends JsonApiResource
 {
-    public function toType(Request $request): string
+    final public function toType(Request $request): string
     {
         return 'order-shipping-events';
     }

--- a/packages/api/src/Http/Resources/OrderShippingResource.php
+++ b/packages/api/src/Http/Resources/OrderShippingResource.php
@@ -15,9 +15,9 @@ use TiMacDonald\JsonApi\JsonApiResourceCollection;
  *
  * @mixin OrderShipping
  */
-final class OrderShippingResource extends JsonApiResource
+class OrderShippingResource extends JsonApiResource
 {
-    public function toType(Request $request): string
+    final public function toType(Request $request): string
     {
         return 'order-shippings';
     }

--- a/packages/api/src/Http/Resources/PaymentMethodResource.php
+++ b/packages/api/src/Http/Resources/PaymentMethodResource.php
@@ -10,9 +10,9 @@ use Shopper\Core\Models\PaymentMethod;
 /**
  * @mixin PaymentMethod
  */
-final class PaymentMethodResource extends JsonApiResource
+class PaymentMethodResource extends JsonApiResource
 {
-    public function toType(Request $request): string
+    final public function toType(Request $request): string
     {
         return 'payment-methods';
     }

--- a/packages/api/src/Http/Resources/PaymentSessionResource.php
+++ b/packages/api/src/Http/Resources/PaymentSessionResource.php
@@ -16,7 +16,7 @@ use Shopper\Api\Support\PaymentSession;
  *
  * @property PaymentSession $resource
  */
-final class PaymentSessionResource extends JsonApiResource
+class PaymentSessionResource extends JsonApiResource
 {
     /**
      * The driver `data` array is an internal grab bag: only keys a storefront
@@ -31,7 +31,7 @@ final class PaymentSessionResource extends JsonApiResource
         return $this->resource->id();
     }
 
-    public function toType(Request $request): string
+    final public function toType(Request $request): string
     {
         return 'payment-sessions';
     }

--- a/packages/api/src/Http/Resources/ProductResource.php
+++ b/packages/api/src/Http/Resources/ProductResource.php
@@ -18,12 +18,12 @@ use Spatie\MediaLibrary\MediaCollections\Models\Media;
 /**
  * @mixin Product
  */
-final class ProductResource extends JsonApiResource
+class ProductResource extends JsonApiResource
 {
     use SerializesMedia;
     use SerializesPrices;
 
-    public function toType(Request $request): string
+    final public function toType(Request $request): string
     {
         return 'products';
     }

--- a/packages/api/src/Http/Resources/ProductVariantResource.php
+++ b/packages/api/src/Http/Resources/ProductVariantResource.php
@@ -13,12 +13,12 @@ use Shopper\Core\Models\ProductVariant;
 /**
  * @mixin ProductVariant
  */
-final class ProductVariantResource extends JsonApiResource
+class ProductVariantResource extends JsonApiResource
 {
     use SerializesMedia;
     use SerializesPrices;
 
-    public function toType(Request $request): string
+    final public function toType(Request $request): string
     {
         return 'variants';
     }

--- a/packages/api/src/Http/Resources/ReviewResource.php
+++ b/packages/api/src/Http/Resources/ReviewResource.php
@@ -10,9 +10,9 @@ use Shopper\Core\Models\Review;
 /**
  * @mixin Review
  */
-final class ReviewResource extends JsonApiResource
+class ReviewResource extends JsonApiResource
 {
-    public function toType(Request $request): string
+    final public function toType(Request $request): string
     {
         return 'reviews';
     }

--- a/packages/api/src/Http/Resources/SettingResource.php
+++ b/packages/api/src/Http/Resources/SettingResource.php
@@ -6,7 +6,7 @@ namespace Shopper\Api\Http\Resources;
 
 use Illuminate\Http\Request;
 
-final class SettingResource extends JsonApiResource
+class SettingResource extends JsonApiResource
 {
     /**
      * The store settings are a singleton, not a row: the id is the constant
@@ -17,7 +17,7 @@ final class SettingResource extends JsonApiResource
         return 'store';
     }
 
-    public function toType(Request $request): string
+    final public function toType(Request $request): string
     {
         return 'settings';
     }

--- a/packages/api/src/Http/Resources/ShippingOptionResource.php
+++ b/packages/api/src/Http/Resources/ShippingOptionResource.php
@@ -14,14 +14,14 @@ use Shopper\Api\Support\ShippingOption;
  *
  * @property ShippingOption $resource
  */
-final class ShippingOptionResource extends JsonApiResource
+class ShippingOptionResource extends JsonApiResource
 {
     public function toId(Request $request): string
     {
         return $this->resource->id();
     }
 
-    public function toType(Request $request): string
+    final public function toType(Request $request): string
     {
         return 'shipping-options';
     }

--- a/packages/api/src/Http/Resources/TagResource.php
+++ b/packages/api/src/Http/Resources/TagResource.php
@@ -10,9 +10,9 @@ use Shopper\Core\Models\ProductTag;
 /**
  * @mixin ProductTag
  */
-final class TagResource extends JsonApiResource
+class TagResource extends JsonApiResource
 {
-    public function toType(Request $request): string
+    final public function toType(Request $request): string
     {
         return 'tags';
     }

--- a/packages/api/src/Http/Resources/ZoneResource.php
+++ b/packages/api/src/Http/Resources/ZoneResource.php
@@ -10,9 +10,9 @@ use Shopper\Core\Models\Zone;
 /**
  * @mixin Zone
  */
-final class ZoneResource extends JsonApiResource
+class ZoneResource extends JsonApiResource
 {
-    public function toType(Request $request): string
+    final public function toType(Request $request): string
     {
         return 'zones';
     }

--- a/packages/api/src/Support/ResourceManifest.php
+++ b/packages/api/src/Support/ResourceManifest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Api\Support;
+
+use InvalidArgumentException;
+use Shopper\Api\Http\Resources\JsonApiResource;
+
+final class ResourceManifest
+{
+    /** @var array<class-string<JsonApiResource>, class-string<JsonApiResource>> */
+    private array $replacements = [];
+
+    /**
+     * @param  class-string<JsonApiResource>|array<class-string<JsonApiResource>, class-string<JsonApiResource>>  $resource
+     * @param  class-string<JsonApiResource>|null  $replacement
+     */
+    public function replace(string|array $resource, ?string $replacement = null): void
+    {
+        $replacements = is_array($resource) ? $resource : [$resource => $replacement];
+
+        foreach ($replacements as $stock => $custom) {
+            if (! is_string($custom) || ! is_a($custom, $stock, true)) {
+                throw new InvalidArgumentException(sprintf(
+                    'The resource [%s] must extend [%s] to replace it.',
+                    is_string($custom) ? $custom : get_debug_type($custom),
+                    $stock,
+                ));
+            }
+        }
+
+        $this->replacements = [...$this->replacements, ...$replacements];
+    }
+
+    /**
+     * @template TResource of JsonApiResource
+     *
+     * @param  class-string<TResource>  $resource
+     * @return class-string<TResource>
+     */
+    public function for(string $resource): string
+    {
+        return $this->replacements[$resource] ?? $resource;
+    }
+}

--- a/tests/Api/Feature/ProductCatalogTest.php
+++ b/tests/Api/Feature/ProductCatalogTest.php
@@ -51,6 +51,14 @@ it('shows a product by slug as a JSON:API document', function (): void {
         ->assertJsonPath('data.attributes.prices.0.currency_code', $product->prices()->first()->currency_code);
 });
 
+it('keeps the price payload limited to its public keys', function (): void {
+    $product = publishedProduct(['name' => 'Guarded']);
+
+    $keys = array_keys($this->getJson('/store/products/'.$product->slug)->json('data.attributes.prices.0'));
+
+    expect($keys)->toBe(['public_id', 'amount', 'compare_amount', 'currency_code']);
+});
+
 it('falls back to the first gallery image for the thumbnail payload', function (): void {
     $product = publishedProduct(['name' => 'Camera']);
 

--- a/tests/Api/Feature/ResourceManifestTest.php
+++ b/tests/Api/Feature/ResourceManifestTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+use Shopper\Api\Facades\ApiResource;
+use Shopper\Api\Http\Resources\BrandResource;
+use Shopper\Api\Http\Resources\ProductResource;
+use Shopper\Core\Models\Brand;
+use Shopper\Core\Models\Currency;
+use Shopper\Core\Models\Inventory;
+use Shopper\Core\Models\Product;
+use Tests\Api\Stubs\CustomBrandResource;
+use Tests\Api\Stubs\CustomProductResource;
+use Tests\Api\Stubs\ProductStubResource;
+
+uses(Tests\Api\TestCase::class);
+
+it('serializes the listing and the detail with the replacement resource', function (): void {
+    ApiResource::replace(ProductResource::class, CustomProductResource::class);
+
+    $product = Product::factory()->publish()->create(['name' => 'Swapped']);
+
+    $this->getJson('/store/products')
+        ->assertOk()
+        ->assertJsonPath('data.0.attributes.warehouse_code', 'WH-'.$product->id);
+
+    $this->getJson('/store/products/'.$product->slug)
+        ->assertOk()
+        ->assertJsonPath('data.attributes.warehouse_code', 'WH-'.$product->id);
+});
+
+it('serializes nested relationships with the replacement resource', function (): void {
+    ApiResource::replace(ProductResource::class, CustomProductResource::class);
+
+    $brand = Brand::factory()->create(['name' => 'BrandSwap', 'slug' => 'brand-swap', 'is_enabled' => true]);
+    $product = Product::factory()->publish()->create(['brand_id' => $brand->id]);
+
+    $this->getJson('/store/brands/'.$brand->slug.'?include=products')
+        ->assertOk()
+        ->assertJsonPath('included.0.type', 'products')
+        ->assertJsonPath('included.0.attributes.warehouse_code', 'WH-'.$product->id);
+});
+
+it('applies every replacement of a batched call', function (): void {
+    ApiResource::replace([
+        ProductResource::class => CustomProductResource::class,
+        BrandResource::class => CustomBrandResource::class,
+    ]);
+
+    $brand = Brand::factory()->create(['name' => 'BrandBatch', 'slug' => 'brand-batch', 'is_enabled' => true]);
+    $product = Product::factory()->publish()->create(['brand_id' => $brand->id]);
+
+    $this->getJson('/store/products/'.$product->slug.'?include=brand')
+        ->assertOk()
+        ->assertJsonPath('data.attributes.warehouse_code', 'WH-'.$product->id)
+        ->assertJsonPath('included.0.attributes.brand_flag', 'custom');
+});
+
+it('registers nothing when one entry of a batched call is invalid', function (): void {
+    expect(fn () => ApiResource::replace([
+        ProductResource::class => CustomProductResource::class,
+        BrandResource::class => ProductStubResource::class,
+    ]))->toThrow(InvalidArgumentException::class);
+
+    $product = Product::factory()->publish()->create();
+
+    expect($this->getJson('/store/products/'.$product->slug)->assertOk()->json('data.attributes'))
+        ->not->toHaveKey('warehouse_code');
+});
+
+it('serializes the cart purchasable with the replacement resource', function (): void {
+    ApiResource::replace(ProductResource::class, CustomProductResource::class);
+
+    setupCurrencies();
+    $currency = Currency::query()->where('code', 'USD')->first();
+    $inventory = Inventory::factory()->create();
+
+    $product = Product::factory()->standard()->publish()->create();
+    $product->prices()->create(['amount' => 2500, 'currency_id' => $currency->id]);
+    $product->mutateStock($inventory->id, 50);
+
+    $cartId = $this->postJson('/store/carts')->json('data.id');
+
+    $response = $this->postJson("/store/carts/{$cartId}/lines?include=lines.purchasable", [
+        'purchasable_type' => 'product',
+        'purchasable_id' => $product->public_id,
+    ])->assertOk();
+
+    $included = collect($response->json('included'))->where('type', 'products')->sole();
+
+    expect($included['attributes']['warehouse_code'])->toBe('WH-'.$product->id);
+});
+
+it('rejects a replacement that does not extend the stock resource', function (): void {
+    expect(fn () => ApiResource::replace(ProductResource::class, ProductStubResource::class))
+        ->toThrow(InvalidArgumentException::class);
+});

--- a/tests/Api/Stubs/CustomBrandResource.php
+++ b/tests/Api/Stubs/CustomBrandResource.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Api\Stubs;
+
+use Illuminate\Http\Request;
+use Shopper\Api\Http\Resources\BrandResource;
+
+class CustomBrandResource extends BrandResource
+{
+    public function toAttributes(Request $request): array
+    {
+        return [
+            ...parent::toAttributes($request),
+            'brand_flag' => 'custom',
+        ];
+    }
+}

--- a/tests/Api/Stubs/CustomProductResource.php
+++ b/tests/Api/Stubs/CustomProductResource.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Api\Stubs;
+
+use Illuminate\Http\Request;
+use Shopper\Api\Http\Resources\ProductResource;
+
+class CustomProductResource extends ProductResource
+{
+    public function toAttributes(Request $request): array
+    {
+        return [
+            ...parent::toAttributes($request),
+            'warehouse_code' => 'WH-'.$this->resource->getKey(),
+        ];
+    }
+}


### PR DESCRIPTION
## Summary

- adds a `ResourceManifest` singleton and the `ApiResource` facade to the api package: `ApiResource::replace(ProductResource::class, CustomProductResource::class)` registers a replacement for any store resource, in a single call or batched
- the replacement must extend the stock resource it replaces, validated when `replace()` runs so a wrong wiring fails at boot instead of returning broken payloads, and a batch is validated entirely before anything is registered
- `JsonApiResource::make()` and `collection()` resolve the replacement transparently, so every call site serializes with it: controllers, nested relationships (`categories?include=products`), cart lines and the cart traits, without touching any of them
- removes `final` from the 27 store resources so a project can extend them, and locks `toType()` instead: the JSON:API type is the contract sparse fieldsets, included deduplication and the SDK indexing rely on, a replacement cannot change it
- widens the `SerializesMedia` helpers to `protected` so a replacement or an addon concern can reuse the exact media payload, conversions included
- adds a guard test pinning the stock price payload to its public keys

## Usage

```php
// app/Providers/AppServiceProvider.php
use Shopper\Api\Facades\ApiResource;

ApiResource::replace(ProductResource::class, CustomProductResource::class);
```

The default behavior is unchanged: without a registered replacement every resource resolves to itself and the payloads are byte for byte identical.