### PR TITLE
fix(security): restrict avatar, logo and cover uploads to curated mime types

### DIFF
--- a/packages/admin/src/Livewire/Components/Account/Profile.php
+++ b/packages/admin/src/Livewire/Components/Account/Profile.php
@@ -50,7 +50,7 @@ class Profile extends Component implements HasActions, HasSchemas
                         FileUpload::make('avatar_location')
                             ->label(__('shopper::forms.label.photo'))
                             ->avatar()
-                            ->image()
+                            ->acceptedFileTypes(config('shopper.media.accepts_mime_types'))
                             ->maxSize(1024)
                             ->disk(config('shopper.media.storage.disk_name')),
                         Grid::make()

--- a/packages/admin/src/Livewire/Pages/Settings/General.php
+++ b/packages/admin/src/Livewire/Pages/Settings/General.php
@@ -121,12 +121,12 @@ class General extends Component implements HasActions, HasSchemas
                         FileUpload::make('logo')
                             ->label(__('shopper::forms.label.logo'))
                             ->avatar()
-                            ->image()
+                            ->acceptedFileTypes(config('shopper.media.accepts_mime_types'))
                             ->maxSize(1024)
                             ->disk(config('shopper.media.storage.disk_name')),
                         FileUpload::make('cover')
                             ->label(__('shopper::forms.label.cover_photo'))
-                            ->image()
+                            ->acceptedFileTypes(config('shopper.media.accepts_mime_types'))
                             ->maxSize(1024)
                             ->disk(config('shopper.media.storage.disk_name')),
                     ]),

--- a/tests/Admin/Livewire/Components/Account/ProfileTest.php
+++ b/tests/Admin/Livewire/Components/Account/ProfileTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Livewire\Livewire;
+use Shopper\Livewire\Components\Account\Profile;
+use Tests\Core\Stubs\User;
+
+uses(Tests\Admin\TestCase::class);
+
+beforeEach(function (): void {
+    Storage::fake(config('shopper.media.storage.disk_name'));
+
+    $this->user = User::factory()->create();
+    $this->actingAs($this->user);
+});
+
+describe(Profile::class, function (): void {
+    it('rejects an SVG avatar to prevent stored XSS from same-origin media', function (): void {
+        Livewire::test(Profile::class)
+            ->set('data.avatar_location', [
+                UploadedFile::fake()->create('avatar.svg', 10, 'image/svg+xml'),
+            ])
+            ->call('save')
+            ->assertHasErrors(['data.avatar_location']);
+    });
+
+    it('accepts a curated image type as an avatar', function (): void {
+        Livewire::test(Profile::class)
+            ->set('data.avatar_location', [
+                UploadedFile::fake()->image('avatar.png'),
+            ])
+            ->call('save')
+            ->assertHasNoErrors(['data.avatar_location']);
+
+        expect($this->user->refresh()->avatar_type)->toBe('storage');
+    });
+})->group('livewire', 'security');

--- a/tests/Admin/Livewire/Pages/Settings/GeneralTest.php
+++ b/tests/Admin/Livewire/Pages/Settings/GeneralTest.php
@@ -74,4 +74,16 @@ describe(General::class, function (): void {
 
         Storage::disk($disk)->assertExists($logo);
     });
+
+    it('rejects SVG logo and cover uploads to prevent stored XSS from same-origin media', function (): void {
+        Storage::fake(config('shopper.media.storage.disk_name'));
+
+        Livewire::test(General::class)
+            ->fillForm([
+                'logo' => UploadedFile::fake()->create('logo.svg', 10, 'image/svg+xml'),
+                'cover' => UploadedFile::fake()->create('cover.svg', 10, 'image/svg+xml'),
+            ])
+            ->call('store')
+            ->assertHasFormErrors(['logo', 'cover']);
+    });
 })->group('livewire', 'settings');


### PR DESCRIPTION
## Problem

Three upload fields in the panel use the generic Filament `FileUpload` with `->image()` instead of `SpatieMediaLibraryFileUpload` bound to a media collection:

- the account avatar in `Profile.php`
- the store logo and cover in `Settings/General.php`

`->image()` sets `acceptedFileTypes(['image/*'])`, and Laravel's `mimetypes` rule matches a wildcard by comparing the type segment, so `image/svg+xml` passes. Those fields never touch the curated allowlist that governs every collection bound upload, so the SVG exclusion added in #595 did not cover them.

An SVG carrying a script payload was therefore accepted, written to the public disk keeping its `.svg` extension, and served same origin under `/storage/<ulid>.svg`. Opening that URL directly, rather than rendering it inside an `<img>`, executes the payload with the viewer's session. The panel sends no CSP and no `X-Content-Type-Options`, so nothing downstream blocks it.

Reaching the avatar field only requires an account that passes `canAccessDashboard()`, which makes this a privilege escalation path from any staff account towards an administrator.

## Fix

Replace `->image()` with `->acceptedFileTypes(config('shopper.media.accepts_mime_types'))` on the three fields.

That is the same key `HasMediaCollections` already feeds to every media collection, so one config now governs every upload path in the panel instead of some of them. The swap has no other effect: `image()` does nothing but set `acceptedFileTypes`, and `getAcceptedFileTypes()` is a plain getter with no branching on the wildcard.

## Behaviour change

Uploading an SVG store logo is no longer possible. Existing files are untouched, but a replacement upload will be rejected. Anyone who needs SVG can add the type back through the publishable `shopper.media.accepts_mime_types` config, with the same origin risk that implies.

No API change: no public signature touched, no new or renamed config key, no migration.
