### PR TITLE
fix(security): prevent privilege escalation through team settings

### DIFF
--- a/packages/admin/resources/lang/en/notifications.php
+++ b/packages/admin/resources/lang/en/notifications.php
@@ -86,6 +86,10 @@ return [
     'unauthorized' => [
         'title' => 'Unauthorized',
         'body' => 'You do not have permission to perform this action.',
+        'administrator_role' => 'Only an administrator can manage the administrator role.',
+        'administrator_only' => 'Only an administrator can create or delete a permission.',
+        'permission_scope' => 'You can only grant a permission that you hold yourself.',
+        'protected_permission' => 'This permission is required by the panel and cannot be deleted.',
     ],
 
     'database' => [

--- a/packages/admin/resources/lang/es/notifications.php
+++ b/packages/admin/resources/lang/es/notifications.php
@@ -80,6 +80,10 @@ return [
     'unauthorized' => [
         'title' => 'No autorizado',
         'body' => 'No tienes permiso para realizar esta acción.',
+        'administrator_role' => 'Solo un administrador puede gestionar el rol de administrador.',
+        'administrator_only' => 'Solo un administrador puede crear o eliminar un permiso.',
+        'permission_scope' => 'Solo puedes conceder un permiso que tú mismo posees.',
+        'protected_permission' => 'El panel necesita este permiso y no se puede eliminar.',
     ],
 
     'database' => [

--- a/packages/admin/resources/lang/fr/notifications.php
+++ b/packages/admin/resources/lang/fr/notifications.php
@@ -86,6 +86,10 @@ return [
     'unauthorized' => [
         'title' => 'Non autorisé',
         'body' => 'Vous n\'avez pas la permission d\'effectuer cette action.',
+        'administrator_role' => 'Seul un administrateur peut gérer le rôle administrateur.',
+        'administrator_only' => 'Seul un administrateur peut créer ou supprimer une permission.',
+        'permission_scope' => 'Vous ne pouvez accorder qu\'une permission que vous détenez vous-même.',
+        'protected_permission' => 'Cette permission est nécessaire au panel et ne peut pas être supprimée.',
     ],
 
     'database' => [

--- a/packages/admin/resources/lang/sv/notifications.php
+++ b/packages/admin/resources/lang/sv/notifications.php
@@ -86,6 +86,10 @@ return [
     'unauthorized' => [
         'title' => 'Obehörig',
         'body' => 'Behörighet saknas för att utföra denna åtgärd.',
+        'administrator_role' => 'Endast en administratör kan hantera administratörsrollen.',
+        'administrator_only' => 'Endast en administratör kan skapa eller ta bort en behörighet.',
+        'permission_scope' => 'Du kan endast tilldela en behörighet som du själv har.',
+        'protected_permission' => 'Denna behörighet krävs av panelen och kan inte tas bort.',
     ],
 
     'database' => [

--- a/packages/admin/resources/lang/tr/notifications.php
+++ b/packages/admin/resources/lang/tr/notifications.php
@@ -74,6 +74,10 @@ return [
     'unauthorized' => [
         'title' => 'Yetkisiz',
         'body' => 'Bu işlemi gerçekleştirme izniniz bulunmuyor.',
+        'administrator_role' => 'Yönetici rolünü yalnızca bir yönetici yönetebilir.',
+        'administrator_only' => 'Yalnızca bir yönetici izin oluşturabilir veya silebilir.',
+        'permission_scope' => 'Yalnızca kendinizde bulunan bir izni verebilirsiniz.',
+        'protected_permission' => 'Bu izin panel için gereklidir ve silinemez.',
     ],
 
 ];

--- a/packages/admin/resources/views/livewire/components/settings/team/permissions.blade.php
+++ b/packages/admin/resources/views/livewire/components/settings/team/permissions.blade.php
@@ -40,7 +40,7 @@
                                 />
                             </div>
                             <div class="flex items-center space-x-3">
-                                @if ($permission->can_be_removed)
+                                @if ($permission->can_be_removed && auth(config('shopper.auth.guard'))->user()?->isAdmin())
                                     <button
                                         wire:click="removePermission({{ $permission->id }})"
                                         type="button"

--- a/packages/admin/src/Livewire/Components/Settings/Team/Permissions.php
+++ b/packages/admin/src/Livewire/Components/Settings/Team/Permissions.php
@@ -5,16 +5,19 @@ declare(strict_types=1);
 namespace Shopper\Livewire\Components\Settings\Team;
 
 use Filament\Notifications\Notification;
+use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Contracts\View\View;
 use Livewire\Attributes\Locked;
 use Livewire\Attributes\On;
 use Livewire\Component;
 use Shopper\Models\Permission;
 use Shopper\Models\Role;
+use Shopper\Traits\AuthorizesTeamManagement;
 use Shopper\Traits\HandlesAuthorizationExceptions;
 
 class Permissions extends Component
 {
+    use AuthorizesTeamManagement;
     use HandlesAuthorizationExceptions;
 
     #[Locked]
@@ -22,12 +25,12 @@ class Permissions extends Component
 
     public function mount(): void
     {
-        $this->authorize('system.users');
+        $this->authorizeTeamAccess($this->role);
     }
 
     public function togglePermission(int $id): void
     {
-        $this->authorize('system.settings');
+        $this->authorizeTeamManagement($this->role);
 
         $permission = Permission::query()->find($id);
 
@@ -42,24 +45,32 @@ class Permissions extends Component
                 ->title(__('shopper::notifications.users_roles.permission_revoke', ['permission' => $permission->display_name]))
                 ->success()
                 ->send();
-        } else {
-            $this->role->givePermissionTo($permission->name);
 
-            Notification::make()
-                ->title(__('shopper::notifications.users_roles.permission_allow', ['permission' => $permission->display_name]))
-                ->success()
-                ->send();
+            return;
         }
+
+        $this->authorizePermissionGrant($this->role, $permission);
+
+        $this->role->givePermissionTo($permission->name);
+
+        Notification::make()
+            ->title(__('shopper::notifications.users_roles.permission_allow', ['permission' => $permission->display_name]))
+            ->success()
+            ->send();
     }
 
     public function removePermission(int $id): void
     {
-        $this->authorize('system.settings');
+        $this->authorizePermissionDefinition();
 
         $permission = Permission::query()->find($id);
 
         if ($permission === null) {
             return;
+        }
+
+        if (! $permission->can_be_removed) {
+            throw new AuthorizationException(__('shopper::notifications.unauthorized.protected_permission'));
         }
 
         $permission->delete();

--- a/packages/admin/src/Livewire/Pages/Settings/Team/RolePermission.php
+++ b/packages/admin/src/Livewire/Pages/Settings/Team/RolePermission.php
@@ -33,6 +33,7 @@ use Shopper\Livewire\Concerns\WithSettingsBreadcrumbs;
 use Shopper\Models\Permission;
 use Shopper\Models\Role;
 use Shopper\Sidebar\Breadcrumbs\Breadcrumb;
+use Shopper\Traits\AuthorizesTeamManagement;
 use Shopper\Traits\HandlesAuthorizationExceptions;
 
 /**
@@ -41,6 +42,7 @@ use Shopper\Traits\HandlesAuthorizationExceptions;
 #[Layout('shopper::components.layouts.setting')]
 class RolePermission extends Component implements HasActions, HasSchemas
 {
+    use AuthorizesTeamManagement;
     use HandlesAuthorizationExceptions;
     use InteractsWithActions;
     use InteractsWithSchemas;
@@ -70,7 +72,7 @@ class RolePermission extends Component implements HasActions, HasSchemas
 
     public function mount(): void
     {
-        $this->authorize('system.users');
+        $this->authorizeTeamAccess($this->role);
 
         $this->form->fill($this->role->toArray());
     }
@@ -118,6 +120,7 @@ class RolePermission extends Component implements HasActions, HasSchemas
             ->icon(Untitledui::ShieldZap)
             ->color('gray')
             ->authorize('system.settings')
+            ->visible(fn (): bool => $this->actingUserIsAdmin())
             ->modalWidth(Width::Medium)
             ->modalHeading(__('shopper::pages/settings/staff.generate_permissions'))
             ->modalDescription(__('shopper::pages/settings/staff.generate_permissions_description'))
@@ -151,6 +154,8 @@ class RolePermission extends Component implements HasActions, HasSchemas
                     ->columnSpan('full'),
             ])
             ->action(function (array $data): void {
+                $this->authorizePermissionDefinition();
+
                 $resource = $data['resource'];
                 $group = $data['group_name'] ?? null;
 
@@ -177,6 +182,7 @@ class RolePermission extends Component implements HasActions, HasSchemas
             ->label(__('shopper::pages/settings/staff.create_permission'))
             ->icon(Untitledui::Lock04)
             ->authorize('system.settings')
+            ->visible(fn (): bool => $this->actingUserIsAdmin())
             ->modalWidth(Width::Medium)
             ->modalHeading(__('shopper::modals.permissions.new'))
             ->modalDescription(__('shopper::modals.permissions.new_description'))
@@ -204,6 +210,8 @@ class RolePermission extends Component implements HasActions, HasSchemas
                     ->columnSpan('full'),
             ])
             ->action(function (array $data): void {
+                $this->authorizePermissionDefinition();
+
                 /** @var Permission $permission */
                 $permission = Permission::query()->create($data);
 
@@ -220,7 +228,7 @@ class RolePermission extends Component implements HasActions, HasSchemas
 
     public function save(): void
     {
-        $this->authorize('system.settings');
+        $this->authorizeTeamManagement($this->role);
 
         $this->role->update($this->form->getState());
 

--- a/packages/admin/src/Livewire/SlideOvers/CreateTeamMember.php
+++ b/packages/admin/src/Livewire/SlideOvers/CreateTeamMember.php
@@ -16,6 +16,8 @@ use Filament\Schemas\Components\Utilities\Set;
 use Filament\Schemas\Concerns\InteractsWithSchemas;
 use Filament\Schemas\Contracts\HasSchemas;
 use Filament\Schemas\Schema;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
@@ -27,6 +29,7 @@ use Shopper\Contracts\SlideOverForm;
 use Shopper\Models\Contracts\ShopperUser;
 use Shopper\Models\Role;
 use Shopper\Notifications\AdminSendCredentials;
+use Shopper\Traits\AuthorizesTeamManagement;
 use Shopper\Traits\HandlesAuthorizationExceptions;
 use Shopper\Traits\InteractsWithSlideOverForm;
 
@@ -35,6 +38,7 @@ use Shopper\Traits\InteractsWithSlideOverForm;
  */
 class CreateTeamMember extends SlideOverComponent implements HasActions, HasSchemas, SlideOverForm
 {
+    use AuthorizesTeamManagement;
     use HandlesAuthorizationExceptions;
     use InteractsWithActions;
     use InteractsWithSchemas;
@@ -51,7 +55,7 @@ class CreateTeamMember extends SlideOverComponent implements HasActions, HasSche
 
     public function mount(): void
     {
-        $this->authorize('system.users');
+        $this->authorizeTeamAccess();
 
         $this->title = __('shopper::pages/settings/staff.add_admin');
 
@@ -106,6 +110,10 @@ class CreateTeamMember extends SlideOverComponent implements HasActions, HasSche
                             ->options(
                                 Role::query()
                                     ->where('name', '<>', config('shopper.admin.roles.user'))
+                                    ->unless(
+                                        $this->actingUserIsAdmin(),
+                                        fn (Builder $query): Builder => $query->where('name', '<>', config('shopper.admin.roles.admin'))
+                                    )
                                     ->pluck('display_name', 'id')
                             )
                             ->columns()
@@ -120,10 +128,15 @@ class CreateTeamMember extends SlideOverComponent implements HasActions, HasSche
 
     public function store(): void
     {
-        $this->authorize('system.users');
+        $this->authorizeTeamAccess();
 
         $data = $this->form->getState();
         $userModel = config('auth.providers.users.model');
+
+        /** @var Collection<int, Role> $roles */
+        $roles = Role::query()->findMany($data['roles']);
+
+        $roles->each(fn (Role $role) => $this->authorizeTeamAccess($role));
 
         /** @var ShopperUser $user */
         $user = $userModel::query()->create([
@@ -138,7 +151,7 @@ class CreateTeamMember extends SlideOverComponent implements HasActions, HasSche
             'email_verified_at' => now()->toDateTimeString(),
         ]);
 
-        $user->assignRole($data['roles']);
+        $user->assignRole($roles->pluck('name')->all());
 
         $this->dispatch('teamUpdate');
 

--- a/packages/admin/src/Traits/AuthorizesTeamManagement.php
+++ b/packages/admin/src/Traits/AuthorizesTeamManagement.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Traits;
+
+use Illuminate\Auth\Access\AuthorizationException;
+use Shopper\Models\Contracts\ShopperUser;
+use Shopper\Models\Permission;
+use Shopper\Models\Role;
+
+trait AuthorizesTeamManagement
+{
+    protected function authorizeTeamAccess(?Role $role = null): void
+    {
+        $this->authorize('system.users');
+
+        $this->denyAdministratorRole($role);
+    }
+
+    protected function authorizeTeamManagement(?Role $role = null): void
+    {
+        $this->authorize('system.settings');
+
+        $this->denyAdministratorRole($role);
+    }
+
+    protected function authorizePermissionDefinition(): void
+    {
+        $this->authorizeTeamManagement();
+
+        if (! $this->actingUserIsAdmin()) {
+            throw new AuthorizationException(__('shopper::notifications.unauthorized.administrator_only'));
+        }
+    }
+
+    protected function authorizePermissionGrant(Role $role, Permission $permission): void
+    {
+        $this->authorizeTeamManagement($role);
+
+        if ($this->actingUserIsAdmin()) {
+            return;
+        }
+
+        if (! $this->actingUser()?->can($permission->name)) {
+            throw new AuthorizationException(__('shopper::notifications.unauthorized.permission_scope'));
+        }
+    }
+
+    protected function actingUserIsAdmin(): bool
+    {
+        return $this->actingUser()?->isAdmin() ?? false;
+    }
+
+    protected function actingUser(): ?ShopperUser
+    {
+        /** @var ?ShopperUser $user */
+        $user = shopper()->auth()->user();
+
+        return $user;
+    }
+
+    private function denyAdministratorRole(?Role $role): void
+    {
+        if ($role?->isAdmin() && ! $this->actingUserIsAdmin()) {
+            throw new AuthorizationException(__('shopper::notifications.unauthorized.administrator_role'));
+        }
+    }
+}

--- a/tests/Admin/Livewire/Components/Settings/Team/PermissionsTest.php
+++ b/tests/Admin/Livewire/Components/Settings/Team/PermissionsTest.php
@@ -12,7 +12,7 @@ uses(Tests\Admin\TestCase::class);
 
 beforeEach(function (): void {
     $this->user = User::factory()->create();
-    $this->user->givePermissionTo(['system.users', 'system.settings']);
+    $this->user->assignRole(config('shopper.admin.roles.admin'));
     $this->actingAs($this->user);
 
     $this->role = Role::create([

--- a/tests/Admin/Livewire/Pages/Settings/Team/RolePermissionTest.php
+++ b/tests/Admin/Livewire/Pages/Settings/Team/RolePermissionTest.php
@@ -12,7 +12,7 @@ uses(Tests\Admin\TestCase::class);
 
 beforeEach(function (): void {
     $this->user = User::factory()->create();
-    $this->user->givePermissionTo(['system.users', 'system.settings']);
+    $this->user->assignRole(config('shopper.admin.roles.admin'));
     $this->actingAs($this->user);
 
     $this->role = Role::create([

--- a/tests/Admin/Security/RolePermissionEscalationTest.php
+++ b/tests/Admin/Security/RolePermissionEscalationTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+use Livewire\Livewire;
+use Shopper\Livewire\Components\Settings\Team\Permissions as RolePermissions;
+use Shopper\Livewire\Pages\Settings\Team\RolePermission;
+use Shopper\Livewire\SlideOvers\CreateTeamMember;
+use Shopper\Models\Permission;
+use Shopper\Models\Role;
+use Tests\Core\Stubs\User;
+
+uses(Tests\Admin\TestCase::class);
+
+beforeEach(function (): void {
+    $this->administratorRole = Role::query()
+        ->where('name', config('shopper.admin.roles.admin'))
+        ->firstOrFail();
+
+    $this->managerRole = Role::query()
+        ->where('name', config('shopper.admin.roles.manager'))
+        ->firstOrFail();
+
+    $this->managerRole->givePermissionTo(['system.users', 'system.settings']);
+
+    $this->staff = User::factory()->create();
+    $this->staff->assignRole($this->managerRole);
+});
+
+it('denies granting a permission the acting user does not hold', function (): void {
+    $this->actingAs($this->staff);
+
+    Livewire::test(RolePermissions::class, ['role' => $this->managerRole])
+        ->call('togglePermission', Permission::query()->where('name', 'orders.delete')->firstOrFail()->id);
+
+    expect($this->managerRole->fresh()->hasPermissionTo('orders.delete'))->toBeFalse();
+});
+
+it('allows granting a permission the acting user already holds', function (): void {
+    $this->managerRole->givePermissionTo('orders.edit');
+
+    $target = Role::create([
+        'name' => 'support',
+        'display_name' => 'Support',
+        'can_be_removed' => true,
+    ]);
+
+    $this->actingAs($this->staff);
+
+    Livewire::test(RolePermissions::class, ['role' => $target])
+        ->call('togglePermission', Permission::query()->where('name', 'orders.edit')->firstOrFail()->id);
+
+    expect($target->fresh()->hasPermissionTo('orders.edit'))->toBeTrue();
+});
+
+it('denies a non administrator any write on the administrator role', function (): void {
+    $this->actingAs($this->staff);
+
+    Livewire::test(RolePermission::class, ['role' => $this->administratorRole])
+        ->set('data.display_name', 'Hijacked')
+        ->call('save');
+
+    expect($this->administratorRole->fresh()->display_name)->not->toBe('Hijacked');
+});
+
+it('denies permission creation to a non administrator', function (): void {
+    $this->actingAs($this->staff);
+
+    Livewire::test(RolePermission::class, ['role' => $this->managerRole])
+        ->assertActionHidden('createPermission')
+        ->assertActionHidden('generatePermissions');
+});
+
+it('refuses to delete a permission the panel depends on', function (): void {
+    $this->asAdmin();
+
+    $permission = Permission::query()->where('name', 'system.settings')->firstOrFail();
+
+    Livewire::test(RolePermissions::class, ['role' => $this->managerRole])
+        ->call('removePermission', $permission->id);
+
+    expect(Permission::query()->whereKey($permission->id)->exists())->toBeTrue();
+});
+
+it('denies a non administrator assigning the administrator role to a new member', function (): void {
+    $this->actingAs($this->staff);
+
+    Livewire::test(CreateTeamMember::class)
+        ->fillForm([
+            'email' => 'intruder@example.com',
+            'password' => 'password12345678',
+            'first_name' => 'Intruder',
+            'last_name' => 'Doe',
+            'roles' => [$this->administratorRole->id],
+            'send_mail' => false,
+        ])
+        ->call('store');
+
+    expect(User::query()->where('email', 'intruder@example.com')->exists())->toBeFalse();
+});


### PR DESCRIPTION
## Problem

3.x carries the same privilege escalation fixed on 2.x by #654, under the renamed permissions. `system.settings`, the general purpose settings permission, was enough to take over the RBAC system. A non administrator holding it could:

- create a permission with any name through `createPermission`, which immediately assigns it to the role being edited
- generate the five CRUD permissions for any resource through `generatePermissions` and receive them all
- open `RolePermission` for the administrator role itself, since the route binds `{role}` with no scoping, and update it
- toggle any existing permission onto their own role through `Permissions::togglePermission()`
- delete any permission through `removePermission()`, since the `can_be_removed` guard existed only in the Blade view
- create a team member and assign them the administrator role through `CreateTeamMember`, since the role options only excluded the customer role

Verified by test: without this fix, a manager holding `system.users` and `system.settings` self-grants `orders.delete`.

## Fix

Port of #654 adapted to 3.x. No new permission, no migration. The gates stay on `system.users` for reads and `system.settings` for writes. Three rules in `Shopper\Traits\AuthorizesTeamManagement`:

| Rule | Effect |
| --- | --- |
| A non administrator cannot target the administrator role | it can no longer be opened, updated, or assigned to a new team member |
| A permission can only be granted if the acting user holds it | granting yourself an unrelated capability is no longer possible |
| Creating or deleting a permission definition is administrator only | inventing a permission to bypass the rule above is no longer possible |

Administrators are unaffected. `removePermission()` now checks `can_be_removed` on the server before deleting.

## Differences with #654

- Gates adapted to the 3.x permission names, unchanged otherwise: `CreateTeamMember` keeps its existing `system.users` gate, only the role scoping is added.
- `CreateTeamMember` assigns multiple roles on 3.x: every selected role is resolved and checked server side before `assignRole`.
- `UsersRole` no longer exists on 3.x, nothing to port there.
- Notifications translated in the five 3.x locales (en, fr, es, sv, tr).
- The seeder description is untouched: the 3.x `system.settings` description already matches what the permission gates.

## Behaviour change

A non administrator who was creating permissions or editing the administrator role through `system.settings` loses that ability. Everything else in the settings area is unchanged, and no existing permission assignment is modified.
